### PR TITLE
Preserve prompt partials when switching configuration to Manual

### DIFF
--- a/e2e/app.ts
+++ b/e2e/app.ts
@@ -114,6 +114,7 @@ class BuiltApplications {
         repositoryId: number;
         commitSha: string;
         rawYaml?: string;
+        partials?: readonly { path: string; content: string }[];
       }) => deliverCommand(server, { type: "github-configuration", ...input }),
       setBillingProduct: (product: FixtureBillingProduct) =>
         deliverCommand(server, { type: "billing-product", product }),

--- a/e2e/helpers/hub.ts
+++ b/e2e/helpers/hub.ts
@@ -15,6 +15,7 @@ import { WebSocket, type RawData } from "ws";
 import { Client } from "pg";
 import { z } from "zod";
 import type { SourcePaseo, SourceRegistration } from "./source-paseo.js";
+import type { PromptPartialBundleFile } from "../../src/config/prompt-partials.js";
 import type { BrowserDiscordEvent } from "../../src/e2e/harness/browser-providers.js";
 import type { BrowserProviderScenario } from "../../src/e2e/harness/browser-providers.js";
 import type { FixtureBillingProduct } from "../../src/e2e/harness/browser-billing.js";
@@ -34,6 +35,7 @@ export interface BuiltApplication {
     repositoryId: number;
     commitSha: string;
     rawYaml?: string;
+    partials?: readonly PromptPartialBundleFile[];
   }): Promise<void>;
   setBillingProduct(product: FixtureBillingProduct): Promise<void>;
   /** Stand in for a portal cancellation: move the organization's fixture subscription to canceled. */

--- a/e2e/helpers/projects/configuration.ts
+++ b/e2e/helpers/projects/configuration.ts
@@ -61,6 +61,12 @@ export class ProjectConfiguration {
     await this.page.getByRole("button", { name: "Save and activate" }).click();
   }
 
+  /** Activate the open documents exactly as they are — the preserved switch-to-manual bundle. */
+  async saveUnmodified() {
+    await this.startEditing();
+    await this.save();
+  }
+
   async save() {
     await this.page.getByRole("button", { name: "Save and activate" }).click();
   }

--- a/e2e/helpers/projects/external.ts
+++ b/e2e/helpers/projects/external.ts
@@ -8,11 +8,17 @@ export class ProjectExternalFacts {
     private readonly requests: APIRequestContext,
   ) {}
 
-  setGitHubRevision(repositoryId: number, commitSha: string, rawYaml?: string) {
+  setGitHubRevision(
+    repositoryId: number,
+    commitSha: string,
+    rawYaml?: string,
+    partials?: readonly { path: string; content: string }[],
+  ) {
     return this.application.setGitHubConfiguration({
       repositoryId,
       commitSha,
       ...(rawYaml === undefined ? {} : { rawYaml }),
+      ...(partials === undefined ? {} : { partials }),
     });
   }
 

--- a/e2e/projects.spec.ts
+++ b/e2e/projects.spec.ts
@@ -129,6 +129,37 @@ test("keeps the GitHub source controls inside the editor rail", async ({ hub, pa
   await app.configuration.expectSourceControlsClearOfTheEditor();
 });
 
+test("keeps GitHub-authored partials openable after switching to manual", async ({
+  hub,
+  page,
+  projectExternal,
+}) => {
+  const app = projectApp(page);
+  await hub.signUpAs("owner", owner);
+  await hub.createOrganization("owner", "Acme");
+  await hub.seedDaemonSlug("owner", "editor-daemon");
+  await app.navigation.openOrganizationSection("Connections");
+  await app.connections.connectGitHub();
+  await app.navigation.openOrganizationSection("Projects");
+  await app.navigation.openProject("Default");
+  await app.configuration.useRepository("acme-inc/app");
+  await projectExternal.setGitHubRevision(9001, "partial-sha", includeConfiguration, [
+    { path: "triage/preamble.md", content: "Triage before labelling." },
+  ]);
+  await app.configuration.syncNow();
+  await app.configuration.expectActiveRevision(1);
+  await app.configuration.expectFiles(["hub.yml", "triage/preamble.md"]);
+  await app.configuration.expectPartialContent("triage/preamble.md", "Triage before labelling.");
+
+  await app.configuration.switchToManual();
+
+  await app.configuration.expectActiveRevision(2);
+  await app.configuration.expectFiles(["hub.yml", "triage/preamble.md"]);
+  await app.configuration.expectPartialContent("triage/preamble.md", "Triage before labelling.");
+  await app.configuration.saveUnmodified();
+  await app.configuration.expectConfigurationActivated(3);
+});
+
 test("explains invalid manual configuration and allows a corrected retry", async ({
   hub,
   page,

--- a/src/configuration/store.test.ts
+++ b/src/configuration/store.test.ts
@@ -5,7 +5,8 @@ import {
   parseCompiledHubConfig,
   rawConfigurationHash,
 } from "../config/compiler.js";
-import { ProjectConfigurationStore } from "./store.js";
+import { resolvePromptPartials } from "../config/prompt-partials.js";
+import { ProjectConfigurationStore, revisionPromptPartials } from "./store.js";
 import { createMemoryDatabase } from "../db/memory.js";
 import { enrollTestDaemon, TEST_DAEMON_SLUG } from "../test-utils/project-configuration.js";
 import type { DiscordConnectionRecord } from "../db/types.js";
@@ -68,6 +69,47 @@ describe("ProjectConfigurationStore resource compilation", () => {
       switched.revision.contentHash,
       compiledConfigurationHash(parseCompiledHubConfig(switched.revision.normalizedConfiguration)),
     );
+  });
+
+  it("keeps authored prompt partials when switching a GitHub-managed configuration to manual", async () => {
+    const database = createMemoryDatabase();
+    await enrollTestDaemon(database);
+    const project = await database.createProject({
+      organizationId: "org_1",
+      name: "GitHub partials project",
+      slug: "github-partials-project",
+      createdByUserId: "user-1",
+    });
+    const store = new ProjectConfigurationStore(database, project.id);
+    const rawConfiguration = includeConfiguration();
+    const resolvedPromptPartials = await resolvePromptPartials({
+      configuration: rawConfiguration,
+      read: (path) =>
+        Promise.resolve(
+          path === ".paseo/partials/triage.md"
+            ? { kind: "file" as const, content: PARTIAL_CONTENT }
+            : undefined,
+        ),
+    });
+    const revision = await store.insertGitHubRevision({
+      rawYaml: "triggers:\n  - name: triage\n",
+      rawConfiguration,
+      githubConnectionId: "github-connection-1",
+      githubRepositoryId: 9001,
+      githubRepositoryFullName: "acme/repo",
+      githubDefaultBranch: "main",
+      commitSha: "sha-with-partials",
+      path: ".paseo/hub.yml",
+      webhookDeliveryId: null,
+      resolvedPromptPartials,
+    });
+    await store.activate(revision.id);
+
+    const switched = await store.switchToManual("user-1");
+
+    assert.deepEqual(revisionPromptPartials(switched.revision), [
+      { path: ".paseo/partials/triage.md", content: PARTIAL_CONTENT },
+    ]);
   });
 
   it("resolves a unique guild without requiring a connection slug", async () => {
@@ -290,6 +332,31 @@ function discordConfiguration(filters: Record<string, string>) {
             idle_timeout: "5m",
             agent: { provider: "test", mode: "default" },
             prompt: [{ text: "Handle the mention" }],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+const PARTIAL_CONTENT = "Triage the request before labeling it.";
+
+function includeConfiguration() {
+  return {
+    environments: [{ name: "runner", kind: "daemon", daemon: TEST_DAEMON_SLUG, cwd: "/repo" }],
+    triggers: [
+      {
+        name: "triage",
+        on: "manual.run",
+        max_runtime: "1h",
+        steps: [
+          {
+            id: "work",
+            environment: "runner",
+            max_runtime: "10m",
+            idle_timeout: "1m",
+            agent: { provider: "test", mode: "default" },
+            prompt: [{ include: "triage.md" }],
           },
         ],
       },

--- a/src/configuration/store.ts
+++ b/src/configuration/store.ts
@@ -227,6 +227,7 @@ export class ProjectConfigurationStore {
       normalizedConfiguration: active.normalizedConfiguration,
       contentHash: compiledConfigurationHash(configuration),
       formattingPreserved,
+      promptPartials: revisionPromptPartials(active),
       routes,
     });
     return { revision, configuration: parseProjectConfiguration(revision) };

--- a/src/db/memory.ts
+++ b/src/db/memory.ts
@@ -2352,6 +2352,7 @@ class MemoryDatabase implements Database {
       sourceEvidence: {
         kind: "authority-switch",
         formattingPreserved: input.formattingPreserved,
+        ...(input.promptPartials.length === 0 ? {} : { partials: input.promptPartials }),
       },
       rawYaml: input.rawYaml,
       normalizedConfiguration: input.normalizedConfiguration,

--- a/src/db/migrations.integration.test.ts
+++ b/src/db/migrations.integration.test.ts
@@ -8,7 +8,8 @@ import { Client, type QueryResultRow } from "pg";
 import { z } from "zod";
 import { createDatabase, createPostgresPool } from "./pg.js";
 import { createHubApplication } from "../app.js";
-import { ProjectConfigurationStore } from "../configuration/store.js";
+import { ProjectConfigurationStore, revisionPromptPartials } from "../configuration/store.js";
+import { resolvePromptPartials } from "../config/prompt-partials.js";
 import { bootstrapInstance } from "../auth/bootstrap.js";
 import type { InstanceAuthPolicy } from "../auth/instance-policy.js";
 import type { ApiKeyScope } from "../auth/api-key-contract.js";
@@ -715,6 +716,71 @@ describe("database migration application", () => {
       assert.equal(accepted.status, "accepted");
       if (accepted.status !== "accepted") return;
       assert.equal(accepted.events[0]?.projectId, project.id);
+    } finally {
+      await database.close();
+    }
+  }, 120_000);
+
+  it("preserves authored prompt partials when switching a GitHub-managed project to manual", async () => {
+    const url = databaseUrl(postgres, "manual_authority_partials");
+    const database = await createDatabase(url);
+    try {
+      const [project] = await createProjectFixtures(database, url);
+      await seedTestDaemon(url, "organization-a");
+      const store = new ProjectConfigurationStore(database, project.id);
+      const rawConfiguration = {
+        environments: [{ name: "runner", kind: "daemon", daemon: "daemon-10000000", cwd: "/repo" }],
+        triggers: [
+          {
+            name: "triage",
+            on: "manual.run",
+            max_runtime: "1h",
+            steps: [
+              {
+                id: "work",
+                environment: "runner",
+                max_runtime: "10m",
+                idle_timeout: "1m",
+                agent: { provider: "test", mode: "default" },
+                prompt: [{ include: "triage.md" }],
+              },
+            ],
+          },
+        ],
+      };
+      const partialContent = "Triage the request before labeling it.";
+      const resolvedPromptPartials = await resolvePromptPartials({
+        configuration: rawConfiguration,
+        read: (path) =>
+          Promise.resolve(
+            path === ".paseo/partials/triage.md"
+              ? { kind: "file" as const, content: partialContent }
+              : undefined,
+          ),
+      });
+      const githubRevision = await store.insertGitHubRevision({
+        rawYaml: "triggers:\n  - name: triage\n",
+        rawConfiguration,
+        githubConnectionId: "github-connection-1",
+        githubRepositoryId: 9251,
+        githubRepositoryFullName: "acme/repo",
+        githubDefaultBranch: "main",
+        commitSha: "sha-with-partials",
+        path: ".paseo/hub.yml",
+        webhookDeliveryId: null,
+        resolvedPromptPartials,
+      });
+      await store.activate(githubRevision.id);
+
+      const switched = await store.switchToManual("project-user");
+      const persisted = await database.findActiveProjectConfiguration(project.id);
+
+      const expectedPartials = [{ path: ".paseo/partials/triage.md", content: partialContent }];
+      assert.deepEqual(revisionPromptPartials(switched.revision), expectedPartials);
+      assert.deepEqual(
+        persisted === undefined ? undefined : revisionPromptPartials(persisted),
+        expectedPartials,
+      );
     } finally {
       await database.close();
     }

--- a/src/db/pg.ts
+++ b/src/db/pg.ts
@@ -3221,20 +3221,21 @@ class PgDatabase implements Database {
          ) values (
            $1, $2,
            coalesce((select max(version) + 1 from project_configuration_revisions where project_id = $1), 1),
-           'manual', jsonb_build_object(
-             'kind', 'authority-switch', 'fromRevisionId', $3::text,
-             'formattingPreserved', $8::boolean
-           ), $4, $5, $6, $7, clock_timestamp(), clock_timestamp()
+           'manual', $3, $4, $5, $6, $7, clock_timestamp(), clock_timestamp()
          ) returning *`,
         [
           input.projectId,
           projectRow.organization_id,
-          projectRow.active_configuration_revision_id,
+          {
+            kind: "authority-switch",
+            fromRevisionId: projectRow.active_configuration_revision_id,
+            formattingPreserved: input.formattingPreserved,
+            ...(input.promptPartials.length === 0 ? {} : { partials: input.promptPartials }),
+          },
           input.rawYaml,
           input.normalizedConfiguration,
           input.contentHash,
           input.userId,
-          input.formattingPreserved,
         ],
       );
       const revision = inserted.rows[0]!;

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -1,4 +1,5 @@
 import type { AgentExecutionStatus, MachineSource, MachineStatus } from "./schema.js";
+import type { PromptPartialBundleFile } from "../config/prompt-partials.js";
 import type { LaunchMachineIntent } from "../dispatcher/launch-machine-intent.js";
 import type { InvocationRejection } from "../triggers/invocation.js";
 import type {
@@ -923,6 +924,8 @@ export interface SwitchProjectConfigurationToManualInput {
   normalizedConfiguration: unknown;
   contentHash: string;
   formattingPreserved: boolean;
+  /** Authored partial files carried over from the superseded revision's source evidence. */
+  promptPartials: readonly PromptPartialBundleFile[];
   routes: readonly ProjectTriggerRoute[];
 }
 

--- a/src/e2e/harness/browser-child.ts
+++ b/src/e2e/harness/browser-child.ts
@@ -41,6 +41,7 @@ interface GitHubConfigurationCommand {
   repositoryId: number;
   commitSha: string;
   rawYaml?: string;
+  partials?: readonly { path: string; content: string }[];
 }
 
 interface BillingProductCommand {
@@ -318,7 +319,22 @@ function isGitHubConfigurationCommand(value: unknown): value is GitHubConfigurat
     typeof Reflect.get(value, "repositoryId") === "number" &&
     typeof Reflect.get(value, "commitSha") === "string" &&
     (Reflect.get(value, "rawYaml") === undefined ||
-      typeof Reflect.get(value, "rawYaml") === "string")
+      typeof Reflect.get(value, "rawYaml") === "string") &&
+    (Reflect.get(value, "partials") === undefined ||
+      isPartialFileList(Reflect.get(value, "partials")))
+  );
+}
+
+function isPartialFileList(value: unknown): value is readonly { path: string; content: string }[] {
+  return (
+    Array.isArray(value) &&
+    value.every(
+      (file) =>
+        typeof file === "object" &&
+        file !== null &&
+        typeof Reflect.get(file, "path") === "string" &&
+        typeof Reflect.get(file, "content") === "string",
+    )
   );
 }
 

--- a/src/e2e/harness/browser-providers.ts
+++ b/src/e2e/harness/browser-providers.ts
@@ -12,6 +12,10 @@ import type {
 } from "../../triggers/github/provider.js";
 import { MemoryDiscordBotClient } from "../../triggers/discord/memory-bot.js";
 import type { GitHubConfigurationProvider } from "../../configuration/github-sync.js";
+import {
+  validatePromptPartialPath,
+  type PromptPartialBundleFile,
+} from "../../config/prompt-partials.js";
 
 const GITHUB_INSTALLATIONS: readonly GitHubInstallationIdentity[] = [
   {
@@ -150,20 +154,35 @@ export class BrowserGitHubConfiguration implements GitHubConfigurationProvider {
     return Promise.resolve(head);
   }
 
-  readFileAtCommit(input: { repositoryId: number; commitSha: string }) {
-    const rawYaml = this.files.get(`${input.repositoryId}:${input.commitSha}`);
-    return Promise.resolve(
-      rawYaml === undefined ? undefined : { kind: "file" as const, content: rawYaml },
-    );
+  readFileAtCommit(input: { repositoryId: number; commitSha: string; path: string }) {
+    const content = this.files.get(`${input.repositoryId}:${input.commitSha}:${input.path}`);
+    return Promise.resolve(content === undefined ? undefined : { kind: "file" as const, content });
   }
 
-  setRevision(input: { repositoryId: number; commitSha: string; rawYaml?: string }) {
+  setRevision(input: {
+    repositoryId: number;
+    commitSha: string;
+    rawYaml?: string;
+    partials?: readonly PromptPartialBundleFile[];
+  }) {
     this.heads.set(input.repositoryId, input.commitSha);
     if (input.rawYaml !== undefined) {
-      this.files.set(`${input.repositoryId}:${input.commitSha}`, input.rawYaml);
+      this.files.set(
+        `${input.repositoryId}:${input.commitSha}:${BROWSER_CONFIGURATION_PATH}`,
+        input.rawYaml,
+      );
+    }
+    for (const partial of input.partials ?? []) {
+      this.files.set(
+        `${input.repositoryId}:${input.commitSha}:${validatePromptPartialPath(partial.path)}`,
+        partial.content,
+      );
     }
   }
 }
+
+/** The repository path the hub reads its configuration from — see github-sync.ts. */
+const BROWSER_CONFIGURATION_PATH = ".paseo/hub.yml";
 
 export class BrowserDiscordConnections implements DiscordConnectionClient {
   private readonly guilds = new Map(DISCORD_GUILDS.map((guild) => [guild.guildId, guild]));


### PR DESCRIPTION
## What changed, and why

Switching a project configuration to Manual now retains its authored prompt partial files. The browser editor can reopen and save the same YAML and partial bundle after the authority switch, while the compiled runtime configuration remains unchanged.

### Goals

- Carry partial source evidence from the active revision into the Manual authority-switch revision.
- Persist the bundle consistently in the in-memory and PostgreSQL database implementations.
- Lock the behavior with store-level coverage and a real browser user journey.

### Non-goals

- Change prompt-partial resolution, validation, or compilation semantics.
- Change runtime agent prompt behavior.
- Add a schema migration or alter unrelated configuration-source flows.

### The why

The authority switch already copied raw YAML and normalized compiled configuration, but the editor reconstructs its file list from revision source evidence. Omitting the partial evidence left the Manual revision with an empty file list even though runtime prompts still contained the inlined content.

### Verification

- Focused store and exact-commit sync tests: 17 passing.
- PostgreSQL migration/integration suite: 19 passing.
- Built browser project journey: 15 passing, including sync, switch to Manual, reopen the exact partial, and save.
- Full test suite: 625 passing, 13 skipped.
- typecheck, lint, format check, build, db:check, and git diff checks: passing.

### Risk surface

The change is limited to authority-switch evidence and the exact-path test fixture used to supply authored files. Both database implementations carry the same path/content bundle; no runtime compilation or database schema behavior changes.