### PR TITLE
Keep the GitHub source form inside the configuration editor rail

### DIFF
--- a/e2e/helpers/projects/configuration.ts
+++ b/e2e/helpers/projects/configuration.ts
@@ -21,6 +21,21 @@ export class ProjectConfiguration {
     await this.page.getByRole("radio", { name: "Manual" }).click();
   }
 
+  async switchToGitHub() {
+    await this.page.getByRole("radio", { name: "GitHub" }).click();
+  }
+
+  /**
+   * The source controls live in the editor's fixed left rail. A control wider
+   * than the rail runs under the document pane instead of being reachable.
+   */
+  async expectSourceControlsClearOfTheEditor() {
+    const picker = await this.page.getByRole("combobox").boundingBox();
+    const document = await this.editor().boundingBox();
+    if (picker === null || document === null) throw new Error("source controls are not rendered");
+    expect(picker.x + picker.width).toBeLessThanOrEqual(document.x);
+  }
+
   /** The open document. CodeMirror exposes its content as a textbox labelled by path. */
   private editor(label = "Configuration YAML") {
     return this.page.getByRole("textbox", { name: label });

--- a/e2e/projects.spec.ts
+++ b/e2e/projects.spec.ts
@@ -119,6 +119,16 @@ test("switches a project's configuration source between GitHub and manual", asyn
   await app.configuration.expectActiveRevision(3);
 });
 
+test("keeps the GitHub source controls inside the editor rail", async ({ hub, page }) => {
+  const app = projectApp(page);
+  await hub.signUpAs("owner", owner);
+  await hub.createOrganization("owner", "Acme");
+  await app.navigation.openProject("Default");
+  await app.navigation.openProjectSection("Configuration");
+  await app.configuration.switchToGitHub();
+  await app.configuration.expectSourceControlsClearOfTheEditor();
+});
+
 test("explains invalid manual configuration and allows a corrected retry", async ({
   hub,
   page,

--- a/src/projects/repository-combobox.tsx
+++ b/src/projects/repository-combobox.tsx
@@ -53,7 +53,7 @@ export function RepositoryCombobox({
           aria-expanded={open}
           aria-controls={listId}
           disabled={disabled}
-          className="w-full justify-between font-normal sm:w-96"
+          className="w-full min-w-0 justify-between font-normal"
         >
           <span className="truncate">{selected?.fullName ?? placeholder}</span>
           {loading ? (


### PR DESCRIPTION
Choosing **GitHub** as a project's configuration source no longer pushes the repository picker and the Manual/GitHub toggle under the document pane, where they were clipped and unreachable. The source form now fits the rail it lives in.

## Goals

- The GitHub source controls stay fully inside the configuration workbench's left rail at every desktop width.
- A regression test that fails on the old layout and passes on the new one.

## Non-goals

- No redesign of the configuration workbench, the rail width, or the repository picker's behaviour.
- No change to the manual source form, which was never affected.

## The why

`RepositoryCombobox`'s trigger carried a fixed `sm:w-96` (384px) from when the source form was a full-width page section. When the form moved into the workbench's fixed `17rem` (272px) rail, that width was never revisited: the 384px trigger set the min-content width of the rail's grid wrapper, so the `w-full` mode toggle stretched with it and the whole form ran 96px past the rail, where the rail's `overflow-y-auto` clipped it. Manual mode has no such control, which is why only GitHub showed the symptom.

The fix is at the producer — the control stops asserting a width its container can't honour and fills whatever it's placed in, leaving width to the layout that owns it. The Radix popover already tracks the anchor width, so the dropdown follows the rail without a second knob.

## Verification

- New Playwright test `keeps the GitHub source controls inside the editor rail` measures the picker's right edge against the editor's left edge. Before the change: picker at 689px, editor at 592px (fail). After: pass.
- Full `e2e/projects.spec.ts` and `e2e/projects-mobile.spec.ts` — 16 passed (desktop-chromium + mobile-chromium).
- `npm run typecheck`, `npm run lint`, `npm run format` clean.
- Screenshotted the GitHub form and the open repository dropdown at the rail width; repository names and default branches still read fine.

## Risk surface

Layout only, one Tailwind class on a single-consumer component. The repository dropdown is now rail-width (~240px) instead of 384px because it tracks the anchor — long `org/repo` names truncate sooner there. Worth an eyeball if you have unusually long repository names.