### PR TITLE
fix(configuration): make the editor scroll a long hub.yml

### DIFF
--- a/e2e/helpers/projects/configuration.ts
+++ b/e2e/helpers/projects/configuration.ts
@@ -91,6 +91,25 @@ export class ProjectConfiguration {
     await expect(this.page.locator(".cm-line span").first()).toBeVisible();
   }
 
+  /** A rendered document line. CodeMirror gives lines no role of their own. */
+  private line(text: string) {
+    return this.page.locator(".cm-line").filter({ hasText: text });
+  }
+
+  /** Reach the end of a long document the way an operator does: wheel over it. */
+  async scrollEditorToEnd() {
+    await this.editor().hover();
+    for (let tick = 0; tick < 20; tick += 1) await this.page.mouse.wheel(0, 600);
+  }
+
+  async expectLineOutOfSight(text: string) {
+    await expect(this.line(text)).not.toBeInViewport();
+  }
+
+  async expectLineInSight(text: string) {
+    await expect(this.line(text)).toBeInViewport();
+  }
+
   async expectValidationError(message: string) {
     await expect(this.page.getByRole("alert")).toContainText(message);
   }

--- a/e2e/projects.spec.ts
+++ b/e2e/projects.spec.ts
@@ -17,6 +17,16 @@ const validConfiguration =
   "environments:\n  - name: runner\n    kind: docker\n    image: paseo/test\ntriggers: []";
 const unresolvedConfiguration =
   "environments:\n  - name: runner\n    kind: daemon\n    daemon: missing-runner\n    cwd: /workspace\ntriggers: []";
+/** Taller than the editor at any desktop viewport, so its last line starts out of sight. */
+const longConfiguration = [
+  "environments:",
+  ...Array.from({ length: 40 }, (_, index) => [
+    `  - name: runner-${String(index + 1)}`,
+    "    kind: docker",
+    "    image: paseo/test",
+  ]).flat(),
+  "triggers: []",
+].join("\n");
 const includeConfiguration = [
   "environments:",
   "  - name: runner",
@@ -173,6 +183,21 @@ test("edits configuration and prompt partials in the editor", async ({ hub, page
   await app.navigation.openProjectSection("Configuration");
   await app.configuration.expectFiles(["hub.yml", "triage/preamble.md"]);
   await app.configuration.expectPartialContent("triage/preamble.md", "Triage before labelling.");
+});
+
+test("scrolls a long configuration down to its last line", async ({ hub, page }) => {
+  const app = projectApp(page);
+  await hub.signUpAs("owner", owner);
+  await hub.createOrganization("owner", "Acme");
+  await app.navigation.openProject("Default");
+  await app.navigation.openProjectSection("Configuration");
+  await app.configuration.saveManualConfiguration(longConfiguration);
+  await app.configuration.expectConfigurationActivated(1);
+
+  await app.configuration.expectReadOnlyEditor("environments:");
+  await app.configuration.expectLineOutOfSight("runner-40");
+  await app.configuration.scrollEditorToEnd();
+  await app.configuration.expectLineInSight("runner-40");
 });
 
 test("rejects a partial the configuration does not include", async ({ hub, page }) => {

--- a/src/projects/configuration/panel.tsx
+++ b/src/projects/configuration/panel.tsx
@@ -168,7 +168,10 @@ function ConfigurationWorkbench({
   return (
     <section
       aria-label="Configuration editor"
-      className="grid h-[70svh] min-h-[30rem] grid-cols-1 overflow-hidden rounded-lg border bg-card md:grid-cols-[17rem_minmax(0,1fr)]"
+      // The row tracks are bounded like the columns are: an `auto` row would size to
+      // the open document and push the editor past this fixed height, where
+      // `overflow-hidden` would clip it with nothing left to scroll.
+      className="grid h-[70svh] min-h-[30rem] grid-cols-1 grid-rows-[auto_minmax(0,1fr)] overflow-hidden rounded-lg border bg-card md:grid-cols-[17rem_minmax(0,1fr)] md:grid-rows-[minmax(0,1fr)]"
     >
       <div className="flex flex-col gap-5 overflow-y-auto border-b p-4 md:border-r md:border-b-0">
         {source}


### PR DESCRIPTION
## The bug

On the Configuration page, a `hub.yml` longer than the editor panel was
unreachable past the fold. The editor did not scroll at all — no wheel, no
scrollbar — so the lower half of an operator's own configuration could not be
read or edited. Reported with a screenshot showing the document cut off
mid-line at the bottom edge of the panel.

No open issue matches this; searched all six.

## Cause

`ConfigurationWorkbench` renders a `<section>` that fixes its own height
(`h-[70svh]`) and clips (`overflow-hidden`), but declared only its *column*
tracks. The implicit row stayed `auto`, so it sized to the right column's
content — the whole open document — instead of to the container.

Measured in the built app with a 122-line `hub.yml` at 1280×720:

| Element | before | after |
| --- | --- | --- |
| `section` `grid-template-rows` | **2825.66px** (container is 504px) | **502px** |
| `section` scroll / client height | 2826 / 502 — overflowing, clipped | 502 / 502 |
| `.cm-scroller` client / scroll | **424 → 2748 / 2748** — equal, so not a scroll container | **424 / 2748** |
| wheel over the editor | `scrollTop 0 → 0` | `scrollTop 0 → 2000` |

The chain: `auto` row → 2826px row → right column, `flex-1`, and the
`h-full` editor host all inherit it → CodeMirror's scroller is exactly as
tall as its content → nothing to scroll → `overflow-hidden` hides the
remainder. The row track is the producer; everything below it was correct.

## Fix

Bound the row tracks the way the column tracks already were:

```
grid-rows-[auto_minmax(0,1fr)] md:grid-rows-[minmax(0,1fr)]
```

Stacked (mobile): rail takes its content, editor takes the rest. Side-by-side
(`md`): the single row is the container. One line, at the layout owner.

## Red → green

New journey `scrolls a long configuration down to its last line` in
`e2e/projects.spec.ts` — activates a 122-line configuration, asserts the last
line is out of sight, wheels over the editor, asserts it is in sight.

- **Red** (before the fix): `expect(locator).toBeInViewport() failed —
  element(s) not found` for line `runner-40` after scrolling. The wheel moved
  the scroller `0 → 0`, so CodeMirror never rendered the line.
- **Green** (after the fix): passes in 6.3s.

Scrolling mechanics live in `scrollEditorToEnd()` on the `ProjectConfiguration`
helper (hover the editor, wheel). Assertions are `toBeInViewport` on the
rendered document line — user-visible reachability, no CSS assertions in the
test body.

## Verification

- `projects.spec.ts` desktop — **14/14 passed**, including the seven existing
  configuration journeys (GitHub↔manual switching, invalid-revision handling,
  partials, activation feedback).
- `projects-mobile.spec.ts` — **1/1 passed** (Pixel 7; configuration route stays
  within the viewport).
- `npm run typecheck`, `npm run lint`, `npm run format:check`, `npm run build` — all clean.

Captured after scrolling to the end at 1280×900: the gutter reads through line
122 (`triggers: []`), with the source rail, the `hub.yml / Read-only / Edit`
header, and the `Valid / No partials` footer all unchanged.

## Risk surface

Confined to the Configuration workbench's grid. The section's height, the
`overflow-y-auto` source rail, the editor header, the save/activation footer,
and the `md` breakpoint are unchanged — the diff only names row tracks that
were previously implicit. Anything relying on the section growing past 70svh
would change, but that growth was the bug and was invisible behind
`overflow-hidden`.

