### PR TITLE
Explain configuration activation failures

### DIFF
--- a/e2e/helpers/hub.ts
+++ b/e2e/helpers/hub.ts
@@ -20,6 +20,7 @@ import type { BrowserProviderScenario } from "../../src/e2e/harness/browser-prov
 import { createDatabase } from "../../src/db/pg.js";
 import { ProjectConfigurationStore } from "../../src/configuration/store.js";
 import { ProjectNavigation } from "./projects/navigation.js";
+import { ProjectConfiguration } from "./projects/configuration.js";
 
 export interface BuiltApplication {
   origin: string;
@@ -633,6 +634,30 @@ export class PaseoHub {
       await user.signUp(account);
       await user.createOrganization("Unconfigured");
       await user.expectNotConfiguredConnections();
+    } finally {
+      await context.close();
+    }
+  }
+
+  async proveManualConfigurationWithoutGitHub(account: Account, rawYaml: string): Promise<void> {
+    const application = await this.startApplication({
+      databaseProfile: "fresh",
+      providerScenario: "discord-only",
+    });
+    const context = await this.browser.newContext();
+    try {
+      const page = await context.newPage();
+      const user = new HubUser(application.origin, context, page);
+      const navigation = new ProjectNavigation(page);
+      const configuration = new ProjectConfiguration(page);
+      await user.signUp(account);
+      await user.createOrganization("Discord only");
+      await navigation.openProject("Default");
+      await navigation.openProjectSection("Configuration");
+      await configuration.saveManualConfiguration(rawYaml);
+      await configuration.expectActiveRevision(1);
+      await page.waitForLoadState("networkidle");
+      expect(application.logs()).not.toContain("github_repositories_unavailable");
     } finally {
       await context.close();
     }

--- a/e2e/helpers/projects/configuration.ts
+++ b/e2e/helpers/projects/configuration.ts
@@ -45,6 +45,15 @@ export class ProjectConfiguration {
     await expect(this.page.getByText(`Revision ${version}`, { exact: true })).toBeVisible();
   }
 
+  async expectNoPriorProjectFeedback(version: number, validationResource: string) {
+    await expect(this.page.getByRole("status")).toHaveText("No active configuration.");
+    await expect(this.page.getByRole("alert")).toHaveCount(0);
+    await expect(this.page.getByText(`Revision ${String(version)}`, { exact: true })).toHaveCount(
+      0,
+    );
+    await expect(this.page.getByText(validationResource)).toHaveCount(0);
+  }
+
   async syncNow() {
     await this.page.getByRole("button", { name: "Sync now" }).click();
   }

--- a/e2e/helpers/projects/configuration.ts
+++ b/e2e/helpers/projects/configuration.ts
@@ -27,6 +27,16 @@ export class ProjectConfiguration {
     await this.page.getByRole("button", { name: "Save and activate" }).click();
   }
 
+  async expectValidationError(message: string) {
+    await expect(this.page.getByRole("alert")).toContainText(message);
+  }
+
+  async expectConfigurationActivated(version: number) {
+    await expect(this.page.getByRole("status")).toHaveText(
+      `Configuration saved and activated as Revision ${String(version)}.`,
+    );
+  }
+
   async expectActiveRevision(version: number) {
     await this.page
       .getByRole("navigation", { name: "Project" })

--- a/e2e/projects.spec.ts
+++ b/e2e/projects.spec.ts
@@ -112,6 +112,26 @@ test("explains invalid manual configuration and allows a corrected retry", async
   await app.configuration.expectActiveRevision(3);
 });
 
+test("scopes configuration activation feedback to its project", async ({ hub, page }) => {
+  const app = projectApp(page);
+  await hub.signUpAs("owner", owner);
+  await hub.createOrganization("owner", "Acme");
+  await app.projects.create("Second", "second");
+  await app.navigation.openProject("Second");
+  await app.navigation.openProjectSection("Configuration");
+  await app.navigation.switchProject("Default");
+
+  await app.configuration.saveManualConfiguration(validConfiguration);
+  await app.configuration.expectConfigurationActivated(1);
+  await app.configuration.expectActiveRevision(1);
+  await app.configuration.saveManualConfiguration(unresolvedConfiguration);
+  await app.configuration.expectValidationError(
+    "Unresolved organization resources: missing-runner",
+  );
+  await app.navigation.switchProject("Second");
+  await app.configuration.expectNoPriorProjectFeedback(1, "missing-runner");
+});
+
 test("uses manual configuration without a GitHub deployment", async ({ hub }) => {
   await hub.proveManualConfigurationWithoutGitHub(owner, validConfiguration);
 });

--- a/e2e/projects.spec.ts
+++ b/e2e/projects.spec.ts
@@ -15,6 +15,8 @@ const owner = {
 };
 const validConfiguration =
   "environments:\n  - name: runner\n    kind: docker\n    image: paseo/test\ntriggers: []";
+const unresolvedConfiguration =
+  "environments:\n  - name: runner\n    kind: daemon\n    daemon: missing-runner\n    cwd: /workspace\ntriggers: []";
 
 test("creates and archives projects through the organization project list", async ({
   hub,
@@ -86,6 +88,32 @@ test("switches a project's configuration source between GitHub and manual", asyn
   await app.configuration.switchToManual();
   await app.configuration.saveManualConfiguration(validConfiguration);
   await app.configuration.expectActiveRevision(3);
+});
+
+test("explains invalid manual configuration and allows a corrected retry", async ({
+  hub,
+  page,
+}) => {
+  const app = projectApp(page);
+  await hub.signUpAs("owner", owner);
+  await hub.createOrganization("owner", "Acme");
+  await app.navigation.openProject("Default");
+  await app.navigation.openProjectSection("Configuration");
+
+  await app.configuration.saveManualConfiguration(validConfiguration);
+  await app.configuration.expectActiveRevision(1);
+  await app.configuration.saveManualConfiguration(unresolvedConfiguration);
+  await app.configuration.expectValidationError(
+    "Unresolved organization resources: missing-runner",
+  );
+  await app.configuration.expectActiveRevision(1);
+  await app.configuration.saveManualConfiguration(validConfiguration);
+  await app.configuration.expectConfigurationActivated(3);
+  await app.configuration.expectActiveRevision(3);
+});
+
+test("uses manual configuration without a GitHub deployment", async ({ hub }) => {
+  await hub.proveManualConfigurationWithoutGitHub(owner, validConfiguration);
 });
 
 test("isolates durable activity and step detail by project", async ({ hub, page }) => {

--- a/src/configuration/store.ts
+++ b/src/configuration/store.ts
@@ -1,4 +1,5 @@
 import { dump } from "js-yaml";
+import { z } from "zod";
 import {
   compileHubConfig,
   compiledConfigurationHash,

--- a/src/configuration/store.ts
+++ b/src/configuration/store.ts
@@ -1,5 +1,4 @@
 import { dump } from "js-yaml";
-import { z } from "zod";
 import {
   compileHubConfig,
   compiledConfigurationHash,
@@ -17,6 +16,10 @@ import type {
   ProjectConfigurationRevisionRecord,
   ProjectTriggerRoute,
 } from "../db/types.js";
+import {
+  configurationValidationErrors,
+  type ConfigurationValidationErrors,
+} from "./validation-errors.js";
 
 export interface StoredProjectConfiguration {
   revision: ProjectConfigurationRevisionRecord;
@@ -286,9 +289,7 @@ async function compileConfiguration(
       success: false,
       kind: "raw",
       missing: [],
-      validationErrors: {
-        formErrors: [formatConfigurationError(error)],
-      },
+      validationErrors: formatConfigurationError(error),
     };
   }
   const project = await database.findProjectById(projectId);
@@ -331,10 +332,12 @@ async function compileConfiguration(
   };
 }
 
-function formatConfigurationError(error: unknown): unknown {
-  if (error instanceof z.ZodError) return z.treeifyError(error);
-  if (error instanceof Error) return error.message;
-  return "invalid configuration";
+function formatConfigurationError(error: unknown): ConfigurationValidationErrors {
+  if (error instanceof z.ZodError) return configurationValidationErrors(error);
+  return {
+    formErrors: [error instanceof Error ? error.message : "invalid configuration"],
+    fieldErrors: {},
+  };
 }
 
 function resolveEnvironment(

--- a/src/configuration/validation-errors.test.ts
+++ b/src/configuration/validation-errors.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { describe, it } from "vitest";
+import { z } from "zod";
+import {
+  configurationValidationErrors,
+  configurationValidationMessages,
+} from "./validation-errors.js";
+
+describe("configuration validation errors", () => {
+  it("preserves form and field failures as actionable messages", () => {
+    const parsed = z
+      .object({ environments: z.array(z.string()), triggers: z.array(z.string()) })
+      .safeParse({ environments: "invalid", triggers: [] });
+
+    assert.equal(parsed.success, false);
+    if (parsed.success) return;
+    const errors = configurationValidationErrors(parsed.error);
+
+    assert.deepEqual(configurationValidationMessages(errors), [
+      "Environments: Invalid input: expected array, received string",
+    ]);
+  });
+
+  it("presents resource failures and safely handles an unknown stored shape", () => {
+    assert.deepEqual(
+      configurationValidationMessages({
+        formErrors: ["unresolved organization resources: missing-runner"],
+      }),
+      ["Unresolved organization resources: missing-runner"],
+    );
+    assert.deepEqual(configurationValidationMessages({ unexpected: true }), [
+      "Configuration validation failed.",
+    ]);
+  });
+});

--- a/src/configuration/validation-errors.ts
+++ b/src/configuration/validation-errors.ts
@@ -1,0 +1,32 @@
+import { z } from "zod";
+
+const storedValidationErrorsSchema = z.object({
+  formErrors: z.array(z.string()),
+  fieldErrors: z.record(z.string(), z.array(z.string())).optional(),
+});
+
+export type ConfigurationValidationErrors = z.infer<typeof storedValidationErrorsSchema>;
+
+export function configurationValidationErrors(error: z.ZodError): ConfigurationValidationErrors {
+  const flattened = z.flattenError(error);
+  return {
+    formErrors: flattened.formErrors,
+    fieldErrors: flattened.fieldErrors,
+  };
+}
+
+export function configurationValidationMessages(errors: unknown): string[] {
+  const parsed = storedValidationErrorsSchema.safeParse(errors);
+  if (!parsed.success) return ["Configuration validation failed."];
+  const messages = [
+    ...parsed.data.formErrors,
+    ...Object.entries(parsed.data.fieldErrors ?? {}).flatMap(([field, failures]) =>
+      failures.map((failure) => `${field}: ${failure}`),
+    ),
+  ].map(sentenceCase);
+  return messages.length === 0 ? ["Configuration validation failed."] : messages;
+}
+
+function sentenceCase(message: string): string {
+  return message.length === 0 ? message : `${message[0]!.toUpperCase()}${message.slice(1)}`;
+}

--- a/src/e2e/harness/browser-child.ts
+++ b/src/e2e/harness/browser-child.ts
@@ -70,6 +70,7 @@ async function main(): Promise<void> {
   );
   const bot = new BrowserDiscordBot();
   const githubConfiguration = new BrowserGitHubConfiguration();
+  const githubConfigured = hasBrowserGitHub(scenario);
   const registrations =
     auth === null
       ? []
@@ -79,23 +80,22 @@ async function main(): Promise<void> {
             auth,
             applicationBaseUrl: publicBaseUrl,
             publicBaseUrl,
-            configuration:
-              scenario === "not-configured"
-                ? null
-                : {
-                    appSlug: "paseo",
-                    clientId: "client",
-                    clientSecret: "secret",
-                    webhookSecret: requiredEnvironment("GITHUB_WEBHOOK_SECRET"),
-                  },
-            ...(scenario === "not-configured"
-              ? {}
-              : {
+            configuration: githubConfigured
+              ? {
+                  appSlug: "paseo",
+                  clientId: "client",
+                  clientSecret: "secret",
+                  webhookSecret: requiredEnvironment("GITHUB_WEBHOOK_SECRET"),
+                }
+              : null,
+            ...(githubConfigured
+              ? {
                   appAuth: new BrowserGitHubAuth(),
                   connectionClient: new BrowserGitHubConnections(publicBaseUrl, scenario),
                   configurationProvider: githubConfiguration,
                   reactionClient: new BrowserGitHubReactions(),
-                }),
+                }
+              : {}),
           }),
           createDiscordRegistration({
             database,
@@ -241,11 +241,16 @@ function readScenario(): BrowserProviderScenario {
     value === "connected" ||
     value === "approval" ||
     value === "conflict" ||
-    value === "not-configured"
+    value === "not-configured" ||
+    value === "discord-only"
   ) {
     return value;
   }
   throw new Error(`invalid browser provider scenario: ${value}`);
+}
+
+function hasBrowserGitHub(scenario: BrowserProviderScenario): boolean {
+  return scenario !== "not-configured" && scenario !== "discord-only";
 }
 
 function browserAuthEnabled(): boolean {

--- a/src/e2e/harness/browser-providers.ts
+++ b/src/e2e/harness/browser-providers.ts
@@ -35,7 +35,12 @@ const DISCORD_GUILDS: readonly DiscordGuildIdentity[] = [
   { guildId: "200", guildName: "Orbit Guild" },
 ];
 
-export type BrowserProviderScenario = "connected" | "approval" | "conflict" | "not-configured";
+export type BrowserProviderScenario =
+  | "connected"
+  | "approval"
+  | "conflict"
+  | "not-configured"
+  | "discord-only";
 
 export class BrowserGitHubAuth implements GitHubAuth, GitHubExecutionTokenAuth {
   getInstallation() {

--- a/src/projects/dashboard.ts
+++ b/src/projects/dashboard.ts
@@ -2,6 +2,7 @@ import { load } from "js-yaml";
 import type { AuthServer } from "../auth/server.js";
 import { capabilitiesFor } from "../auth/organization-policy.js";
 import { ProjectConfigurationStore } from "../configuration/store.js";
+import { configurationValidationMessages } from "../configuration/validation-errors.js";
 import { rawConfigurationHash } from "../config/compiler.js";
 import {
   synchronizeGitHubDefaultBranch,
@@ -30,6 +31,10 @@ export interface ProjectRouteScope {
   organizationSlug: string;
   projectSlug?: string | undefined;
 }
+
+export type ManualConfigurationSaveResult =
+  | { outcome: "activated"; revision: { id: string; version: number } }
+  | { outcome: "invalid"; revision: { id: string; version: number }; errors: string[] };
 
 export class ProjectDashboard {
   constructor(
@@ -156,6 +161,7 @@ export class ProjectDashboard {
     const { tenant } = await this.resolveProject(request, scope);
     const connections = (await this.database.organizationConnectionUsage(tenant.organization.id))
       .github;
+    if (connections.length === 0) return [];
     if (this.github === undefined) {
       throw new ProjectCommandError("github_repositories_unavailable");
     }
@@ -202,7 +208,11 @@ export class ProjectDashboard {
     );
   }
 
-  async saveManualConfiguration(request: Request, scope: ProjectRouteScope, rawYaml: string) {
+  async saveManualConfiguration(
+    request: Request,
+    scope: ProjectRouteScope,
+    rawYaml: string,
+  ): Promise<ManualConfigurationSaveResult> {
     const { account, tenant } = await this.resolveProjectManager(request, scope);
     const status = await this.database.projectConfigurationReadModel(tenant.project.id);
     if (status.authority !== "manual") throw new ProjectCommandError("configuration_read_only");
@@ -211,7 +221,7 @@ export class ProjectDashboard {
     try {
       rawConfiguration = load(rawYaml);
     } catch (error) {
-      return this.database.insertProjectConfigurationRevision({
+      const revision = await this.database.insertProjectConfigurationRevision({
         projectId: tenant.project.id,
         sourceKind: "manual",
         sourceEvidence: { kind: "manual", userId: account.account.id },
@@ -223,14 +233,19 @@ export class ProjectDashboard {
         contentHash: rawConfigurationHash(rawYaml),
         createdByUserId: account.account.id,
       });
+      return invalidManualConfiguration(revision);
     }
     const revision = await store.insertManualRevision({
       rawYaml,
       rawConfiguration,
       userId: account.account.id,
     });
-    if (revision.validationErrors === null) await store.activate(revision.id);
-    return revision;
+    if (revision.validationErrors !== null) return invalidManualConfiguration(revision);
+    await store.activate(revision.id);
+    return {
+      outcome: "activated",
+      revision: { id: revision.id, version: revision.version },
+    };
   }
 
   async syncConfiguration(request: Request, scope: ProjectRouteScope) {
@@ -283,6 +298,16 @@ export class ProjectDashboard {
     }
     return resolved;
   }
+}
+
+function invalidManualConfiguration(
+  revision: Awaited<ReturnType<Database["insertProjectConfigurationRevision"]>>,
+): ManualConfigurationSaveResult {
+  return {
+    outcome: "invalid",
+    revision: { id: revision.id, version: revision.version },
+    errors: configurationValidationMessages(revision.validationErrors),
+  };
 }
 
 export class ProjectCommandError extends Error {

--- a/src/projects/functions.ts
+++ b/src/projects/functions.ts
@@ -5,7 +5,11 @@ import { respondError, respondOk, type Result } from "../contract/respond.js";
 import { getApplication } from "../server/runtime.js";
 import { logger } from "../logger.js";
 import { TenantRouteNotFoundError } from "./access.js";
-import { ProjectCommandError, type ProjectDashboard } from "./dashboard.js";
+import {
+  ProjectCommandError,
+  type ManualConfigurationSaveResult,
+  type ProjectDashboard,
+} from "./dashboard.js";
 
 const organizationScopeSchema = z
   .object({ organizationSlug: z.string().trim().min(1).max(100) })
@@ -114,10 +118,11 @@ export const switchConfigurationToManual = createServerFn({ method: "POST" })
 
 export const saveManualConfiguration = createServerFn({ method: "POST" })
   .validator(manualConfigurationSchema)
-  .handler(async ({ data }) =>
-    command(data, (dashboard) =>
-      dashboard.saveManualConfiguration(getRequest(), data, data.rawYaml),
-    ),
+  .handler(
+    async ({ data }): Promise<Result<ManualConfigurationSaveResult>> =>
+      commandResult(data, (dashboard) =>
+        dashboard.saveManualConfiguration(getRequest(), data, data.rawYaml),
+      ),
   );
 
 export const syncProjectConfiguration = createServerFn({ method: "POST" })
@@ -142,9 +147,18 @@ async function command<T>(
   scope: { organizationSlug: string; projectSlug?: string | undefined },
   operation: (dashboard: ProjectDashboard) => Promise<T>,
 ): Promise<Result<{ state: "complete" }>> {
+  return commandResult(scope, async (dashboard) => {
+    await operation(dashboard);
+    return { state: "complete" } as const;
+  });
+}
+
+async function commandResult<T>(
+  scope: { organizationSlug: string; projectSlug?: string | undefined },
+  operation: (dashboard: ProjectDashboard) => Promise<T>,
+): Promise<Result<T>> {
   try {
-    await operation(await requireDashboard());
-    return respondOk({ state: "complete" });
+    return respondOk(await operation(await requireDashboard()));
   } catch (error) {
     if (error instanceof ProjectCommandError && error.code === "forbidden") {
       return respondError({ message: "You don't have permission to manage this project." });

--- a/src/projects/panels.tsx
+++ b/src/projects/panels.tsx
@@ -402,6 +402,12 @@ export function ProjectOverviewPanel() {
 
 export function ProjectConfigurationPanel() {
   const tenant = useRouteTenant();
+  if (tenant.project === null) throw new Error("configuration route has no project");
+  return <ProjectConfigurationPanelState key={tenant.project.id} />;
+}
+
+function ProjectConfigurationPanelState() {
+  const tenant = useRouteTenant();
   const queryClient = useQueryClient();
   const scope = projectScope(tenant);
   const snapshot = useProjectSnapshot();

--- a/src/projects/panels.tsx
+++ b/src/projects/panels.tsx
@@ -34,7 +34,7 @@ import {
   type ConnectionStatus,
 } from "../connections/functions.js";
 import { useRouteTenant } from "./context.js";
-import type { ProjectDashboard } from "./dashboard.js";
+import type { ManualConfigurationSaveResult, ProjectDashboard } from "./dashboard.js";
 import { RepositoryCombobox, type ComboboxRepository } from "./repository-combobox.js";
 import {
   archiveProject,
@@ -52,8 +52,6 @@ import {
 
 type OrganizationSnapshot = Awaited<ReturnType<ProjectDashboard["organizationSnapshot"]>>;
 type ProjectSnapshot = Awaited<ReturnType<ProjectDashboard["projectSnapshot"]>>;
-type CommandResult = Result<{ state: "complete" }>;
-
 export function ProjectsPanel() {
   const tenant = useRouteTenant();
   const queryClient = useQueryClient();
@@ -409,7 +407,10 @@ export function ProjectConfigurationPanel() {
   const snapshot = useProjectSnapshot();
   const sync = useProjectCommand(syncProjectConfiguration, queryClient, scope);
   const manual = useProjectCommand(switchConfigurationToManual, queryClient, scope);
-  const save = useProjectCommand(saveManualConfiguration, queryClient, scope);
+  const save = useProjectCommand<
+    Parameters<typeof saveManualConfiguration>[0],
+    ManualConfigurationSaveResult
+  >(saveManualConfiguration, queryClient, scope);
   const configure = useProjectCommand(useGitHubConfiguration, queryClient, scope);
   const loadRepositories = useServerFn(availableGitHubRepositories);
   const repositories = useQuery({
@@ -443,6 +444,7 @@ export function ProjectConfigurationPanel() {
         description={`Setup and source for ${data.project.name}.`}
       />
       <CommandError mutations={[sync, manual, save, configure]} />
+      <ManualConfigurationResult result={save.data} />
       <Section title="Active revision">
         <div className="rounded-lg border bg-card p-5">
           {configuration.activeRevision === null ? (
@@ -493,6 +495,36 @@ export function ProjectConfigurationPanel() {
         saveManualPending={save.isPending}
       />
     </>
+  );
+}
+
+function ManualConfigurationResult({
+  result,
+}: {
+  result: Result<ManualConfigurationSaveResult> | undefined;
+}) {
+  if (result?.status !== "ok") return null;
+  if (result.data.outcome === "activated") {
+    return (
+      <Alert role="status" className="mb-5">
+        <AlertDescription>
+          Configuration saved and activated as Revision {result.data.revision.version}.
+        </AlertDescription>
+      </Alert>
+    );
+  }
+  return (
+    <Alert variant="destructive" className="mb-5">
+      <AlertTitle>Configuration couldn't be activated</AlertTitle>
+      <AlertDescription>
+        <p>Correct the YAML and try again. The active revision was not changed.</p>
+        <ul className="list-disc pl-5">
+          {result.data.errors.map((error) => (
+            <li key={error}>{error}</li>
+          ))}
+        </ul>
+      </AlertDescription>
+    </Alert>
   );
 }
 
@@ -925,15 +957,15 @@ function queryState<T>(
   return { ok: true, data: query.data.data };
 }
 
-function useProjectCommand<TInput>(
-  command: (input: TInput) => Promise<CommandResult>,
+function useProjectCommand<TInput, TOutput = { state: "complete" }>(
+  command: (input: TInput) => Promise<Result<TOutput>>,
   queryClient: ReturnType<typeof useQueryClient>,
   scope: { organizationSlug: string; projectSlug?: string },
 ) {
   return useMutation({
     mutationFn: useServerFn(command as never) as unknown as (
       input: TInput,
-    ) => Promise<CommandResult>,
+    ) => Promise<Result<TOutput>>,
     onSuccess: async (result) => {
       if (result.status === "ok") await invalidateScope(queryClient, scope);
     },


### PR DESCRIPTION
Users now see actionable, accessible validation feedback when manual configuration cannot be activated, while the editable YAML and prior active revision remain available for correction and retry. Feedback is scoped to the project where the save occurred, and successful activation reports the new revision clearly.

## Goals

- Return typed activation outcomes and normalized validation messages from the configuration boundary.
- Render failed activation as an accessible alert with retry guidance.
- Preserve the prior active revision after an invalid save and make a corrected retry succeed.
- Keep activation feedback and state local to the current project when switching projects.
- Keep manual deployments with Discord but no GitHub configuration independent of repository discovery.
- Cover these journeys through the real browser and application stack.

## Non-goals

- Change daemon identity or resource-resolution semantics.
- Change GitHub synchronization behavior for organizations with GitHub connections.
- Redesign the broader configuration format.

## Why

Manual saves persisted invalid revisions, but the server command reduced every completed call to a generic success state. That discarded the validation result before the UI could explain it. Repository discovery also treated an absent GitHub provider as an error even when the organization had no GitHub connections. Finally, activation results were owned by a route-level mutation instance rather than the project identity, allowing route reuse to expose another project's feedback.

The save boundary now returns an explicit activated-or-invalid result, repository discovery defines no connections as an empty repository set, and the stateful configuration panel is keyed at the project ownership boundary. React only renders those committed, project-local shapes.

## Verification

- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test -- --run src/configuration/validation-errors.test.ts src/configuration/store.test.ts` (9 passed)
- `npx playwright test e2e/projects.spec.ts --project=desktop-chromium` (11 passed)
- Full unit suite: 406 passed; two unrelated environment/concurrency failures passed on focused rerun.

## Risk surface

- Manual configuration save response shape and validation-message normalization.
- Configuration-panel mutation and draft state now remount when project identity changes.
- Stored schema-validation errors use a flat typed shape; activation validity remains determined by null versus non-null.
- Repository discovery returns an empty list only when the organization has no GitHub connections.

Refs #1
