### PR TITLE
Synchronize asynchronous daemon observations

### DIFF
--- a/e2e/helpers/hub.ts
+++ b/e2e/helpers/hub.ts
@@ -1725,7 +1725,7 @@ export class PaseoHub {
     executionId: string,
     daemon: ContractDaemon,
   ): Promise<void> {
-    const capability = daemon.executionCapability(executionId);
+    const capability = await daemon.executionCapability(executionId);
     const client = new McpClient({ name: "paseo-hub-browser-contract", version: "1.0.0" });
     const transport = new StreamableHTTPClientTransport(new URL(capability.url), {
       requestInit: { headers: capability.headers },
@@ -3633,9 +3633,10 @@ class ContractDaemon {
   readonly daemonId = randomUUID();
   readonly slug: string;
   private readonly credential = randomUUID();
-  private readonly executionCapabilities = new Map<
+  private readonly executionCapabilities = new Map<string, ExecutionCapability>();
+  private readonly executionCreateEvents = new Map<
     string,
-    { url: string; headers: Record<string, string> }
+    { promise: Promise<void>; resolve: () => void }
   >();
   private socket: WebSocket | undefined;
   private webSocketUrl = "";
@@ -3683,7 +3684,20 @@ class ContractDaemon {
     });
   }
 
-  executionCapability(executionId: string): { url: string; headers: Record<string, string> } {
+  async executionCapability(executionId: string): Promise<ExecutionCapability> {
+    const capability = this.executionCapabilities.get(executionId);
+    if (capability !== undefined) return capability;
+    const existingEvent = this.executionCreateEvents.get(executionId);
+    if (existingEvent !== undefined) {
+      await existingEvent.promise;
+    } else {
+      let resolve!: () => void;
+      const promise = new Promise<void>((fulfill) => {
+        resolve = fulfill;
+      });
+      this.executionCreateEvents.set(executionId, { promise, resolve });
+      await promise;
+    }
     return z
       .object({ url: z.string().url(), headers: z.record(z.string(), z.string()) })
       .parse(this.executionCapabilities.get(executionId));
@@ -3717,7 +3731,11 @@ class ContractDaemon {
     if (!envelope.success) return;
     const request = envelope.data.message;
     const capability = request.mcpServers?.["hub"];
-    if (capability !== undefined) this.executionCapabilities.set(request.executionId, capability);
+    if (capability !== undefined) {
+      this.executionCapabilities.set(request.executionId, capability);
+    }
+    this.executionCreateEvents.get(request.executionId)?.resolve();
+    this.executionCreateEvents.delete(request.executionId);
     this.socket?.send(
       JSON.stringify({
         type: "session",
@@ -3736,6 +3754,8 @@ class ContractDaemon {
     );
   }
 }
+
+type ExecutionCapability = { url: string; headers: Record<string, string> };
 
 interface HttpContract {
   name: string;

--- a/src/daemons/daemons.test.ts
+++ b/src/daemons/daemons.test.ts
@@ -924,6 +924,7 @@ describe("daemon enrollment and execution", () => {
       },
     );
     await hub.drainWorkflowOutbox();
+    await hub.failureNotified();
     assert.equal(hub.failureHookCount(), 1);
     assert.equal(hub.createdAgentCount(), 0);
   });
@@ -945,6 +946,7 @@ describe("daemon enrollment and execution", () => {
       { status: "failed", result: { status: "failed", reason: "whole_run_timeout" } },
     );
     await hub.drainWorkflowOutbox();
+    await hub.failureNotified();
     assert.equal(hub.failureHookCount(), 1);
     assert.deepEqual(hub.controlActions(), ["interrupt"]);
     assert.equal(await hub.completeExecution(result.execution.id), 409);


### PR DESCRIPTION
## What changed, and why

The daemon test harness now waits on terminal-notification production before asserting failure hooks, and the browser contract daemon waits for the matching execution create request before opening an execution MCP session. This removes two asynchronous observation races without changing runtime daemon, workflow, or database behavior.

## Goals

- Make terminal hook-count assertions observe the existing producer completion signal.
- Correlate execution capability observation with the execution ID's WebSocket create event.
- Keep synchronization event-driven and local to the owning harnesses.

## Non-goals

- No production daemon or workflow changes.
- No database or schema changes.
- No sleeps, polling, retries, or timeout changes.
- No deployment or API contract changes.

## The why

Durable execution state can legitimately become observable before its asynchronous hooks and WebSocket capability message. The harnesses previously read those consumer-side observations immediately after a durable state transition. Waiting on the existing producer signal and a per-execution create event makes each harness observe the event it owns.

## Verification

- Exact Node 22.20.0 unit test repeated 10 times: 10/10 passed.
- Complete daemon suite: 8 files, 113/113 tests passed.
- Full Vitest: 76 files passed; 508 tests passed, 12 skipped.
- Phase 0 built-app contract journey: passed.
- Full built-app browser suite: 55 passed; 2 unrelated local failures required the separate exact source checkout because PASEO_E2E_WORKTREE was unset.
- Full source-built Hub E2E was attempted with the local exact companion checkout but failed before journeys because the Hub child could not identify its bootstrap organization (InstanceBootstrapError).
- Typecheck, lint, format check, Drizzle check, build, and git diff --check: passed.

## Risk surface

The change is limited to two test-harness ownership boundaries. The unit path waits on an existing harness signal, and the browser path retains capability validation while waiting only for the matching execution ID's create request. Runtime daemon behavior, workflow wakeups, persistence, and public contracts are unchanged.