### PR TITLE
Expose available Hub capabilities in agent prompts

### DIFF
--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -20,7 +20,7 @@ The configuration install body may also include an optional `partials` array. Ea
 
 ## Workflow prompt capability inventory
 
-Each workflow step's agent prompt includes a factual inventory of the Hub capabilities available to that execution by default. The inventory uses stable semantic names: `hub.finalize` records the current agent execution as complete and returns its result to the workflow, while `hub.reply` sends a message to the conversation that triggered the execution when that output is allowed and available. Finalizing an execution does not necessarily complete the whole workflow.
+Each workflow step's agent prompt begins with a factual inventory of the capabilities available to that execution by default. It uses the header `Capabilities available in this execution:`, lists only the available capabilities, then leaves a blank line before the authored prompt. The inventory uses stable semantic names: `hub.finalize` records the current agent execution as complete and returns its result to the workflow, while `hub.reply` sends a message to the conversation that triggered the execution when that output is allowed and available. Finalizing an execution does not necessarily complete the whole workflow.
 
 Authors may opt out for an individual step with `inject_tool_inventory: false`:
 

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -18,6 +18,21 @@ Configuration YAML may include an optional non-empty top-level string `project` 
 
 The configuration install body may also include an optional `partials` array. Each item is `{ "path": "docs/safety.md", "content": "..." }`, where `path` is a normalized relative path under `.paseo/partials/`. When YAML prompt blocks use `include`, the bundle must contain exactly those referenced files; missing, duplicate, unsafe, unexpected, or oversized files are rejected before a revision is recorded. Hub resolves the submitted content into the compiled revision and preserves it in source evidence, so changing only a partial creates a new revision. Requests without partial includes remain compatible with the YAML-only body.
 
+## Workflow prompt capability inventory
+
+Each workflow step's agent prompt includes a factual inventory of the Hub capabilities available to that execution by default. The inventory uses stable semantic names: `hub.finalize` records the current agent execution as complete and returns its result to the workflow, while `hub.reply` sends a message to the conversation that triggered the execution when that output is allowed and available. Finalizing an execution does not necessarily complete the whole workflow.
+
+Authors may opt out for an individual step with `inject_tool_inventory: false`:
+
+```yaml
+steps:
+  - id: classify
+    inject_tool_inventory: false
+    # ...the remaining step fields
+```
+
+The setting affects prompt discoverability only; server-side capability permissions and completion rules remain enforced.
+
 `deliveryKey` is caller-supplied request identity for the existing durable manual-event path. Hub namespaces it by the authenticated organization and resolved project before persistence, so the same caller key can be used independently in different tenants or projects. Existing receipt/run de-duplication applies, but this API does not promise exactly-once execution or guaranteed response replay; retries can still fail or conflict during restart and timing races. A successful representation contains `deliveryKey`, `providerEventReceiptId`, `triggerRunId`, `configuredTriggerName`, and the durable `workflowStatus`.
 
 The self-hosted Scalar reference is served with a restrictive Content Security Policy and does not require external fonts, scripts, telemetry, registries, or proxies.
@@ -62,3 +77,4 @@ The public Hub docs live in the separate `getpaseo/paseo` repository under `publ
 4. Replace the manual-run success example with the five durable fields listed above.
 5. Describe RFC 9457 errors, structured `issues`, `requestId`, `X-Request-ID`, and narrow delivery-key semantics.
 6. Document `GET /api/billing/plans` (unauthenticated, no scopes) — this is what paseo.sh's pricing page will fetch.
+7. Document workflow-step `inject_tool_inventory` and the semantic `hub.finalize` / `hub.reply` inventory names.

--- a/src/app.ts
+++ b/src/app.ts
@@ -134,8 +134,13 @@ export function createHubApplication(options: HubRuntimeOptions): HubApplication
   const providers = [manualProvider, ...configuredProviders, ...(options.providers ?? [])].filter(
     (provider): provider is TriggerProvider => provider !== undefined,
   );
-  const daemonModule = createAppDaemonModule(options, daemons, providers);
-  const capabilityServer = createAppExecutionCapabilityServer(options, daemonModule);
+  const outputRegistry = options.outputRegistry ?? new OutputExecutorRegistry();
+  const daemonModule = createAppDaemonModule(options, daemons, providers, outputRegistry);
+  const capabilityServer = createAppExecutionCapabilityServer(
+    options,
+    daemonModule,
+    outputRegistry,
+  );
   const registration =
     options.database === null || daemons === null
       ? null
@@ -284,13 +289,14 @@ function createAppPublicOperations(
 function createAppExecutionCapabilityServer(
   options: HubRuntimeOptions,
   daemonModule: DaemonModule | null,
+  outputRegistry: OutputExecutorRegistry,
 ) {
   if (options.database === null || daemonModule === null) {
     return null;
   }
   return createExecutionCapabilityServer({
     database: options.database,
-    outputs: options.outputRegistry ?? new OutputExecutorRegistry(),
+    outputs: outputRegistry,
     completeExecution: (input) =>
       daemonModule.lifecycle.completeAgentExecutionFromCallback(input, { deferHubAction: true }),
   });
@@ -335,6 +341,7 @@ function createAppDaemonModule(
   options: HubRuntimeOptions,
   daemons: ActiveDaemonRegistry | null,
   providers: readonly TriggerProvider[],
+  outputRegistry: OutputExecutorRegistry,
 ): DaemonModule | null {
   if (options.database === null) {
     return null;
@@ -345,6 +352,7 @@ function createAppDaemonModule(
   return createDaemonModule({
     database: options.database,
     connectionForDaemon: options.daemonConnectionForId ?? ((id) => daemons?.connection(id)),
+    executionCapabilities: outputRegistry,
     ...(options.completionTokenSecret === undefined
       ? {}
       : { completionTokenSecret: options.completionTokenSecret }),

--- a/src/application-runtime.test.ts
+++ b/src/application-runtime.test.ts
@@ -12,7 +12,7 @@ import type { Database } from "./db/types.js";
 import { EntitlementsService } from "./entitlements/service.js";
 import type { ProviderRegistration, TriggerProviderResources } from "./providers/registration.js";
 import { createApplicationRuntime } from "./application-runtime.js";
-import { replyOutputTool } from "./execution-capabilities/outputs.js";
+import { replyCapabilityMetadata, replyOutputTool } from "./execution-capabilities/outputs.js";
 
 describe("application runtime provider composition", () => {
   it("collects a fake registration without a concrete-provider case", async () => {
@@ -41,7 +41,14 @@ describe("application runtime provider composition", () => {
           },
         },
       ],
-      outputs: [{ type: "fake.output", tool: replyOutputTool, execute: () => Promise.resolve() }],
+      outputs: [
+        {
+          type: "fake.output",
+          hub: replyCapabilityMetadata,
+          tool: replyOutputTool,
+          execute: () => Promise.resolve(),
+        },
+      ],
       requests: [
         {
           name: "webhook",

--- a/src/config/compiler.test.ts
+++ b/src/config/compiler.test.ts
@@ -133,6 +133,23 @@ describe("workflow compiler", () => {
     );
   });
 
+  it("defaults tool inventory injection and accepts a step opt-out", () => {
+    const base = configuration();
+    const defaulted = compileHubConfig(base);
+    assert.equal(defaulted.triggers[0]?.steps[0]?.injectToolInventory, true);
+
+    const optedOut = compileHubConfig({
+      ...base,
+      triggers: [
+        {
+          ...base.triggers[0],
+          steps: [{ ...base.triggers[0]!.steps[0], inject_tool_inventory: false }],
+        },
+      ],
+    });
+    assert.equal(optedOut.triggers[0]?.steps[0]?.injectToolInventory, false);
+  });
+
   it("rejects duplicate IDs, unknown references, forward references, and value cycles", () => {
     const trigger = configuration().triggers[0]!;
     assert.throws(

--- a/src/config/compiler.ts
+++ b/src/config/compiler.ts
@@ -149,6 +149,7 @@ const StepSchema = z
     output: z.object({ schema: JsonSchemaSchema }).strict().optional(),
     allow_outputs: z.array(AllowOutputSchema).optional(),
     auto_archive: z.boolean().optional(),
+    inject_tool_inventory: z.boolean().optional(),
   })
   .strict();
 
@@ -213,6 +214,7 @@ export interface CompiledStep {
   output?: { schema: JsonValue } | undefined;
   allowOutputs: readonly { type: string; max: number; required: boolean }[];
   autoArchive: boolean;
+  injectToolInventory: boolean;
 }
 
 export type CompiledSteps = readonly CompiledStep[];
@@ -333,6 +335,7 @@ const CompiledStepSchema: z.ZodType<CompiledStep> = z
         .strict(),
     ),
     autoArchive: z.boolean(),
+    injectToolInventory: z.boolean().default(true),
   })
   .strict();
 
@@ -494,6 +497,7 @@ function compileStep(
       required: allowOutput.required ?? false,
     })),
     autoArchive: step.auto_archive ?? false,
+    injectToolInventory: step.inject_tool_inventory ?? true,
   };
 }
 

--- a/src/daemons/daemons.test.ts
+++ b/src/daemons/daemons.test.ts
@@ -266,7 +266,7 @@ describe("daemon enrollment and execution", () => {
 
       hub.releaseLaunchMaterialization();
       await hub.waitForRecoveredExecution(handedOff.execution.id);
-      assert.match(String(hub.createdAgentLaunch().prompt), /^token=resolved-secret/u);
+      assert.match(String(hub.createdAgentLaunch().prompt), /token=resolved-secret$/u);
       assert.equal(Reflect.get(Object(hub.createdAgentLaunch().env), "TOKEN"), "resolved-secret");
       assert.deepEqual(hub.createdAgentLaunch().worktree, {
         mode: "checkout-branch",
@@ -317,7 +317,7 @@ describe("daemon enrollment and execution", () => {
     assert(execution !== undefined);
     await hub.waitForRecoveredExecution(execution.id);
 
-    assert.match(String(hub.createdAgentLaunch().prompt), /^token=resolved-secret/u);
+    assert.match(String(hub.createdAgentLaunch().prompt), /token=resolved-secret$/u);
     assert.equal(Reflect.get(Object(hub.createdAgentLaunch().env), "TOKEN"), "resolved-secret");
     assert.deepEqual(hub.createdAgentLaunch().worktree, {
       mode: "checkout-branch",

--- a/src/daemons/daemons.test.ts
+++ b/src/daemons/daemons.test.ts
@@ -111,7 +111,15 @@ describe("daemon enrollment and execution", () => {
     const agent = hub.createdAgentLaunch();
     assert.deepEqual({ worktree: agent.worktree }, { worktree: undefined });
     assert.equal(agent.cwd, "/workspace");
-    assert.equal(agent.prompt, "Reply pong.");
+    assert.equal(
+      agent.prompt,
+      [
+        "Reply pong.",
+        "",
+        "Hub capabilities available in this execution:",
+        "- hub.finalize: records the current agent execution as complete and returns its result to the workflow.",
+      ].join("\n"),
+    );
     assert.equal(agent.thinkingOptionId, "xhigh");
     assert.deepEqual(agent.env, {
       USER_DEFINED: "yes",
@@ -128,6 +136,47 @@ describe("daemon enrollment and execution", () => {
         headers: { Authorization: "Bearer <private>" },
       },
     });
+  });
+
+  it("inventories available Hub capabilities in the agent prompt", async () => {
+    await hub.connectDaemon();
+
+    await hub.dispatch({
+      outputContext: { provider: "discord", channelId: "channel-1" },
+    });
+    assert.equal(
+      hub.createdAgentLaunch().prompt,
+      [
+        "Reply pong.",
+        "",
+        "Hub capabilities available in this execution:",
+        "- hub.finalize: records the current agent execution as complete and returns its result to the workflow.",
+        "- hub.reply: sends a message to the conversation that triggered the execution.",
+      ].join("\n"),
+    );
+
+    await hub.dispatch({
+      outputContext: { provider: "manual", channelId: "channel-1" },
+    });
+    assert.equal(
+      hub.createdAgentLaunch().prompt,
+      [
+        "Reply pong.",
+        "",
+        "Hub capabilities available in this execution:",
+        "- hub.finalize: records the current agent execution as complete and returns its result to the workflow.",
+      ].join("\n"),
+    );
+  });
+
+  it("allows an execution to opt out of the Hub capability inventory", async () => {
+    await hub.connectDaemon();
+    await hub.dispatch({
+      injectToolInventory: false,
+      outputContext: { provider: "discord", channelId: "channel-1" },
+    });
+
+    assert.equal(hub.createdAgentLaunch().prompt, "Reply pong.");
   });
 
   it("deduplicates durable fan-out per configured trigger match", async () => {

--- a/src/daemons/daemons.test.ts
+++ b/src/daemons/daemons.test.ts
@@ -114,10 +114,10 @@ describe("daemon enrollment and execution", () => {
     assert.equal(
       agent.prompt,
       [
-        "Reply pong.",
-        "",
-        "Hub capabilities available in this execution:",
+        "Capabilities available in this execution:",
         "- hub.finalize: records the current agent execution as complete and returns its result to the workflow.",
+        "",
+        "Reply pong.",
       ].join("\n"),
     );
     assert.equal(agent.thinkingOptionId, "xhigh");
@@ -147,11 +147,11 @@ describe("daemon enrollment and execution", () => {
     assert.equal(
       hub.createdAgentLaunch().prompt,
       [
-        "Reply pong.",
-        "",
-        "Hub capabilities available in this execution:",
+        "Capabilities available in this execution:",
         "- hub.finalize: records the current agent execution as complete and returns its result to the workflow.",
         "- hub.reply: sends a message to the conversation that triggered the execution.",
+        "",
+        "Reply pong.",
       ].join("\n"),
     );
 
@@ -161,10 +161,10 @@ describe("daemon enrollment and execution", () => {
     assert.equal(
       hub.createdAgentLaunch().prompt,
       [
-        "Reply pong.",
-        "",
-        "Hub capabilities available in this execution:",
+        "Capabilities available in this execution:",
         "- hub.finalize: records the current agent execution as complete and returns its result to the workflow.",
+        "",
+        "Reply pong.",
       ].join("\n"),
     );
   });

--- a/src/daemons/index.ts
+++ b/src/daemons/index.ts
@@ -16,6 +16,7 @@ import type {
   DaemonCreateAgentOptions,
 } from "./protocol.js";
 import type { Logger } from "pino";
+import type { OutputExecutorRegistry } from "../execution-capabilities/outputs.js";
 
 export type {
   DaemonAgentStreamEvent,
@@ -35,6 +36,7 @@ interface DaemonModuleTestOptions {
 
 export interface DaemonModuleOptions {
   database: Database;
+  executionCapabilities?: OutputExecutorRegistry;
   providers?: readonly TriggerProvider[];
   integrations?: readonly ProviderIntegrationRegistration[];
   connectionForDaemon(daemonId: string): DaemonConnection | undefined;
@@ -54,6 +56,9 @@ export function createDaemonModule(options: DaemonModuleOptions): DaemonModule {
     lifecycle: createDaemonDispatchLifecycle({
       database: options.database,
       connectionForDaemon: (daemonId) => options.connectionForDaemon(daemonId),
+      ...(options.executionCapabilities === undefined
+        ? {}
+        : { executionCapabilities: options.executionCapabilities }),
       providers: options.providers ?? [],
       integrations: options.integrations ?? [],
       ...(options.publicBaseUrl === undefined ? {} : { publicBaseUrl: options.publicBaseUrl }),

--- a/src/daemons/lifecycle.ts
+++ b/src/daemons/lifecycle.ts
@@ -21,6 +21,8 @@ import type { LaunchMachineIntent } from "../dispatcher/launch-machine-intent.js
 import { logger as defaultLogger } from "../logger.js";
 import type { TriggerProvider } from "../triggers/index.js";
 import type { ProviderIntegrationRegistration } from "../providers/registration.js";
+import { composeExecutionPrompt } from "../execution-capabilities/prompt.js";
+import { OutputExecutorRegistry } from "../execution-capabilities/outputs.js";
 import {
   notifyAgentExecutionCompleted,
   notifyAgentExecutionFailed,
@@ -90,6 +92,7 @@ const systemExecutionDeadlineClock: ExecutionDeadlineClock = {
 export interface DaemonDispatchLifecycleOptions {
   database: Database;
   connectionForDaemon(daemonId: string): DaemonConnection | undefined;
+  executionCapabilities?: OutputExecutorRegistry;
   providers?: readonly TriggerProvider[];
   integrations?: readonly ProviderIntegrationRegistration[];
   publicBaseUrl?: string;
@@ -135,6 +138,7 @@ export class AgentExecutionOutputValidationFailure extends Error {
 
 export class DaemonDispatchLifecycle {
   private readonly providersByName: Map<string, TriggerProvider>;
+  private readonly executionCapabilities: OutputExecutorRegistry;
   private readonly startedExecutions = new Set<string>();
   private readonly pendingStreamHandlersByExecution = new Map<string, Promise<void>>();
   private readonly completionWatchersByExecution = new Map<
@@ -149,6 +153,7 @@ export class DaemonDispatchLifecycle {
   private stopping = false;
 
   constructor(private readonly options: DaemonDispatchLifecycleOptions) {
+    this.executionCapabilities = options.executionCapabilities ?? new OutputExecutorRegistry();
     this.providersByName = new Map(
       (options.providers ?? []).map((provider) => [provider.name, provider]),
     );
@@ -506,27 +511,41 @@ export class DaemonDispatchLifecycle {
     provider: TriggerProvider | undefined,
     executionId: string,
   ): Promise<LaunchMachineIntent> {
+    const composed = {
+      ...intent,
+      prompt: composeExecutionPrompt({
+        prompt: intent.prompt,
+        ...(intent.injectToolInventory === undefined
+          ? {}
+          : { injectToolInventory: intent.injectToolInventory }),
+        allowOutputs: intent.allowOutputs,
+        outputContext: intent.outputContext,
+        capabilities: this.executionCapabilities,
+      }),
+    };
     const persistedWorktree = intent.environment.worktree;
     if (provider?.materializeLaunch === undefined) {
-      return intent;
+      return composed;
     }
     const materialized = await provider.materializeLaunch({
       executionId,
-      organizationId: intent.organizationId,
-      projectId: intent.projectId,
-      prompt: intent.prompt,
-      ...(intent.environment.env === undefined ? {} : { environmentEnv: intent.environment.env }),
+      organizationId: composed.organizationId,
+      projectId: composed.projectId,
+      prompt: composed.prompt,
+      ...(composed.environment.env === undefined
+        ? {}
+        : { environmentEnv: composed.environment.env }),
       ...(persistedWorktree === undefined ? {} : { environmentWorktree: persistedWorktree }),
-      triggerContext: intent.triggerContext,
+      triggerContext: composed.triggerContext,
     });
     const {
       env: _persistedEnvironmentEnv,
       worktree: _persistedWorktree,
       ...environment
-    } = intent.environment;
+    } = composed.environment;
     const environmentWorktree = materialized.environmentWorktree ?? persistedWorktree;
     return {
-      ...intent,
+      ...composed,
       prompt: materialized.prompt,
       environment: {
         ...environment,

--- a/src/daemons/test-utils/hub-harness.ts
+++ b/src/daemons/test-utils/hub-harness.ts
@@ -42,6 +42,7 @@ import type { WorktreeTarget } from "../../config/index.js";
 import {
   OutputExecutorRegistry,
   outputContextProvider,
+  replyCapabilityMetadata,
   replyOutputTool,
 } from "../../execution-capabilities/outputs.js";
 import type { DaemonClock } from "../registry.js";
@@ -1321,6 +1322,7 @@ export class HubHarness {
     const registry = new OutputExecutorRegistry();
     registry.register({
       type: "discord.reply",
+      hub: replyCapabilityMetadata,
       tool: replyOutputTool,
       available: outputContextProvider("discord"),
       execute: async () => undefined,

--- a/src/dispatcher/launch-machine-intent.ts
+++ b/src/dispatcher/launch-machine-intent.ts
@@ -30,6 +30,7 @@ export interface LaunchMachineIntent {
   triggerContext: unknown;
   outputContext: unknown;
   outputSchema?: JsonValue;
+  injectToolInventory?: boolean;
   configurationRevisionId: string;
   deadlineAt?: Date;
   hubConfig: unknown;
@@ -51,6 +52,7 @@ export function buildLaunchMachineIntent(input: {
   autoArchive: boolean;
   triggerContext: unknown;
   outputContext: unknown;
+  injectToolInventory?: boolean;
   hubConfig: unknown;
 }): LaunchMachineIntent {
   return {
@@ -69,6 +71,7 @@ export function buildLaunchMachineIntent(input: {
     autoArchive: input.autoArchive,
     triggerContext: input.triggerContext,
     outputContext: input.outputContext,
+    ...(input.injectToolInventory === false ? { injectToolInventory: false } : {}),
     configurationRevisionId: input.configurationRevisionId,
     hubConfig: input.hubConfig,
   };

--- a/src/e2e/harness/hub-child.ts
+++ b/src/e2e/harness/hub-child.ts
@@ -7,6 +7,7 @@ import { Client } from "pg";
 import {
   OutputExecutorRegistry,
   outputContextProvider,
+  replyCapabilityMetadata,
   replyOutputTool,
 } from "../../execution-capabilities/outputs.js";
 import { createFetchServer } from "../../http/node-server.js";
@@ -60,6 +61,7 @@ async function main(): Promise<void> {
   const outputs = new OutputExecutorRegistry();
   outputs.register({
     type: "discord.reply",
+    hub: replyCapabilityMetadata,
     tool: replyOutputTool,
     available: outputContextProvider("discord"),
     execute: async (output) => {

--- a/src/e2e/hub-foundation.e2e.test.ts
+++ b/src/e2e/hub-foundation.e2e.test.ts
@@ -127,7 +127,12 @@ describeHubE2E("Paseo Hub cross-repository contract", () => {
     const recovered = await hub.completedRun(run.executionId);
 
     assert.deepEqual(recovered, {
-      prompt: "Deploy requested for phase-five-operator",
+      prompt: [
+        "Deploy requested for phase-five-operator",
+        "",
+        "Hub capabilities available in this execution:",
+        "- hub.finalize: records the current agent execution as complete and returns its result to the workflow.",
+      ].join("\n"),
       output: "phase-five:requested",
       status: "succeeded",
       daemonId: enrollment.daemonId,

--- a/src/e2e/hub-foundation.e2e.test.ts
+++ b/src/e2e/hub-foundation.e2e.test.ts
@@ -46,7 +46,12 @@ describeHubE2E("Paseo Hub cross-repository contract", () => {
 
     assert.equal(connected.state, "connected");
     assert.deepEqual(completed, {
-      prompt: "Deploy requested for phase-five-operator",
+      prompt: [
+        "Deploy requested for phase-five-operator",
+        "",
+        "Hub capabilities available in this execution:",
+        "- hub.finalize: records the current agent execution as complete and returns its result to the workflow.",
+      ].join("\n"),
       output: "phase-five:requested",
       status: "succeeded",
       daemonId: enrollment.daemonId,

--- a/src/e2e/hub-foundation.e2e.test.ts
+++ b/src/e2e/hub-foundation.e2e.test.ts
@@ -47,10 +47,10 @@ describeHubE2E("Paseo Hub cross-repository contract", () => {
     assert.equal(connected.state, "connected");
     assert.deepEqual(completed, {
       prompt: [
-        "Deploy requested for phase-five-operator",
-        "",
-        "Hub capabilities available in this execution:",
+        "Capabilities available in this execution:",
         "- hub.finalize: records the current agent execution as complete and returns its result to the workflow.",
+        "",
+        "Deploy requested for phase-five-operator",
       ].join("\n"),
       output: "phase-five:requested",
       status: "succeeded",
@@ -128,10 +128,10 @@ describeHubE2E("Paseo Hub cross-repository contract", () => {
 
     assert.deepEqual(recovered, {
       prompt: [
-        "Deploy requested for phase-five-operator",
-        "",
-        "Hub capabilities available in this execution:",
+        "Capabilities available in this execution:",
         "- hub.finalize: records the current agent execution as complete and returns its result to the workflow.",
+        "",
+        "Deploy requested for phase-five-operator",
       ].join("\n"),
       output: "phase-five:requested",
       status: "succeeded",

--- a/src/execution-capabilities/outputs.ts
+++ b/src/execution-capabilities/outputs.ts
@@ -16,6 +16,11 @@ export interface OutputToolSchema extends OutputToolSchemaNode {
   readonly required?: string[];
 }
 
+export interface HubCapabilityMetadata {
+  readonly name: `hub.${string}`;
+  readonly description: string;
+}
+
 export interface OutputToolDefinition {
   readonly name: string;
   readonly description: string;
@@ -34,6 +39,7 @@ export type OutputExecutor = (input: OutputExecutionInput) => Promise<void>;
 
 export interface OutputCapability {
   readonly type: string;
+  readonly hub: HubCapabilityMetadata;
   readonly tool: OutputToolDefinition;
   readonly available?: (outputContext: unknown) => boolean;
   readonly execute: OutputExecutor;
@@ -43,6 +49,17 @@ export interface MaterializedOutputCapability {
   readonly declaration: AllowedOutput;
   readonly capability: OutputCapability;
 }
+
+export const finalizeCapabilityMetadata = {
+  name: "hub.finalize",
+  description:
+    "records the current agent execution as complete and returns its result to the workflow.",
+} as const satisfies HubCapabilityMetadata;
+
+export const replyCapabilityMetadata = {
+  name: "hub.reply",
+  description: "sends a message to the conversation that triggered the execution.",
+} as const satisfies HubCapabilityMetadata;
 
 export const replyOutputTool: OutputToolDefinition = {
   name: "reply",
@@ -71,6 +88,16 @@ export class OutputCapabilityValidationError extends Error {
 
 export class OutputExecutorRegistry {
   private readonly capabilities = new Map<string, OutputCapability>();
+  private readonly registeredCapabilities = new Map<
+    string,
+    { metadata: HubCapabilityMetadata; outputType?: string }
+  >();
+
+  constructor() {
+    this.registeredCapabilities.set(finalizeCapabilityMetadata.name, {
+      metadata: finalizeCapabilityMetadata,
+    });
+  }
 
   register(capability: OutputCapability): void {
     if (capability.type.length === 0) throw new Error("output capability type is required");
@@ -81,6 +108,10 @@ export class OutputExecutorRegistry {
       throw new Error(`output capability is already registered: ${capability.type}`);
     }
     this.capabilities.set(capability.type, capability);
+    this.registeredCapabilities.set(capability.type, {
+      metadata: capability.hub,
+      outputType: capability.type,
+    });
   }
 
   validateRequiredOutputs(allowedOutputs: readonly AllowedOutput[], outputContext: unknown): void {
@@ -100,12 +131,7 @@ export class OutputExecutorRegistry {
     outputContext: unknown,
   ): readonly MaterializedOutputCapability[] {
     this.validateRequiredOutputs(allowedOutputs, outputContext);
-    const materialized = allowedOutputs.flatMap((declaration) => {
-      const capability = this.capabilities.get(declaration.type);
-      return capability !== undefined && this.isAvailable(declaration.type, outputContext)
-        ? [{ declaration, capability }]
-        : [];
-    });
+    const materialized = this.availableOutputs(allowedOutputs, outputContext);
     const byToolName = new Map<string, MaterializedOutputCapability>();
     for (const output of materialized) {
       const previous = byToolName.get(output.capability.tool.name);
@@ -117,6 +143,34 @@ export class OutputExecutorRegistry {
       byToolName.set(output.capability.tool.name, output);
     }
     return materialized;
+  }
+
+  availableCapabilities(
+    allowedOutputs: readonly AllowedOutput[],
+    outputContext: unknown,
+  ): readonly HubCapabilityMetadata[] {
+    const availableTypes = new Set(
+      this.availableOutputs(allowedOutputs, outputContext).map((output) => output.declaration.type),
+    );
+    const byName = new Map<string, HubCapabilityMetadata>();
+    for (const capability of this.registeredCapabilities.values()) {
+      if (capability.outputType !== undefined && !availableTypes.has(capability.outputType))
+        continue;
+      byName.set(capability.metadata.name, capability.metadata);
+    }
+    return [...byName.values()];
+  }
+
+  private availableOutputs(
+    allowedOutputs: readonly AllowedOutput[],
+    outputContext: unknown,
+  ): readonly MaterializedOutputCapability[] {
+    return allowedOutputs.flatMap((declaration) => {
+      const capability = this.capabilities.get(declaration.type);
+      return capability !== undefined && this.isAvailable(declaration.type, outputContext)
+        ? [{ declaration, capability }]
+        : [];
+    });
   }
 
   private isAvailable(type: string, outputContext: unknown): boolean {

--- a/src/execution-capabilities/prompt.ts
+++ b/src/execution-capabilities/prompt.ts
@@ -1,0 +1,24 @@
+import type { AllowedOutput, OutputExecutorRegistry } from "./outputs.js";
+
+export interface ExecutionPromptInput {
+  prompt: string;
+  injectToolInventory?: boolean;
+  allowOutputs: readonly AllowedOutput[];
+  outputContext: unknown;
+  capabilities: OutputExecutorRegistry;
+}
+
+export function composeExecutionPrompt(input: ExecutionPromptInput): string {
+  if (input.injectToolInventory === false) return input.prompt;
+
+  const inventory = input.capabilities.availableCapabilities(
+    input.allowOutputs,
+    input.outputContext,
+  );
+  return [
+    input.prompt,
+    "",
+    "Hub capabilities available in this execution:",
+    ...inventory.map((capability) => `- ${capability.name}: ${capability.description}`),
+  ].join("\n");
+}

--- a/src/execution-capabilities/prompt.ts
+++ b/src/execution-capabilities/prompt.ts
@@ -16,9 +16,9 @@ export function composeExecutionPrompt(input: ExecutionPromptInput): string {
     input.outputContext,
   );
   return [
-    input.prompt,
-    "",
-    "Hub capabilities available in this execution:",
+    "Capabilities available in this execution:",
     ...inventory.map((capability) => `- ${capability.name}: ${capability.description}`),
+    "",
+    input.prompt,
   ].join("\n");
 }

--- a/src/execution-capabilities/server.test.ts
+++ b/src/execution-capabilities/server.test.ts
@@ -18,7 +18,12 @@ import { createMemoryDatabase } from "../db/memory.js";
 import type { LaunchMachineIntent } from "../dispatcher/launch-machine-intent.js";
 import { createFetchServer } from "../http/node-server.js";
 import { registerResponseLifecycle, takeResponseLifecycle } from "../http/response-lifecycle.js";
-import { OutputExecutorRegistry, replyOutputTool, type OutputCapability } from "./outputs.js";
+import {
+  OutputExecutorRegistry,
+  replyCapabilityMetadata,
+  replyOutputTool,
+  type OutputCapability,
+} from "./outputs.js";
 import { createExecutionCapabilityServer } from "./server.js";
 
 const RpcResponseSchema = z
@@ -515,6 +520,7 @@ describe("execution capability MCP boundary", () => {
       [
         {
           type: "manual.reply",
+          hub: replyCapabilityMetadata,
           tool: { ...replyOutputTool, name: "send_manual_reply" },
           execute: async () => undefined,
         },
@@ -680,6 +686,7 @@ async function capabilityFixture(
   const outputs = new OutputExecutorRegistry();
   outputs.register({
     type: "slack.reply",
+    hub: replyCapabilityMetadata,
     tool: outputTool,
     execute: async (input) => {
       outbound.push(input);

--- a/src/index.bootstrap.test.ts
+++ b/src/index.bootstrap.test.ts
@@ -31,10 +31,10 @@ describe("production Hub runtime", () => {
     assert.equal(
       hub.createdAgentLaunch().prompt,
       [
-        "Deploy the requested service",
-        "",
-        "Hub capabilities available in this execution:",
+        "Capabilities available in this execution:",
         "- hub.finalize: records the current agent execution as complete and returns its result to the workflow.",
+        "",
+        "Deploy the requested service",
       ].join("\n"),
     );
   });

--- a/src/index.bootstrap.test.ts
+++ b/src/index.bootstrap.test.ts
@@ -28,7 +28,15 @@ describe("production Hub runtime", () => {
     assert.equal(run.status, 200);
     const execution = await hub.waitForPendingExecution();
     await hub.waitForRecoveredExecution(execution.id);
-    assert.equal(hub.createdAgentLaunch().prompt, "Deploy the requested service");
+    assert.equal(
+      hub.createdAgentLaunch().prompt,
+      [
+        "Deploy the requested service",
+        "",
+        "Hub capabilities available in this execution:",
+        "- hub.finalize: records the current agent execution as complete and returns its result to the workflow.",
+      ].join("\n"),
+    );
   });
 });
 

--- a/src/providers/discord/index.ts
+++ b/src/providers/discord/index.ts
@@ -19,7 +19,11 @@ import { createDiscordGatewaySource } from "../../triggers/discord/gateway.js";
 import { createDiscordTriggerProvider } from "../../triggers/discord/provider.js";
 import { createDiscordAttachmentResolver } from "../../triggers/discord/attachments.js";
 import { createDiscordReplyExecutor } from "../../triggers/discord/reply.js";
-import { outputContextProvider, replyOutputTool } from "../../execution-capabilities/outputs.js";
+import {
+  outputContextProvider,
+  replyCapabilityMetadata,
+  replyOutputTool,
+} from "../../execution-capabilities/outputs.js";
 import {
   createDiscordConnectionClient,
   type DiscordConnectionClient,
@@ -112,6 +116,7 @@ export function createDiscordRegistration(
     outputs: [
       {
         type: "discord.reply",
+        hub: replyCapabilityMetadata,
         tool: replyOutputTool,
         available: outputContextProvider("discord"),
         execute: createDiscordReplyExecutor({ bot }),

--- a/src/providers/registration.ts
+++ b/src/providers/registration.ts
@@ -1,7 +1,11 @@
 import type { ProjectConfigurationStore } from "../configuration/store.js";
 import type { ConnectionResolutionContext, ConnectionResolver } from "../config/connections.js";
 import type { OrganizationConnectionUsage } from "../db/types.js";
-import type { OutputExecutor, OutputToolDefinition } from "../execution-capabilities/outputs.js";
+import type {
+  HubCapabilityMetadata,
+  OutputExecutor,
+  OutputToolDefinition,
+} from "../execution-capabilities/outputs.js";
 import type { TriggerProvider, TriggerSource } from "../triggers/index.js";
 import type { GitHubConfigurationProvider } from "../configuration/github-sync.js";
 import type {
@@ -38,6 +42,7 @@ export interface ProviderConnectionRegistration {
 
 export interface ProviderOutputRegistration {
   type: string;
+  hub: HubCapabilityMetadata;
   tool: OutputToolDefinition;
   available?: (outputContext: unknown) => boolean;
   execute: OutputExecutor;

--- a/src/providers/slack/index.ts
+++ b/src/providers/slack/index.ts
@@ -18,7 +18,11 @@ import { createSlackBotClient, type SlackBotClient } from "../../triggers/slack/
 import { createSlackTriggerProvider } from "../../triggers/slack/provider.js";
 import { createSlackAttachmentResolver } from "../../triggers/slack/attachments.js";
 import { createSlackReplyExecutor } from "../../triggers/slack/reply.js";
-import { outputContextProvider, replyOutputTool } from "../../execution-capabilities/outputs.js";
+import {
+  outputContextProvider,
+  replyCapabilityMetadata,
+  replyOutputTool,
+} from "../../execution-capabilities/outputs.js";
 import { createSlackWebhookSource } from "../../triggers/slack/webhook.js";
 import type { ProviderConnectionRegistration, ProviderRegistration } from "../registration.js";
 import {
@@ -129,6 +133,7 @@ export function createSlackRegistration(
     outputs: [
       {
         type: "slack.reply",
+        hub: replyCapabilityMetadata,
         tool: replyOutputTool,
         available: outputContextProvider("slack"),
         execute: createSlackReplyExecutor({ client: bot }),

--- a/src/workflows/engine.ts
+++ b/src/workflows/engine.ts
@@ -746,6 +746,7 @@ function buildStepIntent(
       autoArchive: step.autoArchive,
       triggerContext: run.triggerContext,
       outputContext: run.outputContext,
+      injectToolInventory: step.injectToolInventory,
       configurationRevisionId: run.configurationRevisionId,
       hubConfig: configuration,
     }),


### PR DESCRIPTION
## What changed and why

Agent prompts now begin with a short, factual inventory of the capabilities available to the current execution. The inventory is neutral and appears before the authored workflow prompt, so workflow authors do not need to name implementation details in every prompt.

### Prompt shape

The injected section uses this exact header and ordering:

`Capabilities available in this execution:`
- available capability descriptions
(blank line)
- authored workflow prompt

The stable semantic names are:

- `hub.finalize`: records the current agent execution as complete and returns its result to the workflow.
- `hub.reply`: sends a message to the conversation that triggered the execution.

### Goals

- Derive the inventory from the registered execution-capability registry and capability-owned metadata.
- List only capabilities that are actually allowed and available for the execution context.
- Enable inventory injection by default for every workflow step, with `inject_tool_inventory: false` as an explicit per-step opt-out.
- Compose the prompt before provider launch materialization.

### Non-goals

- No provider-specific Hub semantics or adapter branches.
- No replacement for server-side authorization, output limits, required outputs, or completion validation.
- No workflow policy about when an agent should finalize or reply.
- No instructions or behavioral examples in the injected inventory.
- No change to the separate public Paseo repository in this PR.

### The why

The inventory is owned by the execution-capability registry, so newly registered capabilities can supply factual metadata and participate automatically. Prompt composition remains at the daemon launch boundary, while existing server enforcement remains authoritative. Finalization completes the current agent execution; it does not imply completion of the whole workflow.

### Verification

- TDD red to green: the corrected daemon-boundary assertion first failed because the launched prompt put the authored text first and used the old Hub-specific header. After the composition change, the focused inventory test passed.
- Focused post-correction tests: 3 daemon boundary tests and 39 compiler, capability enforcement, bootstrap, and runtime tests passed.
- `npm run typecheck` passed, including E2E typechecking.
- `npm run lint` passed.
- `npm run format` passed.
- `git diff --check` passed.
- The pre-correction full suite passed: 89 test files, 611 tests passed, with 5 files and 13 tests skipped.
- The branch rebased cleanly onto current `origin/main`.

### Risk surface

The change adjusts prompt text at one lifecycle composition point and updates its contract assertions. It does not alter provider adapters, tool transport, permission checks, required-output enforcement, completion behavior, or reply behavior. The principal user-visible risk is prompt wording or added prompt length; the inventory remains short and factual.

### Documentation follow-up

Hub documentation records the new setting, exact prompt ordering, neutral header, and semantic names. Companion public Paseo documentation is required in the separate `getpaseo/paseo` repository, including the workflow-step setting and capability inventory description. This PR intentionally does not create a second repository PR.

### Issues

All six open Hub issues were reviewed again; none is a genuine match for this change.