### PR TITLE
Make project selection the point of the project list

### DIFF
--- a/e2e/helpers/projects/projects.ts
+++ b/e2e/helpers/projects/projects.ts
@@ -16,15 +16,26 @@ export class ProjectLifecycle {
     await expect(this.page.getByRole("link", { name })).toBeVisible();
   }
 
+  /** Archiving lives in project settings; the list is only for choosing a project. */
   async archive(name: string) {
-    await this.page.getByRole("button", { name: `Actions for ${name}` }).click();
-    await this.page.getByRole("menuitem", { name: "Archive" }).click();
+    await this.page.getByRole("link", { name }).click();
+    await this.page
+      .getByRole("navigation", { name: "Project" })
+      .getByRole("link", {
+        name: "Settings",
+      })
+      .click();
+    await this.page.getByRole("button", { name: "Archive project" }).click();
     await this.page
       .getByRole("alertdialog")
       .getByRole("button", { name: "Archive project" })
       .click();
-    await expect(this.page.getByRole("row", { name: new RegExp(name, "u") })).toContainText(
-      "Archived",
-    );
+    // Back on the list, an archived project keeps its row and loses its link.
+    const row = this.page
+      .getByRole("list", { name: "Projects" })
+      .getByRole("listitem")
+      .filter({ hasText: name });
+    await expect(row).toContainText("Archived");
+    await expect(row.getByRole("link")).toHaveCount(0);
   }
 }

--- a/src/projects/panels.tsx
+++ b/src/projects/panels.tsx
@@ -2,10 +2,12 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useNavigate } from "@tanstack/react-router";
 import { useServerFn } from "@tanstack/react-start";
+import { ChevronRight } from "lucide-react";
 import { useState, type FormEvent, type ReactNode } from "react";
 import { CONNECTION_MUTATION_KEY } from "../auth/tenant-mutation.js";
 import { ConfirmAction, ConfirmMenuItem } from "../components/app/confirm-action.js";
 import { DataCell, DataRow, DataTable } from "../components/app/data-table.js";
+import { EmptyState } from "../components/app/empty-state.js";
 import { PageHeader } from "../components/app/page.js";
 import { RowActions } from "../components/app/row-actions.js";
 import { Section } from "../components/app/section.js";
@@ -60,7 +62,6 @@ export function ProjectsPanel() {
   const [connectionResult] = useState(consumeConnectionResult);
   const [creating, setCreating] = useState(false);
   const create = useProjectCommand(createProject, queryClient, scope);
-  const archive = useProjectCommand(archiveProject, queryClient, scope);
   if (!snapshot.ok) return snapshot.element;
   const data = snapshot.data;
   const submitCreate = (event: FormEvent<HTMLFormElement>) => {
@@ -77,10 +78,7 @@ export function ProjectsPanel() {
   };
   return (
     <>
-      <PageHeader
-        title="Projects"
-        description={`Operational boundaries in ${data.organization.name}.`}
-      >
+      <PageHeader title="Projects" description="Select a project to work in.">
         {data.capabilities.manageResources ? (
           <Button onClick={() => setCreating(true)}>New project</Button>
         ) : null}
@@ -90,59 +88,26 @@ export function ProjectsPanel() {
           <AlertDescription>{connectionResultCopy(connectionResult)}</AlertDescription>
         </Alert>
       )}
-      <CommandError mutations={[create, archive]} />
-      <DataTable
-        label="Projects"
-        columns={[
-          { header: "Project" },
-          { header: "Status" },
-          { header: "Created" },
-          { header: "" },
-        ]}
-        isEmpty={data.projects.length === 0}
-        empty={{ title: "No projects" }}
-      >
-        {data.projects.map((project) => (
-          <DataRow key={project.id}>
-            <DataCell>
-              {project.status === "active" ? (
-                <Link
-                  className="font-medium hover:underline"
-                  to={`/o/${data.organization.slug}/projects/${project.slug}/overview` as never}
-                >
-                  {project.name}
-                </Link>
-              ) : (
-                <span className="font-medium">{project.name}</span>
-              )}
-              <span className="block font-mono text-xs text-muted-foreground">{project.slug}</span>
-            </DataCell>
-            <DataCell>
-              <StatusPill tone={project.status === "active" ? "success" : "neutral"}>
-                {project.status === "active" ? "Active" : "Archived"}
-              </StatusPill>
-            </DataCell>
-            <DataCell muted>{formatDate(project.createdAt)}</DataCell>
-            <DataCell align="end">
-              {data.capabilities.manageResources && project.status === "active" ? (
-                <RowActions label={`Actions for ${project.name}`}>
-                  <ConfirmMenuItem
-                    destructive
-                    label="Archive"
-                    title={`Archive ${project.name}?`}
-                    description="Routing is released. History remains available from this list."
-                    confirmLabel="Archive project"
-                    cancelLabel="Cancel"
-                    onConfirm={() =>
-                      archive.mutate({ data: { ...scope, projectSlug: project.slug } })
-                    }
-                  />
-                </RowActions>
-              ) : null}
-            </DataCell>
-          </DataRow>
-        ))}
-      </DataTable>
+      <CommandError mutations={[create]} />
+      {data.projects.length === 0 ? (
+        <div className="rounded-lg border bg-card">
+          <EmptyState
+            title="No projects"
+            description="Create a project to route provider events at a daemon."
+          />
+        </div>
+      ) : (
+        <ul aria-label="Projects" className="grid gap-2">
+          {data.projects.map((project) => (
+            <li key={project.id}>
+              <ProjectCard
+                project={project}
+                to={`/o/${data.organization.slug}/projects/${project.slug}/overview`}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
       <Dialog open={creating} onOpenChange={setCreating}>
         <DialogContent>
           <DialogHeader>
@@ -164,6 +129,60 @@ export function ProjectsPanel() {
       </Dialog>
     </>
   );
+}
+
+/**
+ * The project chooser row. Choosing a project is the whole job of that screen, so the
+ * card itself is the target rather than the name inside a cell. Archived projects keep
+ * their row but lose every affordance — their routes stop resolving once archived.
+ */
+function ProjectCard({
+  project,
+  to,
+}: {
+  project: OrganizationSnapshot["projects"][number];
+  to: string;
+}) {
+  const card = "flex items-center gap-4 rounded-lg border bg-card px-4 py-3.5";
+  const body = (
+    <>
+      <span
+        aria-hidden="true"
+        className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-primary/15 text-sm font-semibold text-link"
+      >
+        {monogram(project.name)}
+      </span>
+      <span className="grid min-w-0 flex-1 gap-0.5">
+        <span className="flex items-center gap-2">
+          <span className="truncate font-medium group-hover:text-link">{project.name}</span>
+          {project.status === "active" ? null : <StatusPill tone="neutral">Archived</StatusPill>}
+        </span>
+        <span className="truncate font-mono text-xs text-muted-foreground">{project.slug}</span>
+      </span>
+      <span className="hidden shrink-0 text-xs text-muted-foreground sm:block">
+        Created {formatDate(project.createdAt)}
+      </span>
+    </>
+  );
+  if (project.status !== "active") {
+    return <div className={cn(card, "opacity-60")}>{body}</div>;
+  }
+  return (
+    <Link
+      to={to as never}
+      className={cn(card, "group transition-colors hover:border-primary/60 hover:bg-accent/40")}
+    >
+      {body}
+      <ChevronRight className="size-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:text-foreground" />
+    </Link>
+  );
+}
+
+function monogram(name: string) {
+  const words = name.split(/\s+/).filter((word) => word.length > 0);
+  const letters =
+    words.length > 1 ? `${words[0]?.[0] ?? ""}${words[1]?.[0] ?? ""}` : name.slice(0, 2);
+  return letters.toUpperCase();
 }
 
 export function OrganizationConnectionsPanel() {
@@ -841,7 +860,18 @@ export function ProjectGeneralSettingsPanel() {
   const scope = projectScope(tenant);
   const snapshot = useProjectSnapshot();
   const updateSlug = useProjectCommand(updateProjectSlug, queryClient, scope);
-  const archive = useProjectCommand(archiveProject, queryClient, scope);
+  // Archiving deletes the route this panel is standing on: the project stops resolving
+  // for every project URL. Leave for the project list before invalidating, or the
+  // refetch lands on a project route that can no longer answer.
+  const archiveProjectFn = useServerFn(archiveProject);
+  const archive = useMutation({
+    mutationFn: archiveProjectFn,
+    onSuccess: async (result) => {
+      if (result.status !== "ok") return;
+      await navigate({ to: `/o/${tenant.organization.slug}/projects` as never });
+      await invalidateScope(queryClient, scope);
+    },
+  });
   if (!snapshot.ok) return snapshot.element;
   const data = snapshot.data;
   const submit = (event: FormEvent<HTMLFormElement>) => {
@@ -890,17 +920,8 @@ export function ProjectGeneralSettingsPanel() {
               description="Routing is released; running recovery and history remain."
               confirmLabel="Archive project"
               cancelLabel="Cancel"
-              onConfirm={() =>
-                archive.mutate(
-                  { data: scope },
-                  {
-                    onSuccess: (result) => {
-                      if (result.status === "ok")
-                        void navigate({ to: `/o/${tenant.organization.slug}/projects` as never });
-                    },
-                  },
-                )
-              }
+              busy={archive.isPending}
+              onConfirm={() => archive.mutate({ data: scope })}
             />
           </Section>
         </>


### PR DESCRIPTION
Projects now render as full-width cards you click anywhere on, instead of a table row whose only hit target was the project name. Archiving moved out of the row kebab into project settings, which already owned it.


## Goals

- Selecting a project reads as the primary action on the screen: the whole card is the target, with a hover surface, brand border, and a chevron.
- Archived projects stay visible and stay honest — no affordance that leads nowhere.
- One place to archive a project: project settings.
- The archive flow ends on the project list, never on a dead project route.

## Non-goals

- No new data on the card. It shows name, slug, status and created date — exactly what `organizationSnapshot` already returns. Repository and last-run would each need a new read, and were not asked for.
- No pagination, filtering or search on the list (see #3).
- No change to who may archive, or to what archiving does server-side.

## The why

The name was the only hit target, and it was styled the same as the plain text an archived project renders — nothing on the row said it went anywhere. Selecting a project is the whole job of that screen, so the card itself is now the link.

Archived projects are deliberately *not* clickable. `resolveTenantRouteAccess` joins projects on `status = 'active'` (`src/db/pg.ts:2889`), so every project URL stops resolving the moment a project is archived. Making the whole row clickable regardless would send you straight to "Project unavailable" — the e2e caught exactly that on the first pass.

Moving archive into settings exposed a real bug in the settings flow. `useProjectCommand` invalidates the project queries on success, so the refetch fired while the panel was still mounted on the archived project's own route, rendered "Project unavailable", and beat the navigation home. It was timing-dependent, which is why the test passed in isolation and failed in the full file. Settings now owns an archive mutation that navigates to the list first and invalidates after.

## Verification

- `e2e/projects.spec.ts` (desktop-chromium): 11/11 pass, including the axe accessibility check on the projects route.
- `e2e/projects-mobile.spec.ts` (mobile-chromium): 1/1 pass.
- `npm run typecheck`, `npm run lint`, `npm run format` clean.
- `ProjectLifecycle.archive` rewritten to drive project settings; it asserts the archived row keeps its text and has zero links.
- Rendered and inspected the real page with several projects plus an archived one.

## Risk surface

- **Archive is no longer reachable from the list.** Anyone used to the row kebab has to open the project and go to Settings. This is the intended trade, but it is the one behaviour change a user will notice.
- **The table is gone from this screen.** `DataTable`/`DataRow` are untouched and still used by every other list; only the projects list left them for a `<ul>` of cards. Any future test that assumed `getByRole("row")` on this screen will need the listitem shape instead.
- **Archived rows are no longer links.** Assertions elsewhere that locate a project by link role will not match an archived project.
- The archive mutation in settings no longer routes through `useProjectCommand`, so it does not share that hook's error surface — `CommandError` still renders it because the mutation shape is the same.
