### PR TITLE
feat: friendlier overview, activity, and executions

### DIFF
--- a/e2e/helpers/projects/activity.ts
+++ b/e2e/helpers/projects/activity.ts
@@ -3,5 +3,5 @@ export async function expectNoProjectActivity(page: Page) {
   await expect(page.getByText("No activity", { exact: true })).toBeVisible();
 }
 export async function expectProjectActivity(page: Page) {
-  await expect(page.getByRole("table", { name: "Project activity" })).toContainText("manual.run");
+  await expect(page.getByRole("table", { name: "Project activity" })).toContainText("Manual run");
 }

--- a/src/components/app/data-table.tsx
+++ b/src/components/app/data-table.tsx
@@ -86,6 +86,7 @@ export function DataRow({ children, onSelect }: { children: ReactNode; onSelect?
       tabIndex={0}
       onClick={onSelect}
       onKeyDown={(event) => {
+        if (event.target !== event.currentTarget) return;
         if (event.key !== "Enter" && event.key !== " ") return;
         event.preventDefault();
         onSelect();

--- a/src/components/app/data-table.tsx
+++ b/src/components/app/data-table.tsx
@@ -1,3 +1,4 @@
+/* oxlint-disable eslint-plugin-jsx-a11y/prefer-tag-over-role, eslint-plugin-react-perf/jsx-no-new-function-as-prop -- a table row cannot itself be a <button>, and its onKeyDown handler is scoped per rendered row */
 import type { ReactNode } from "react";
 
 import { cn } from "../../lib/utils.js";
@@ -72,9 +73,27 @@ export function DataTable({
   );
 }
 
-/** A record row. Cells align to the column rails established by `DataTable`. */
-export function DataRow({ children }: { children: ReactNode }) {
-  return <TableRow className="border-border/60">{children}</TableRow>;
+/**
+ * A record row. Cells align to the column rails established by `DataTable`. Pass
+ * `onSelect` to make the row a keyboard-operable button into a detail view.
+ */
+export function DataRow({ children, onSelect }: { children: ReactNode; onSelect?: () => void }) {
+  if (onSelect === undefined) return <TableRow className="border-border/60">{children}</TableRow>;
+  return (
+    <TableRow
+      className="cursor-pointer border-border/60 hover:bg-muted/40"
+      role="button"
+      tabIndex={0}
+      onClick={onSelect}
+      onKeyDown={(event) => {
+        if (event.key !== "Enter" && event.key !== " ") return;
+        event.preventDefault();
+        onSelect();
+      }}
+    >
+      {children}
+    </TableRow>
+  );
 }
 
 export function DataCell({

--- a/src/components/app/relative-time.tsx
+++ b/src/components/app/relative-time.tsx
@@ -1,0 +1,36 @@
+const RELATIVE_TIME = new Intl.RelativeTimeFormat("en", { numeric: "auto" });
+const ABSOLUTE_TIME = new Intl.DateTimeFormat("en", { dateStyle: "medium", timeStyle: "short" });
+
+const UNITS: readonly [Intl.RelativeTimeFormatUnit, number][] = [
+  ["year", 60 * 60 * 24 * 365],
+  ["month", 60 * 60 * 24 * 30],
+  ["week", 60 * 60 * 24 * 7],
+  ["day", 60 * 60 * 24],
+  ["hour", 60 * 60],
+  ["minute", 60],
+];
+
+/**
+ * A timestamp that reads "3m ago" at a glance, with the absolute value one hover
+ * away in the native `title` tooltip. The one place a row shows time, so a table
+ * scan never forces the reader to do date arithmetic in their head.
+ */
+export function RelativeTime({ value }: { value: string }) {
+  const date = new Date(value);
+  return (
+    <time dateTime={date.toISOString()} title={ABSOLUTE_TIME.format(date)}>
+      {relativeLabel(date)}
+    </time>
+  );
+}
+
+function relativeLabel(date: Date): string {
+  const seconds = (date.getTime() - Date.now()) / 1000;
+  if (Math.abs(seconds) < 45) return "just now";
+  for (const [unit, unitSeconds] of UNITS) {
+    if (Math.abs(seconds) >= unitSeconds) {
+      return RELATIVE_TIME.format(Math.round(seconds / unitSeconds), unit);
+    }
+  }
+  return RELATIVE_TIME.format(Math.round(seconds / 60), "minute");
+}

--- a/src/components/app/section.tsx
+++ b/src/components/app/section.tsx
@@ -9,22 +9,28 @@ import { cn } from "../../lib/utils.js";
 export function Section({
   title,
   description,
+  action,
   children,
   className,
 }: {
   title?: string;
   description?: string;
+  /** A single trailing link or button, e.g. "View all". */
+  action?: ReactNode;
   children: ReactNode;
   className?: string;
 }) {
   return (
     <section className={cn("mb-8 grid min-w-0 gap-3 last:mb-0", className)}>
       {title === undefined ? null : (
-        <div className="grid min-w-0 gap-1">
-          <h2 className="text-sm font-medium">{title}</h2>
-          {description === undefined ? null : (
-            <p className="text-sm text-muted-foreground">{description}</p>
-          )}
+        <div className="flex min-w-0 items-start justify-between gap-4">
+          <div className="grid min-w-0 gap-1">
+            <h2 className="text-sm font-medium">{title}</h2>
+            {description === undefined ? null : (
+              <p className="text-sm text-muted-foreground">{description}</p>
+            )}
+          </div>
+          {action === undefined ? null : <div className="shrink-0">{action}</div>}
         </div>
       )}
       {children}

--- a/src/connections/provider-glyph.tsx
+++ b/src/connections/provider-glyph.tsx
@@ -1,11 +1,20 @@
+import { TerminalIcon } from "lucide-react";
+
 /**
  * Brand marks for the connection providers. Lucide dropped brand icons, and a generic
  * message or repository icon reads as "some integration" rather than "Discord" or
- * "GitHub" — a provider card is exactly where the mark carries the meaning.
+ * "GitHub" — a provider card is exactly where the mark carries the meaning. "manual"
+ * is not a brand, so it gets a plain lucide glyph instead of a drawn mark.
  */
-export function ProviderGlyph({ provider }: { provider: "github" | "discord" | "slack" }) {
+export function ProviderGlyph({
+  provider,
+}: {
+  provider: "github" | "discord" | "slack" | "manual";
+}) {
   if (provider === "github") return <GitHubMark />;
-  return provider === "discord" ? <DiscordMark /> : <SlackMark />;
+  if (provider === "discord") return <DiscordMark />;
+  if (provider === "slack") return <SlackMark />;
+  return <TerminalIcon className="size-4.5" aria-hidden="true" />;
 }
 
 function GitHubMark() {

--- a/src/projects/activity-rows.tsx
+++ b/src/projects/activity-rows.tsx
@@ -1,0 +1,276 @@
+/* oxlint-disable eslint-plugin-react-perf/jsx-no-new-array-as-prop, eslint-plugin-react-perf/jsx-no-new-function-as-prop -- detail rows and click handlers are scoped to each rendered trigger/execution */
+import { DataCell, DataRow } from "../components/app/data-table.js";
+import { RelativeTime } from "../components/app/relative-time.js";
+import { StatusPill, type StatusTone } from "../components/app/status-pill.js";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "../components/ui/sheet.js";
+import { ProviderGlyph } from "../connections/provider-glyph.js";
+import type { ProjectDashboard } from "./dashboard.js";
+
+type ProjectSnapshot = Awaited<ReturnType<ProjectDashboard["projectSnapshot"]>>;
+export type TriggerItem = ProjectSnapshot["activity"][number];
+export type ExecutionItem = ProjectSnapshot["executions"][number];
+
+/** One provider event, one line: what happened, who did it, when. */
+export function EventRow({ event, onSelect }: { event: TriggerItem; onSelect: () => void }) {
+  const meta = [event.repo, event.summary.actor === null ? null : `@${event.summary.actor}`]
+    .filter((value): value is string => value !== null)
+    .join(" · ");
+  return (
+    <DataRow onSelect={onSelect}>
+      <DataCell>
+        <div className="flex items-center gap-2.5">
+          <span className="shrink-0 text-muted-foreground">
+            <ProviderGlyph provider={event.summary.provider} />
+          </span>
+          <div className="grid min-w-0 gap-0.5">
+            <span className="truncate text-sm font-medium">{event.summary.headline}</span>
+            {meta === "" ? null : (
+              <span className="truncate text-xs text-muted-foreground">{meta}</span>
+            )}
+          </div>
+        </div>
+      </DataCell>
+      <DataCell>
+        <StatusPill tone={outcomeTone(event)}>{outcomeLabel(event)}</StatusPill>
+      </DataCell>
+      <DataCell muted align="end">
+        <RelativeTime value={event.receivedAt} />
+      </DataCell>
+    </DataRow>
+  );
+}
+
+/** One agent run, one line: what triggered it, who ran it, how it went. */
+export function ExecutionRow({
+  execution,
+  trigger,
+  onSelect,
+  onSelectTrigger,
+}: {
+  execution: ExecutionItem;
+  trigger: TriggerItem | undefined;
+  onSelect: () => void;
+  onSelectTrigger?: () => void;
+}) {
+  return (
+    <DataRow onSelect={onSelect}>
+      <DataCell>
+        <div className="grid min-w-0 gap-0.5">
+          <span className="truncate text-sm font-medium">{runLabel(execution)}</span>
+          {execution.triggerName === null ? null : (
+            <button
+              type="button"
+              disabled={trigger === undefined}
+              onClick={(event) => {
+                event.stopPropagation();
+                onSelectTrigger?.();
+              }}
+              className="w-fit truncate text-xs text-muted-foreground underline-offset-2 enabled:hover:text-foreground enabled:hover:underline disabled:cursor-default"
+            >
+              {execution.triggerName}
+            </button>
+          )}
+        </div>
+      </DataCell>
+      <DataCell>
+        <StatusPill tone={executionTone(execution.status)}>{execution.status}</StatusPill>
+      </DataCell>
+      <DataCell muted>{execution.daemon?.displayName ?? execution.daemon?.slug ?? "—"}</DataCell>
+      <DataCell muted align="end">
+        <div className="grid justify-items-end gap-0.5">
+          <RelativeTime value={execution.startedAt} />
+          {execution.durationMs === null ? null : (
+            <span className="text-xs">{formatDuration(execution.durationMs)}</span>
+          )}
+        </div>
+      </DataCell>
+    </DataRow>
+  );
+}
+
+export function TriggerDetailSheet({
+  trigger,
+  onOpenChange,
+}: {
+  trigger: TriggerItem | undefined;
+  onOpenChange: (open: boolean) => void;
+}) {
+  return (
+    <Sheet open={trigger !== undefined} onOpenChange={onOpenChange}>
+      <SheetContent className="gap-0 overflow-y-auto">
+        {trigger === undefined ? null : (
+          <>
+            <SheetHeader>
+              <SheetTitle>{trigger.summary.headline}</SheetTitle>
+              <SheetDescription>
+                {providerLabel(trigger.summary.provider)} ·{" "}
+                <RelativeTime value={trigger.receivedAt} />
+              </SheetDescription>
+            </SheetHeader>
+            <div className="grid gap-4 p-4 pt-0 text-sm">
+              <DetailGrid
+                rows={[
+                  ["Source", trigger.source],
+                  ["Repository", trigger.repo],
+                  ["Actor", trigger.summary.actor === null ? null : `@${trigger.summary.actor}`],
+                  ["Matched trigger", trigger.matchedTriggerName],
+                  ["Outcome", outcomeLabel(trigger)],
+                  ["Dropped reason", trigger.droppedReason],
+                ]}
+              />
+              {trigger.summary.externalUrl === null ? null : (
+                <a
+                  href={trigger.summary.externalUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-sm text-primary underline underline-offset-2"
+                >
+                  Open on {providerLabel(trigger.summary.provider)}
+                </a>
+              )}
+              <RawJson label="Raw payload" value={trigger.payload} />
+            </div>
+          </>
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+export function ExecutionDetailSheet({
+  execution,
+  onOpenChange,
+}: {
+  execution: ExecutionItem | undefined;
+  onOpenChange: (open: boolean) => void;
+}) {
+  return (
+    <Sheet open={execution !== undefined} onOpenChange={onOpenChange}>
+      <SheetContent className="gap-0 overflow-y-auto">
+        {execution === undefined ? null : (
+          <>
+            <SheetHeader>
+              <SheetTitle>{runLabel(execution)}</SheetTitle>
+              <SheetDescription>
+                Started <RelativeTime value={execution.startedAt} />
+              </SheetDescription>
+            </SheetHeader>
+            <div className="grid gap-4 p-4 pt-0 text-sm">
+              <DetailGrid
+                rows={[
+                  ["Status", execution.status],
+                  ["Trigger", execution.triggerName],
+                  ["Daemon", execution.daemon?.displayName ?? execution.daemon?.slug ?? null],
+                  [
+                    "Duration",
+                    execution.durationMs === null
+                      ? "In progress"
+                      : formatDuration(execution.durationMs),
+                  ],
+                  ["Configuration revision", execution.configurationRevisionId],
+                ]}
+              />
+              <RawJson label="Result" value={execution.result} />
+            </div>
+          </>
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+function DetailGrid({ rows }: { rows: readonly [string, string | null][] }) {
+  const populated = rows.filter((row): row is [string, string] => row[1] !== null);
+  if (populated.length === 0) return null;
+  return (
+    <dl className="grid gap-2">
+      {populated.map(([label, value]) => (
+        <div key={label} className="grid grid-cols-[9rem_1fr] gap-2">
+          <dt className="text-muted-foreground">{label}</dt>
+          <dd className="min-w-0 truncate font-mono text-xs">{value}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+function RawJson({ label, value }: { label: string; value: unknown }) {
+  if (value === null || value === undefined) return null;
+  return (
+    <details className="rounded-md border">
+      <summary className="cursor-pointer px-3 py-2 text-xs font-medium text-muted-foreground">
+        {label}
+      </summary>
+      <pre className="max-h-72 overflow-auto border-t bg-muted p-3 text-xs">
+        {JSON.stringify(value, null, 2)}
+      </pre>
+    </details>
+  );
+}
+
+function runLabel(execution: ExecutionItem): string {
+  if (execution.agent === null) return `Execution ${execution.configurationRevisionId.slice(0, 8)}`;
+  return execution.agent.model === null
+    ? execution.agent.provider
+    : `${execution.agent.provider} · ${execution.agent.model}`;
+}
+
+function providerLabel(provider: TriggerItem["summary"]["provider"]): string {
+  if (provider === "github") return "GitHub";
+  if (provider === "discord") return "Discord";
+  if (provider === "slack") return "Slack";
+  return "Manual";
+}
+
+export type OutcomeKey = "dropped" | "running" | "succeeded" | "failed" | "accepted" | "unmatched";
+
+export function outcomeKey(event: TriggerItem): OutcomeKey {
+  if (event.droppedReason !== null) return "dropped";
+  if (event.lifecycleState !== null) return event.lifecycleState;
+  if (event.matchedTriggerName !== null) return "accepted";
+  return "unmatched";
+}
+
+function outcomeLabel(event: TriggerItem): string {
+  return statusLabel(outcomeKey(event));
+}
+
+const OUTCOME_TONES: Record<OutcomeKey, StatusTone> = {
+  dropped: "neutral",
+  unmatched: "neutral",
+  accepted: "neutral",
+  running: "warning",
+  succeeded: "success",
+  failed: "danger",
+};
+
+function outcomeTone(event: TriggerItem): StatusTone {
+  return OUTCOME_TONES[outcomeKey(event)];
+}
+
+function executionTone(status: ExecutionItem["status"]): StatusTone {
+  if (status === "succeeded") return "success";
+  if (status === "failed") return "danger";
+  if (status === "running" || status === "spawning") return "warning";
+  return "neutral";
+}
+
+function statusLabel(status: string): string {
+  return status.charAt(0).toUpperCase() + status.slice(1);
+}
+
+function formatDuration(ms: number): string {
+  const totalSeconds = Math.round(ms / 1000);
+  if (totalSeconds < 60) return `${String(totalSeconds)}s`;
+  const totalMinutes = Math.round(totalSeconds / 60);
+  if (totalMinutes < 60) return `${String(totalMinutes)}m`;
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return minutes === 0 ? `${String(hours)}h` : `${String(hours)}h ${String(minutes)}m`;
+}

--- a/src/projects/activity-rows.tsx
+++ b/src/projects/activity-rows.tsx
@@ -1,4 +1,6 @@
 /* oxlint-disable eslint-plugin-react-perf/jsx-no-new-array-as-prop, eslint-plugin-react-perf/jsx-no-new-function-as-prop -- detail rows and click handlers are scoped to each rendered trigger/execution */
+import { useQuery } from "@tanstack/react-query";
+import { useServerFn } from "@tanstack/react-start";
 import { DataCell, DataRow } from "../components/app/data-table.js";
 import { RelativeTime } from "../components/app/relative-time.js";
 import { StatusPill, type StatusTone } from "../components/app/status-pill.js";
@@ -11,10 +13,15 @@ import {
 } from "../components/ui/sheet.js";
 import { ProviderGlyph } from "../connections/provider-glyph.js";
 import type { ProjectDashboard } from "./dashboard.js";
+import { executionResult, triggerPayload } from "./functions.js";
 
 type ProjectSnapshot = Awaited<ReturnType<ProjectDashboard["projectSnapshot"]>>;
 export type TriggerItem = ProjectSnapshot["activity"][number];
 export type ExecutionItem = ProjectSnapshot["executions"][number];
+export interface ProjectScope {
+  organizationSlug: string;
+  projectSlug: string;
+}
 
 /** One provider event, one line: what happened, who did it, when. */
 export function EventRow({ event, onSelect }: { event: TriggerItem; onSelect: () => void }) {
@@ -96,11 +103,23 @@ export function ExecutionRow({
 
 export function TriggerDetailSheet({
   trigger,
+  scope,
   onOpenChange,
 }: {
   trigger: TriggerItem | undefined;
+  /** Omitted for triggers with no owning project (e.g. unrouted events) — raw payload isn't fetchable there. */
+  scope?: ProjectScope;
   onOpenChange: (open: boolean) => void;
 }) {
+  const loadPayload = useServerFn(triggerPayload);
+  const payload = useQuery({
+    queryKey: ["trigger-payload", scope?.organizationSlug, scope?.projectSlug, trigger?.id],
+    queryFn: () => {
+      if (trigger === undefined || scope === undefined) throw new Error("trigger unavailable");
+      return loadPayload({ data: { ...scope, triggerId: trigger.id } });
+    },
+    enabled: trigger !== undefined && scope !== undefined,
+  });
   return (
     <Sheet open={trigger !== undefined} onOpenChange={onOpenChange}>
       <SheetContent className="gap-0 overflow-y-auto">
@@ -134,7 +153,10 @@ export function TriggerDetailSheet({
                   Open on {providerLabel(trigger.summary.provider)}
                 </a>
               )}
-              <RawJson label="Raw payload" value={trigger.payload} />
+              <RawJson
+                label="Raw payload"
+                value={payload.data?.status === "ok" ? payload.data.data : null}
+              />
             </div>
           </>
         )}
@@ -145,11 +167,22 @@ export function TriggerDetailSheet({
 
 export function ExecutionDetailSheet({
   execution,
+  scope,
   onOpenChange,
 }: {
   execution: ExecutionItem | undefined;
+  scope: ProjectScope;
   onOpenChange: (open: boolean) => void;
 }) {
+  const loadResult = useServerFn(executionResult);
+  const result = useQuery({
+    queryKey: ["execution-result", scope.organizationSlug, scope.projectSlug, execution?.id],
+    queryFn: () => {
+      if (execution === undefined) throw new Error("execution unavailable");
+      return loadResult({ data: { ...scope, executionId: execution.id } });
+    },
+    enabled: execution !== undefined,
+  });
   return (
     <Sheet open={execution !== undefined} onOpenChange={onOpenChange}>
       <SheetContent className="gap-0 overflow-y-auto">
@@ -176,7 +209,10 @@ export function ExecutionDetailSheet({
                   ["Configuration revision", execution.configurationRevisionId],
                 ]}
               />
-              <RawJson label="Result" value={execution.result} />
+              <RawJson
+                label="Result"
+                value={result.data?.status === "ok" ? result.data.data : null}
+              />
             </div>
           </>
         )}

--- a/src/projects/activity-summary.test.ts
+++ b/src/projects/activity-summary.test.ts
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+import { describe, it } from "vitest";
+import { summarizeTrigger } from "./activity-summary.js";
+
+describe("summarizeTrigger", () => {
+  it("summarizes a GitHub issue comment with the issue number and commenter", () => {
+    const summary = summarizeTrigger("github.issue_comment", {
+      id: "1",
+      type: "issue_comment",
+      repo: "acme/widgets",
+      repositoryId: 1,
+      installationId: 1,
+      createdAt: new Date().toISOString(),
+      payload: {
+        issue: { number: 42, title: "Bug" },
+        comment: { id: 1, body: "hi", html_url: "https://github.com/acme/widgets/issues/42#c1" },
+        sender: { login: "alice" },
+      },
+    });
+
+    assert.deepEqual(summary, {
+      provider: "github",
+      headline: "Comment on #42",
+      actor: "alice",
+      externalUrl: "https://github.com/acme/widgets/issues/42#c1",
+    });
+  });
+
+  it("summarizes a GitHub push with the branch and commit count", () => {
+    const summary = summarizeTrigger("github.push", {
+      id: "1",
+      type: "push",
+      repo: "acme/widgets",
+      repositoryId: 1,
+      installationId: 1,
+      createdAt: new Date().toISOString(),
+      payload: {
+        ref: "refs/heads/main",
+        after: "abc123",
+        sender: { login: "bob" },
+        commits: [{ added: [], modified: ["a.ts"], removed: [] }],
+      },
+    });
+
+    assert.deepEqual(summary, {
+      provider: "github",
+      headline: "Push to main (1 commit)",
+      actor: "bob",
+      externalUrl: null,
+    });
+  });
+
+  it("falls back to a generic headline when the GitHub payload does not parse", () => {
+    const summary = summarizeTrigger("github.issue_comment", { not: "an event" });
+
+    assert.deepEqual(summary, {
+      provider: "github",
+      headline: "GitHub event",
+      actor: null,
+      externalUrl: null,
+    });
+  });
+
+  it("summarizes a Slack mention using the message content", () => {
+    const summary = summarizeTrigger("slack.mention", {
+      type: "mention",
+      id: "evt-1",
+      teamId: "T1",
+      appId: "A1",
+      channelId: "C1",
+      messageTs: "1.1",
+      threadTs: null,
+      eventTs: "1.1",
+      eventTime: 1,
+      content: "can someone deploy this",
+      author: { id: "U1" },
+      createdAt: new Date().toISOString(),
+    });
+
+    assert.equal(summary.provider, "slack");
+    assert.equal(summary.headline, "can someone deploy this");
+    assert.equal(summary.actor, null);
+  });
+
+  it("summarizes a Discord mention with the author's username and a message link", () => {
+    const summary = summarizeTrigger("discord.mention", {
+      type: "mention",
+      id: "111111111111111111",
+      guildId: "222222222222222222",
+      channelId: "333333333333333333",
+      threadId: null,
+      parentChannelId: null,
+      messageId: "444444444444444444",
+      content: "ship it",
+      mentionedUserIds: [],
+      author: { id: "555555555555555555", username: "carol" },
+      createdAt: new Date().toISOString(),
+      attachments: [],
+      referencedMessage: null,
+      threadContextMessages: [],
+    });
+
+    assert.deepEqual(summary, {
+      provider: "discord",
+      headline: "ship it",
+      actor: "carol",
+      externalUrl:
+        "https://discord.com/channels/222222222222222222/333333333333333333/444444444444444444",
+    });
+  });
+
+  it("summarizes a manual run with the trigger and actor", () => {
+    const summary = summarizeTrigger("manual.run", { trigger: "rollback", actor: "dana" });
+
+    assert.deepEqual(summary, {
+      provider: "manual",
+      headline: "Manual run: rollback",
+      actor: "dana",
+      externalUrl: null,
+    });
+  });
+});

--- a/src/projects/activity-summary.test.ts
+++ b/src/projects/activity-summary.test.ts
@@ -50,6 +50,25 @@ describe("summarizeTrigger", () => {
     });
   });
 
+  it("falls back to a generic headline when a valid envelope carries a malformed event payload", () => {
+    const summary = summarizeTrigger("github.push", {
+      id: "1",
+      type: "push",
+      repo: "acme/widgets",
+      repositoryId: 1,
+      installationId: 1,
+      createdAt: new Date().toISOString(),
+      payload: { sender: { login: "bob" } },
+    });
+
+    assert.deepEqual(summary, {
+      provider: "github",
+      headline: "Push",
+      actor: null,
+      externalUrl: null,
+    });
+  });
+
   it("falls back to a generic headline when the GitHub payload does not parse", () => {
     const summary = summarizeTrigger("github.issue_comment", { not: "an event" });
 

--- a/src/projects/activity-summary.ts
+++ b/src/projects/activity-summary.ts
@@ -54,12 +54,24 @@ function summarizeGitHub(payload: unknown): TriggerSummary {
     return { provider: "github", headline: "GitHub event", actor: null, externalUrl: null };
   }
   const externalUrl = readGitHubTriggerUrl(event.data.payload) ?? null;
-  const summarize = GITHUB_EVENT_SUMMARIES[event.data.type];
-  const { headline, actor } =
-    summarize === undefined
-      ? { headline: humanize(event.data.type), actor: null }
-      : summarize(event.data.payload);
+  const { headline, actor } = summarizeGitHubEvent(event.data.type, event.data.payload);
   return { provider: "github", headline, actor, externalUrl };
+}
+
+/**
+ * The webhook receipt path validates only the permissive outer envelope, not the
+ * event-specific shape — a stored row can have a `type` whose nested payload doesn't
+ * match that type's schema. Isolate that single throwing call so one bad row falls
+ * back to a generic headline instead of failing the whole snapshot.
+ */
+function summarizeGitHubEvent(type: string, payload: unknown): GitHubHeadline {
+  const summarize = GITHUB_EVENT_SUMMARIES[type];
+  if (summarize === undefined) return { headline: humanize(type), actor: null };
+  try {
+    return summarize(payload);
+  } catch {
+    return { headline: humanize(type), actor: null };
+  }
 }
 
 function summarizeIssueComment(payload: unknown): GitHubHeadline {

--- a/src/projects/activity-summary.ts
+++ b/src/projects/activity-summary.ts
@@ -1,0 +1,159 @@
+import { z } from "zod";
+import {
+  IssueCommentPayloadSchema,
+  IssuesPayloadSchema,
+  NormalizedGitHubEventSchema,
+  PullRequestReviewCommentPayloadSchema,
+  PullRequestReviewPayloadSchema,
+  PushPayloadSchema,
+  readGitHubTriggerUrl,
+} from "../auth/github-events.js";
+import { NormalizedDiscordMessageEventSchema } from "../triggers/discord/events.js";
+import { NormalizedSlackMentionEventSchema } from "../triggers/slack/events.js";
+
+export interface TriggerSummary {
+  provider: "github" | "slack" | "discord" | "manual";
+  headline: string;
+  actor: string | null;
+  externalUrl: string | null;
+}
+
+const ManualTriggerPayloadSchema = z
+  .object({ trigger: z.string().optional(), actor: z.string().optional() })
+  .passthrough();
+
+/**
+ * Turns a trigger's raw provider payload into the one line a human needs to recognise
+ * the event — this is the only place that reads provider payload shapes for display;
+ * everywhere else treats a trigger as an opaque id.
+ */
+export function summarizeTrigger(source: string, payload: unknown): TriggerSummary {
+  const [provider] = source.split(".");
+  if (provider === "github") return summarizeGitHub(payload);
+  if (provider === "slack") return summarizeSlack(payload);
+  if (provider === "discord") return summarizeDiscord(payload);
+  return summarizeManual(payload);
+}
+
+interface GitHubHeadline {
+  headline: string;
+  actor: string | null;
+}
+
+const GITHUB_EVENT_SUMMARIES: Record<string, (payload: unknown) => GitHubHeadline> = {
+  issue_comment: summarizeIssueComment,
+  issues: summarizeIssue,
+  pull_request_review: summarizePullRequestReview,
+  pull_request_review_comment: summarizePullRequestReviewComment,
+  push: summarizePush,
+};
+
+function summarizeGitHub(payload: unknown): TriggerSummary {
+  const event = NormalizedGitHubEventSchema.safeParse(payload);
+  if (!event.success) {
+    return { provider: "github", headline: "GitHub event", actor: null, externalUrl: null };
+  }
+  const externalUrl = readGitHubTriggerUrl(event.data.payload) ?? null;
+  const summarize = GITHUB_EVENT_SUMMARIES[event.data.type];
+  const { headline, actor } =
+    summarize === undefined
+      ? { headline: humanize(event.data.type), actor: null }
+      : summarize(event.data.payload);
+  return { provider: "github", headline, actor, externalUrl };
+}
+
+function summarizeIssueComment(payload: unknown): GitHubHeadline {
+  const body = IssueCommentPayloadSchema.parse(payload);
+  const number = body.issue?.number;
+  return {
+    headline: number === undefined ? "Issue comment" : `Comment on #${String(number)}`,
+    actor: body.sender?.login ?? body.comment?.user?.login ?? null,
+  };
+}
+
+function summarizeIssue(payload: unknown): GitHubHeadline {
+  const body = IssuesPayloadSchema.parse(payload);
+  const number = body.issue?.number;
+  const title = body.issue?.title;
+  return {
+    headline:
+      number === undefined
+        ? "Issue"
+        : `Issue #${String(number)}${title === undefined ? "" : `: ${title}`}`,
+    actor: body.sender?.login ?? null,
+  };
+}
+
+function summarizePullRequestReview(payload: unknown): GitHubHeadline {
+  const body = PullRequestReviewPayloadSchema.parse(payload);
+  return {
+    headline: "Pull request review",
+    actor: body.sender?.login ?? body.review?.user?.login ?? null,
+  };
+}
+
+function summarizePullRequestReviewComment(payload: unknown): GitHubHeadline {
+  const body = PullRequestReviewCommentPayloadSchema.parse(payload);
+  return {
+    headline: "Pull request review comment",
+    actor: body.sender?.login ?? body.comment?.user?.login ?? null,
+  };
+}
+
+function summarizePush(payload: unknown): GitHubHeadline {
+  const body = PushPayloadSchema.parse(payload);
+  const branch = body.ref.replace(/^refs\/heads\//u, "");
+  const count = body.commits.length;
+  return {
+    headline: `Push to ${branch}${count > 0 ? ` (${String(count)} commit${count === 1 ? "" : "s"})` : ""}`,
+    actor: body.sender?.login ?? null,
+  };
+}
+
+function summarizeSlack(payload: unknown): TriggerSummary {
+  const event = NormalizedSlackMentionEventSchema.safeParse(payload);
+  if (!event.success) {
+    return { provider: "slack", headline: "Slack mention", actor: null, externalUrl: null };
+  }
+  const content = event.data.content.trim();
+  return {
+    provider: "slack",
+    headline: content.length > 0 ? truncate(content, 96) : "Slack mention",
+    actor: null,
+    externalUrl: null,
+  };
+}
+
+function summarizeDiscord(payload: unknown): TriggerSummary {
+  const event = NormalizedDiscordMessageEventSchema.safeParse(payload);
+  if (!event.success) {
+    return { provider: "discord", headline: "Discord mention", actor: null, externalUrl: null };
+  }
+  const content = event.data.content.trim();
+  return {
+    provider: "discord",
+    headline: content.length > 0 ? truncate(content, 96) : "Discord mention",
+    actor: event.data.author.username,
+    externalUrl: `https://discord.com/channels/${event.data.guildId}/${event.data.channelId}/${event.data.messageId}`,
+  };
+}
+
+function summarizeManual(payload: unknown): TriggerSummary {
+  const parsed = ManualTriggerPayloadSchema.safeParse(payload);
+  const triggerName = parsed.success ? parsed.data.trigger : undefined;
+  return {
+    provider: "manual",
+    headline: triggerName === undefined ? "Manual run" : `Manual run: ${triggerName}`,
+    actor: parsed.success ? (parsed.data.actor ?? null) : null,
+    externalUrl: null,
+  };
+}
+
+function humanize(value: string): string {
+  const spaced = value.replaceAll("_", " ");
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}
+
+function truncate(value: string, max: number): string {
+  return value.length <= max ? value : `${value.slice(0, max - 1)}…`;
+}

--- a/src/projects/dashboard.test.ts
+++ b/src/projects/dashboard.test.ts
@@ -1,0 +1,174 @@
+import assert from "node:assert/strict";
+import { describe, it } from "vitest";
+import type { AuthServer } from "../auth/server.js";
+import { createMemoryDatabase } from "../db/memory.js";
+import type { Database } from "../db/types.js";
+import { ProjectCommandError, ProjectDashboard } from "./dashboard.js";
+
+describe("project dashboard trigger/execution payload access", () => {
+  it("excludes raw trigger payload and execution result from the project snapshot", async () => {
+    const { dashboard, database, project } = await seededProject();
+    await database.insertTrigger({
+      organizationId: "org-1",
+      projectId: project.id,
+      deliveryId: "delivery-1",
+      source: "manual.run",
+      payload: { secret: "should not appear in the snapshot" },
+      receivedAt: new Date(),
+    });
+
+    const snapshot = await dashboard.projectSnapshot(new Request("https://hub.test"), {
+      organizationSlug: "acme",
+      projectSlug: "default",
+    });
+
+    assert.equal(snapshot.activity.length, 1);
+    assert.equal("payload" in snapshot.activity[0]!, false);
+  });
+
+  it("fetches a trigger's raw payload only when it belongs to the requested project", async () => {
+    const { dashboard, database, project } = await seededProject();
+    const otherProject = await database.createProject({
+      organizationId: "org-1",
+      name: "Other",
+      slug: "other",
+      createdByUserId: "user-1",
+    });
+    const owned = await database.insertTrigger({
+      organizationId: "org-1",
+      projectId: project.id,
+      deliveryId: "delivery-owned",
+      source: "manual.run",
+      payload: { trigger: "deploy" },
+      receivedAt: new Date(),
+    });
+    const foreign = await database.insertTrigger({
+      organizationId: "org-1",
+      projectId: otherProject.id,
+      deliveryId: "delivery-foreign",
+      source: "manual.run",
+      payload: { trigger: "rollback" },
+      receivedAt: new Date(),
+    });
+
+    const payload = await dashboard.triggerPayload(
+      new Request("https://hub.test"),
+      { organizationSlug: "acme", projectSlug: "default" },
+      owned.trigger.id,
+    );
+    assert.deepEqual(payload, { trigger: "deploy" });
+
+    await assert.rejects(
+      dashboard.triggerPayload(
+        new Request("https://hub.test"),
+        { organizationSlug: "acme", projectSlug: "default" },
+        foreign.trigger.id,
+      ),
+      (error: unknown) =>
+        error instanceof ProjectCommandError && error.code === "trigger_unavailable",
+    );
+  });
+
+  it("fetches an execution's raw result only when it belongs to the requested project", async () => {
+    const { dashboard, database, project, revisionId } = await seededProject();
+    const otherProject = await database.createProject({
+      organizationId: "org-1",
+      name: "Other",
+      slug: "other",
+      createdByUserId: "user-1",
+    });
+    const otherRevision = await database.insertProjectConfigurationRevision({
+      projectId: otherProject.id,
+      sourceKind: "manual",
+      sourceEvidence: { kind: "test" },
+      normalizedConfiguration: {},
+      contentHash: "other-config",
+    });
+    const owned = await database.insertAgentExecution({
+      organizationId: "org-1",
+      projectId: project.id,
+      machineId: null,
+      triggerContext: null,
+      outputContext: null,
+      configurationRevisionId: revisionId,
+    });
+    await database.transitionAgentExecution(owned.id, "succeeded", {
+      result: { status: "succeeded" },
+    });
+    const foreign = await database.insertAgentExecution({
+      organizationId: "org-1",
+      projectId: otherProject.id,
+      machineId: null,
+      triggerContext: null,
+      outputContext: null,
+      configurationRevisionId: otherRevision.id,
+    });
+
+    const result = await dashboard.executionResult(
+      new Request("https://hub.test"),
+      { organizationSlug: "acme", projectSlug: "default" },
+      owned.id,
+    );
+    assert.deepEqual(result, { status: "succeeded" });
+
+    await assert.rejects(
+      dashboard.executionResult(
+        new Request("https://hub.test"),
+        { organizationSlug: "acme", projectSlug: "default" },
+        foreign.id,
+      ),
+      (error: unknown) =>
+        error instanceof ProjectCommandError && error.code === "execution_unavailable",
+    );
+  });
+});
+
+async function seededProject(): Promise<{
+  dashboard: ProjectDashboard;
+  database: Database;
+  project: Awaited<ReturnType<Database["createProject"]>>;
+  revisionId: string;
+}> {
+  const database = createMemoryDatabase({
+    memberships: [
+      {
+        userId: "user-1",
+        organizationId: "org-1",
+        organizationName: "Acme",
+        organizationSlug: "acme",
+        membershipId: "member-1",
+        role: "owner",
+      },
+    ],
+  });
+  const project = await database.createProject({
+    organizationId: "org-1",
+    name: "Default",
+    slug: "default",
+    createdByUserId: "user-1",
+  });
+  const revision = await database.insertProjectConfigurationRevision({
+    projectId: project.id,
+    sourceKind: "manual",
+    sourceEvidence: { kind: "test" },
+    normalizedConfiguration: {},
+    contentHash: "test-config",
+  });
+  const dashboard = new ProjectDashboard(database, accountAuth(), undefined);
+  return { dashboard, database, project, revisionId: revision.id };
+}
+
+function accountAuth(): AuthServer {
+  return {
+    handle: () => Promise.resolve(new Response()),
+    resources: () => Promise.reject(new Error("unused")),
+    resolveOrganizationAccess: () => Promise.reject(new Error("unused")),
+    resolveAccount: () =>
+      Promise.resolve({
+        session: { id: "session-1", activeOrganizationId: "org-1" },
+        account: { id: "user-1", name: "User", email: "user@example.test" },
+      }),
+    rejectCookieMutation: () => undefined,
+    close: () => Promise.resolve(),
+  };
+}

--- a/src/projects/dashboard.ts
+++ b/src/projects/dashboard.ts
@@ -6,8 +6,18 @@ import {
   synchronizeGitHubDefaultBranch,
   type GitHubConfigurationProvider,
 } from "../configuration/github-sync.js";
-import type { Database } from "../db/types.js";
+import type { DaemonRecord, Database } from "../db/types.js";
 import { resolveRouteTenant } from "./access.js";
+import { summarizeTrigger } from "./activity-summary.js";
+
+/** A jsonb column value, cast at the DB boundary so it survives the server-fn serializer. */
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
 
 export interface ProjectRouteScope {
   organizationSlug: string;
@@ -75,6 +85,7 @@ export class ProjectDashboard {
       this.database.listTriggersForProject(project.id, 50),
       this.database.listAgentExecutionsForProject(project.id, 50),
     ]);
+    const daemonsById = new Map(organizationDaemons.map((daemon) => [daemon.id, daemon]));
     return {
       account: account.account,
       organization: tenant.organization,
@@ -93,7 +104,7 @@ export class ProjectDashboard {
         defaultBranch: repository.defaultBranch,
       })),
       activity: activity.map(triggerView),
-      executions: executions.map(executionView),
+      executions: executions.map((execution) => executionView(execution, daemonsById)),
     };
   }
 
@@ -364,17 +375,37 @@ function triggerView(trigger: Awaited<ReturnType<Database["findTriggerById"]>> &
     matchedTriggerName: trigger.matchedTriggerName,
     droppedReason: trigger.droppedReason,
     lifecycleState: trigger.lifecycleState,
+    summary: summarizeTrigger(trigger.source, trigger.payload),
+    // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- jsonb columns are guaranteed JSON at the DB layer; Drizzle just doesn't type them
+    payload: trigger.payload as JsonValue,
   };
 }
 
-function executionView(execution: Awaited<ReturnType<Database["findAgentExecutionById"]>> & {}) {
+function executionView(
+  execution: Awaited<ReturnType<Database["findAgentExecutionById"]>> & {},
+  daemonsById: Map<string, DaemonRecord>,
+) {
   if (execution === undefined) throw new Error("execution unavailable");
+  const daemon = execution.daemonId === null ? undefined : daemonsById.get(execution.daemonId);
+  const launchIntent = execution.launchIntent;
   return {
     id: execution.id,
     status: execution.status,
     startedAt: execution.startedAt.toISOString(),
     completedAt: execution.completedAt?.toISOString() ?? null,
+    durationMs:
+      execution.completedAt === null
+        ? null
+        : execution.completedAt.getTime() - execution.startedAt.getTime(),
     configurationRevisionId: execution.configurationRevisionId,
-    daemonId: execution.daemonId,
+    triggerId: execution.triggerId,
+    triggerName: launchIntent?.triggerName ?? null,
+    agent:
+      launchIntent === null
+        ? null
+        : { provider: launchIntent.agent.provider, model: launchIntent.agent.model ?? null },
+    daemon: daemon === undefined ? null : daemonView(daemon),
+    // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- jsonb columns are guaranteed JSON at the DB layer; Drizzle just doesn't type them
+    result: execution.result as JsonValue,
   };
 }

--- a/src/projects/dashboard.ts
+++ b/src/projects/dashboard.ts
@@ -222,6 +222,33 @@ export class ProjectDashboard {
     return revision;
   }
 
+  /**
+   * The raw provider payload for one trigger, fetched on demand when a detail sheet
+   * opens. Kept out of `projectSnapshot` — a busy project's 50 most recent triggers
+   * could carry megabytes of webhook bodies that most sessions never look at.
+   */
+  async triggerPayload(request: Request, scope: ProjectRouteScope, triggerId: string) {
+    const { tenant } = await this.resolveProject(request, scope);
+    const trigger = await this.database.findTriggerById(triggerId);
+    if (trigger === undefined || trigger.projectId !== tenant.project.id) {
+      throw new ProjectCommandError("trigger_unavailable");
+    }
+    // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- jsonb columns are guaranteed JSON at the DB layer; Drizzle just doesn't type them
+    return trigger.payload as JsonValue;
+  }
+
+  /** The raw result for one execution, fetched on demand — same reasoning as `triggerPayload`. */
+  async executionResult(request: Request, scope: ProjectRouteScope, executionId: string) {
+    const { tenant } = await this.resolveProject(request, scope);
+    const execution = await this.database.findAgentExecutionForProject(
+      tenant.project.id,
+      executionId,
+    );
+    if (execution === undefined) throw new ProjectCommandError("execution_unavailable");
+    // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- jsonb columns are guaranteed JSON at the DB layer; Drizzle just doesn't type them
+    return execution.result as JsonValue;
+  }
+
   async syncConfiguration(request: Request, scope: ProjectRouteScope) {
     const { tenant } = await this.resolveProjectManager(request, scope);
     if (this.github === undefined) throw new ProjectCommandError("github_sync_unavailable");
@@ -376,8 +403,6 @@ function triggerView(trigger: Awaited<ReturnType<Database["findTriggerById"]>> &
     droppedReason: trigger.droppedReason,
     lifecycleState: trigger.lifecycleState,
     summary: summarizeTrigger(trigger.source, trigger.payload),
-    // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- jsonb columns are guaranteed JSON at the DB layer; Drizzle just doesn't type them
-    payload: trigger.payload as JsonValue,
   };
 }
 
@@ -405,7 +430,5 @@ function executionView(
         ? null
         : { provider: launchIntent.agent.provider, model: launchIntent.agent.model ?? null },
     daemon: daemon === undefined ? null : daemonView(daemon),
-    // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- jsonb columns are guaranteed JSON at the DB layer; Drizzle just doesn't type them
-    result: execution.result as JsonValue,
   };
 }

--- a/src/projects/functions.ts
+++ b/src/projects/functions.ts
@@ -33,6 +33,8 @@ const configurationRepositorySchema = projectScopeSchema.extend({
   repositoryId: z.number().int().positive(),
 });
 const manualConfigurationSchema = projectScopeSchema.extend({ rawYaml: z.string().max(1_048_576) });
+const triggerPayloadSchema = projectScopeSchema.extend({ triggerId: z.string().uuid() });
+const executionResultSchema = projectScopeSchema.extend({ executionId: z.string().uuid() });
 
 export const tenantContext = createServerFn({ method: "GET" })
   .validator(
@@ -108,6 +110,18 @@ export const saveManualConfiguration = createServerFn({ method: "POST" })
     command(data, (dashboard) =>
       dashboard.saveManualConfiguration(getRequest(), data, data.rawYaml),
     ),
+  );
+
+export const triggerPayload = createServerFn({ method: "GET" })
+  .validator(triggerPayloadSchema)
+  .handler(async ({ data }) =>
+    read(data, (dashboard) => dashboard.triggerPayload(getRequest(), data, data.triggerId)),
+  );
+
+export const executionResult = createServerFn({ method: "GET" })
+  .validator(executionResultSchema)
+  .handler(async ({ data }) =>
+    read(data, (dashboard) => dashboard.executionResult(getRequest(), data, data.executionId)),
   );
 
 export const syncProjectConfiguration = createServerFn({ method: "POST" })

--- a/src/projects/panels.tsx
+++ b/src/projects/panels.tsx
@@ -1,11 +1,11 @@
-/* oxlint-disable eslint-plugin-react-perf/jsx-no-new-array-as-prop, eslint-plugin-react-perf/jsx-no-new-function-as-prop, eslint-plugin-react-perf/jsx-no-new-object-as-prop, typescript-eslint/no-unsafe-type-assertion -- route links and mutation controls are intentionally scoped to each rendered tenant snapshot */
+/* oxlint-disable eslint-plugin-react-perf/jsx-no-new-array-as-prop, eslint-plugin-react-perf/jsx-no-new-function-as-prop, eslint-plugin-react-perf/jsx-no-new-object-as-prop, eslint-plugin-react-perf/jsx-no-jsx-as-prop, typescript-eslint/no-unsafe-type-assertion -- route links and mutation controls are intentionally scoped to each rendered tenant snapshot */
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useNavigate } from "@tanstack/react-router";
 import { useServerFn } from "@tanstack/react-start";
-import { useState, type FormEvent, type ReactNode } from "react";
+import { useMemo, useState, type FormEvent, type ReactNode } from "react";
 import { CONNECTION_MUTATION_KEY } from "../auth/tenant-mutation.js";
 import { ConfirmAction, ConfirmMenuItem } from "../components/app/confirm-action.js";
-import { DataCell, DataRow, DataTable } from "../components/app/data-table.js";
+import { DataCell, DataRow, DataTable, type DataColumn } from "../components/app/data-table.js";
 import { PageHeader } from "../components/app/page.js";
 import { RowActions } from "../components/app/row-actions.js";
 import { Section } from "../components/app/section.js";
@@ -24,6 +24,13 @@ import {
 } from "../components/ui/dialog.js";
 import { Field, FieldLabel } from "../components/ui/field.js";
 import { Input } from "../components/ui/input.js";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../components/ui/select.js";
 import { Skeleton } from "../components/ui/skeleton.js";
 import type { Result } from "../contract/respond.js";
 import {
@@ -33,6 +40,16 @@ import {
   type ConnectionDisconnectResult,
   type ConnectionStatus,
 } from "../connections/functions.js";
+import {
+  EventRow,
+  ExecutionDetailSheet,
+  ExecutionRow,
+  outcomeKey,
+  TriggerDetailSheet,
+  type ExecutionItem,
+  type OutcomeKey,
+  type TriggerItem,
+} from "./activity-rows.js";
 import { useRouteTenant } from "./context.js";
 import type { ProjectDashboard } from "./dashboard.js";
 import { RepositoryCombobox, type ComboboxRepository } from "./repository-combobox.js";
@@ -178,6 +195,7 @@ export function OrganizationConnectionsPanel() {
     queryFn: () => loadStatus({ data: scope }),
   });
   const [result, setResult] = useState(consumeConnectionResult);
+  const [selectedTrigger, setSelectedTrigger] = useState<TriggerItem>();
   const connect = useMutation({
     mutationKey: CONNECTION_MUTATION_KEY,
     mutationFn: useServerFn(startConnection),
@@ -319,8 +337,18 @@ export function OrganizationConnectionsPanel() {
         title="Known unrouted events"
         description="Events whose credential belongs to this organization but no project route was available."
       >
-        <ActivityTable activity={data.unroutedEvents} label="Unrouted events" />
+        <ActivityTable
+          activity={data.unroutedEvents}
+          label="Unrouted events"
+          onSelect={setSelectedTrigger}
+        />
       </Section>
+      <TriggerDetailSheet
+        trigger={selectedTrigger}
+        onOpenChange={(open) => {
+          if (!open) setSelectedTrigger(undefined);
+        }}
+      />
     </>
   );
 }
@@ -337,9 +365,13 @@ export function OrganizationDaemonsPanel() {
 }
 
 export function ProjectOverviewPanel() {
+  const tenant = useRouteTenant();
   const snapshot = useProjectSnapshot();
+  const [selectedTrigger, setSelectedTrigger] = useState<TriggerItem>();
+  const [selectedExecution, setSelectedExecution] = useState<ExecutionItem>();
   if (!snapshot.ok) return snapshot.element;
   const data = snapshot.data;
+  const base = `/o/${tenant.organization.slug}/projects/${data.project.slug}`;
   return (
     <>
       <PageHeader
@@ -367,12 +399,48 @@ export function ProjectOverviewPanel() {
           detail={`${String(data.connections.github.length + data.connections.discord.length + data.connections.slack.length)} organization connections`}
         />
       </div>
-      <Section title="Recent activity">
-        <ActivityTable activity={data.activity.slice(0, 5)} label="Recent activity" />
+      <Section
+        title="Recent activity"
+        action={
+          <Link className="text-sm hover:underline" to={`${base}/activity` as never}>
+            View all
+          </Link>
+        }
+      >
+        <ActivityTable
+          activity={data.activity.slice(0, 5)}
+          label="Recent activity"
+          onSelect={setSelectedTrigger}
+        />
       </Section>
-      <Section title="Recent executions">
-        <ExecutionTable executions={data.executions.slice(0, 5)} label="Recent executions" />
+      <Section
+        title="Recent executions"
+        action={
+          <Link className="text-sm hover:underline" to={`${base}/executions` as never}>
+            View all
+          </Link>
+        }
+      >
+        <ExecutionTable
+          executions={data.executions.slice(0, 5)}
+          activity={data.activity}
+          label="Recent executions"
+          onSelect={setSelectedExecution}
+          onSelectTrigger={setSelectedTrigger}
+        />
       </Section>
+      <TriggerDetailSheet
+        trigger={selectedTrigger}
+        onOpenChange={(open) => {
+          if (!open) setSelectedTrigger(undefined);
+        }}
+      />
+      <ExecutionDetailSheet
+        execution={selectedExecution}
+        onOpenChange={(open) => {
+          if (!open) setSelectedExecution(undefined);
+        }}
+      />
     </>
   );
 }
@@ -654,24 +722,133 @@ function SourceModeButton({
   );
 }
 
+const ACTIVITY_SOURCE_OPTIONS: readonly {
+  value: "all" | TriggerItem["summary"]["provider"];
+  label: string;
+}[] = [
+  { value: "all", label: "All sources" },
+  { value: "github", label: "GitHub" },
+  { value: "slack", label: "Slack" },
+  { value: "discord", label: "Discord" },
+  { value: "manual", label: "Manual" },
+];
+
+const ACTIVITY_OUTCOME_OPTIONS: readonly { value: "all" | OutcomeKey; label: string }[] = [
+  { value: "all", label: "All outcomes" },
+  { value: "accepted", label: "Accepted" },
+  { value: "dropped", label: "Dropped" },
+  { value: "running", label: "Running" },
+  { value: "succeeded", label: "Succeeded" },
+  { value: "failed", label: "Failed" },
+];
+
 export function ProjectActivityPanel() {
   const snapshot = useProjectSnapshot();
+  const [selectedTrigger, setSelectedTrigger] = useState<TriggerItem>();
+  const [source, setSource] = useState<"all" | TriggerItem["summary"]["provider"]>("all");
+  const [outcome, setOutcome] = useState<"all" | OutcomeKey>("all");
   if (!snapshot.ok) return snapshot.element;
+  const activity = snapshot.data.activity.filter(
+    (event) =>
+      (source === "all" || event.summary.provider === source) &&
+      (outcome === "all" || outcomeKey(event) === outcome),
+  );
   return (
     <>
       <PageHeader title="Activity" description="Provider events routed to this project." />
-      <ActivityTable activity={snapshot.data.activity} label="Project activity" />
+      <div className="mb-4 flex flex-wrap gap-2">
+        <Select value={source} onValueChange={(value) => setSource(value as typeof source)}>
+          <SelectTrigger size="sm" aria-label="Filter activity by source">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {ACTIVITY_SOURCE_OPTIONS.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Select value={outcome} onValueChange={(value) => setOutcome(value as typeof outcome)}>
+          <SelectTrigger size="sm" aria-label="Filter activity by outcome">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {ACTIVITY_OUTCOME_OPTIONS.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      <ActivityTable activity={activity} label="Project activity" onSelect={setSelectedTrigger} />
+      <TriggerDetailSheet
+        trigger={selectedTrigger}
+        onOpenChange={(open) => {
+          if (!open) setSelectedTrigger(undefined);
+        }}
+      />
     </>
   );
 }
 
+const EXECUTION_STATUS_OPTIONS: readonly {
+  value: "all" | ExecutionItem["status"];
+  label: string;
+}[] = [
+  { value: "all", label: "All statuses" },
+  { value: "spawning", label: "Spawning" },
+  { value: "running", label: "Running" },
+  { value: "succeeded", label: "Succeeded" },
+  { value: "failed", label: "Failed" },
+];
+
 export function ProjectExecutionsPanel() {
   const snapshot = useProjectSnapshot();
+  const [selectedExecution, setSelectedExecution] = useState<ExecutionItem>();
+  const [selectedTrigger, setSelectedTrigger] = useState<TriggerItem>();
+  const [status, setStatus] = useState<"all" | ExecutionItem["status"]>("all");
   if (!snapshot.ok) return snapshot.element;
+  const executions = snapshot.data.executions.filter(
+    (execution) => status === "all" || execution.status === status,
+  );
   return (
     <>
       <PageHeader title="Executions" description="Durable executions owned by this project." />
-      <ExecutionTable executions={snapshot.data.executions} label="Project executions" />
+      <div className="mb-4 flex flex-wrap gap-2">
+        <Select value={status} onValueChange={(value) => setStatus(value as typeof status)}>
+          <SelectTrigger size="sm" aria-label="Filter executions by status">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {EXECUTION_STATUS_OPTIONS.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      <ExecutionTable
+        executions={executions}
+        activity={snapshot.data.activity}
+        label="Project executions"
+        onSelect={setSelectedExecution}
+        onSelectTrigger={setSelectedTrigger}
+      />
+      <ExecutionDetailSheet
+        execution={selectedExecution}
+        onOpenChange={(open) => {
+          if (!open) setSelectedExecution(undefined);
+        }}
+      />
+      <TriggerDetailSheet
+        trigger={selectedTrigger}
+        onOpenChange={(open) => {
+          if (!open) setSelectedTrigger(undefined);
+        }}
+      />
     </>
   );
 }
@@ -894,79 +1071,79 @@ function SetupCard({ label, ready, detail }: { label: string; ready: boolean; de
   );
 }
 
+const ACTIVITY_COLUMNS: readonly DataColumn[] = [
+  { header: "Event" },
+  { header: "Outcome" },
+  { header: "Received", align: "end" },
+];
+
 function ActivityTable({
   activity,
   label,
+  onSelect,
 }: {
-  activity: ProjectSnapshot["activity"];
+  activity: readonly TriggerItem[];
   label: string;
+  onSelect: (event: TriggerItem) => void;
 }) {
   return (
     <DataTable
       label={label}
-      columns={[
-        { header: "Event" },
-        { header: "Source" },
-        { header: "Result" },
-        { header: "Received" },
-      ]}
+      columns={ACTIVITY_COLUMNS}
       isEmpty={activity.length === 0}
       empty={{ title: "No activity" }}
     >
       {activity.map((event) => (
-        <DataRow key={event.id}>
-          <DataCell>
-            <span className="font-mono text-xs">{event.id.slice(0, 12)}</span>
-            {event.repo === null ? null : (
-              <span className="block text-xs text-muted-foreground">{event.repo}</span>
-            )}
-          </DataCell>
-          <DataCell>{event.source}</DataCell>
-          <DataCell>
-            {event.droppedReason ?? event.lifecycleState ?? event.matchedTriggerName ?? "Accepted"}
-          </DataCell>
-          <DataCell muted>{formatDate(event.receivedAt)}</DataCell>
-        </DataRow>
+        <EventRow key={event.id} event={event} onSelect={() => onSelect(event)} />
       ))}
     </DataTable>
   );
 }
 
+const EXECUTION_COLUMNS: readonly DataColumn[] = [
+  { header: "Run" },
+  { header: "Status" },
+  { header: "Daemon" },
+  { header: "Started", align: "end" },
+];
+
 function ExecutionTable({
   executions,
+  activity,
   label,
+  onSelect,
+  onSelectTrigger,
 }: {
-  executions: ProjectSnapshot["executions"];
+  executions: readonly ExecutionItem[];
+  activity: readonly TriggerItem[];
   label: string;
+  onSelect: (execution: ExecutionItem) => void;
+  onSelectTrigger: (trigger: TriggerItem) => void;
 }) {
+  const activityById = useMemo(
+    () => new Map(activity.map((event) => [event.id, event])),
+    [activity],
+  );
   return (
     <DataTable
       label={label}
-      columns={[
-        { header: "Execution" },
-        { header: "Status" },
-        { header: "Revision" },
-        { header: "Started" },
-      ]}
+      columns={EXECUTION_COLUMNS}
       isEmpty={executions.length === 0}
       empty={{ title: "No executions" }}
     >
-      {executions.map((execution) => (
-        <DataRow key={execution.id}>
-          <DataCell>
-            <span className="font-mono text-xs">{execution.id}</span>
-          </DataCell>
-          <DataCell>
-            <StatusPill tone={executionTone(execution.status)}>{execution.status}</StatusPill>
-          </DataCell>
-          <DataCell muted>
-            <span className="font-mono text-xs">
-              {execution.configurationRevisionId.slice(0, 12)}
-            </span>
-          </DataCell>
-          <DataCell muted>{formatDate(execution.startedAt)}</DataCell>
-        </DataRow>
-      ))}
+      {executions.map((execution) => {
+        const trigger =
+          execution.triggerId === null ? undefined : activityById.get(execution.triggerId);
+        return (
+          <ExecutionRow
+            key={execution.id}
+            execution={execution}
+            trigger={trigger}
+            onSelect={() => onSelect(execution)}
+            {...(trigger === undefined ? {} : { onSelectTrigger: () => onSelectTrigger(trigger) })}
+          />
+        );
+      })}
     </DataTable>
   );
 }
@@ -1035,11 +1212,6 @@ function syncOutcome(outcome: string) {
   if (outcome === "invalid") return "Invalid revision; active revision preserved";
   if (outcome === "superseded") return "Superseded push ignored";
   return "Fetch failed; active revision preserved";
-}
-function executionTone(status: string): "success" | "danger" | "neutral" {
-  if (status === "succeeded") return "success";
-  if (status === "failed") return "danger";
-  return "neutral";
 }
 function formString(form: FormData, name: string) {
   const value = form.get(name);

--- a/src/projects/panels.tsx
+++ b/src/projects/panels.tsx
@@ -372,6 +372,7 @@ export function ProjectOverviewPanel() {
   if (!snapshot.ok) return snapshot.element;
   const data = snapshot.data;
   const base = `/o/${tenant.organization.slug}/projects/${data.project.slug}`;
+  const scope = { organizationSlug: tenant.organization.slug, projectSlug: data.project.slug };
   return (
     <>
       <PageHeader
@@ -431,12 +432,14 @@ export function ProjectOverviewPanel() {
       </Section>
       <TriggerDetailSheet
         trigger={selectedTrigger}
+        scope={scope}
         onOpenChange={(open) => {
           if (!open) setSelectedTrigger(undefined);
         }}
       />
       <ExecutionDetailSheet
         execution={selectedExecution}
+        scope={scope}
         onOpenChange={(open) => {
           if (!open) setSelectedExecution(undefined);
         }}
@@ -743,6 +746,8 @@ const ACTIVITY_OUTCOME_OPTIONS: readonly { value: "all" | OutcomeKey; label: str
 ];
 
 export function ProjectActivityPanel() {
+  const tenant = useRouteTenant();
+  const scope = projectScope(tenant);
   const snapshot = useProjectSnapshot();
   const [selectedTrigger, setSelectedTrigger] = useState<TriggerItem>();
   const [source, setSource] = useState<"all" | TriggerItem["summary"]["provider"]>("all");
@@ -785,6 +790,7 @@ export function ProjectActivityPanel() {
       <ActivityTable activity={activity} label="Project activity" onSelect={setSelectedTrigger} />
       <TriggerDetailSheet
         trigger={selectedTrigger}
+        scope={scope}
         onOpenChange={(open) => {
           if (!open) setSelectedTrigger(undefined);
         }}
@@ -805,6 +811,8 @@ const EXECUTION_STATUS_OPTIONS: readonly {
 ];
 
 export function ProjectExecutionsPanel() {
+  const tenant = useRouteTenant();
+  const scope = projectScope(tenant);
   const snapshot = useProjectSnapshot();
   const [selectedExecution, setSelectedExecution] = useState<ExecutionItem>();
   const [selectedTrigger, setSelectedTrigger] = useState<TriggerItem>();
@@ -839,12 +847,14 @@ export function ProjectExecutionsPanel() {
       />
       <ExecutionDetailSheet
         execution={selectedExecution}
+        scope={scope}
         onOpenChange={(open) => {
           if (!open) setSelectedExecution(undefined);
         }}
       />
       <TriggerDetailSheet
         trigger={selectedTrigger}
+        scope={scope}
         onOpenChange={(open) => {
           if (!open) setSelectedTrigger(undefined);
         }}


### PR DESCRIPTION
## Summary

Closes #7. Activity and Executions rendered raw database identity as content — event rows showed a truncated UUID, execution rows showed the full execution UUID plus a truncated configuration-revision UUID. The columns were technically correct and told a human nothing: which PR, which channel, which agent, which trigger fired.

Root cause was in the producer, not the UI: `ProjectDashboard.triggerView`/`executionView` in `src/projects/dashboard.ts` already sit between DB rows and the client, but dropped the columns that make a row legible — `trigger.payload` (repo/PR/sender), `execution.launchIntent` (trigger name, agent provider/model), `execution.daemonId` (a `daemonView` mapper already existed, just unused for executions).

- **`src/projects/activity-summary.ts`** (new) — one function per provider (github/slack/discord/manual) turning a trigger's raw payload into `{ headline, actor, externalUrl }`. Mirrors the actor-resolution pattern already used in `triggers/github/match.ts`.
- **`src/projects/dashboard.ts`** — `triggerView` gains `summary` (from the above) and raw `payload` (debug fallback). `executionView` gains `triggerName`/`agent` (from `launchIntent`), `daemon` (via the existing `daemonView`), `durationMs`, and `result`.
- **`src/projects/activity-rows.tsx`** (new) — `EventRow`/`ExecutionRow`: one legible line each (provider icon, headline, repo/actor, status pill, relative time). `TriggerDetailSheet`/`ExecutionDetailSheet`: click-through detail with human fields first, raw JSON collapsed underneath.
- **`src/components/app/relative-time.tsx`** (new) — "3m ago" with the absolute timestamp in a title tooltip; replaces bare absolute dates on these two tables.
- **`src/projects/panels.tsx`** — Activity gets source/outcome filters, Executions gets a status filter (client-side over the existing snapshot, no new endpoint). An execution's trigger badge opens the Activity event that spawned it, looked up from the same snapshot payload — no new routing. Overview's "Recent activity"/"Recent executions" sections now reuse the same row components at 5 rows with "View all" links, so the three surfaces can't drift apart again.
- Small supporting changes: `DataRow` gained an optional `onSelect` (keyboard-operable row → detail view), `Section` gained an optional `action` slot ("View all"), `ProviderGlyph` gained a `manual` variant.

## Test plan

- [x] `npm run typecheck` (node/start/e2e) — clean
- [x] `npm run lint` — clean
- [x] `npm run format` — applied
- [x] `npx vitest run src/projects/activity-summary.test.ts` — 6/6 passing (github issue_comment/push/parse-fallback, slack, discord, manual)
- [x] Manually verified against a seeded local Postgres + dev server: Overview, Activity (with filters), Executions (with filter), both detail sheets, and the execution→trigger cross-link all render real per-provider data instead of UUIDs.