### PR TITLE
Expose actual MCP tool names in execution inventories

### DIFF
--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -20,7 +20,7 @@ The configuration install body may also include an optional `partials` array. Ea
 
 ## Workflow prompt capability inventory
 
-Each workflow step's agent prompt begins with a factual inventory of the capabilities available to that execution by default. It uses the header `Capabilities available in this execution:`, lists only the available capabilities, then leaves a blank line before the authored prompt. The inventory uses stable semantic names: `hub.finalize` records the current agent execution as complete and returns its result to the workflow, while `hub.reply` sends a message to the conversation that triggered the execution when that output is allowed and available. Finalizing an execution does not necessarily complete the whole workflow.
+Each workflow step's agent prompt begins with a factual inventory of the MCP tools available to that execution by default. It uses the header `Capabilities available in this execution:`, lists the actual callable tool names and descriptions, then leaves a blank line before the authored prompt. Completion is exposed as `finish_execution`; allowed and materialized output tools use their registered names, such as `reply`. For structured-output steps, `finish_execution` accepts the configured result under `output`. Completing an execution does not necessarily complete the whole workflow.
 
 Authors may opt out for an individual step with `inject_tool_inventory: false`:
 
@@ -77,4 +77,4 @@ The public Hub docs live in the separate `getpaseo/paseo` repository under `publ
 4. Replace the manual-run success example with the five durable fields listed above.
 5. Describe RFC 9457 errors, structured `issues`, `requestId`, `X-Request-ID`, and narrow delivery-key semantics.
 6. Document `GET /api/billing/plans` (unauthenticated, no scopes) — this is what paseo.sh's pricing page will fetch.
-7. Document workflow-step `inject_tool_inventory` and the semantic `hub.finalize` / `hub.reply` inventory names.
+7. Document workflow-step `inject_tool_inventory` and the actual `finish_execution` / output-tool inventory names.

--- a/src/application-runtime.test.ts
+++ b/src/application-runtime.test.ts
@@ -12,7 +12,7 @@ import type { Database } from "./db/types.js";
 import { EntitlementsService } from "./entitlements/service.js";
 import type { ProviderRegistration, TriggerProviderResources } from "./providers/registration.js";
 import { createApplicationRuntime } from "./application-runtime.js";
-import { replyCapabilityMetadata, replyOutputTool } from "./execution-capabilities/outputs.js";
+import { replyOutputTool } from "./execution-capabilities/outputs.js";
 
 describe("application runtime provider composition", () => {
   it("collects a fake registration without a concrete-provider case", async () => {
@@ -44,7 +44,6 @@ describe("application runtime provider composition", () => {
       outputs: [
         {
           type: "fake.output",
-          hub: replyCapabilityMetadata,
           tool: replyOutputTool,
           execute: () => Promise.resolve(),
         },

--- a/src/daemons/daemons.test.ts
+++ b/src/daemons/daemons.test.ts
@@ -115,7 +115,7 @@ describe("daemon enrollment and execution", () => {
       agent.prompt,
       [
         "Capabilities available in this execution:",
-        "- hub.finalize: records the current agent execution as complete and returns its result to the workflow.",
+        "- finish_execution: Completes this execution and records its optional structured output.",
         "",
         "Reply pong.",
       ].join("\n"),
@@ -148,8 +148,8 @@ describe("daemon enrollment and execution", () => {
       hub.createdAgentLaunch().prompt,
       [
         "Capabilities available in this execution:",
-        "- hub.finalize: records the current agent execution as complete and returns its result to the workflow.",
-        "- hub.reply: sends a message to the conversation that triggered the execution.",
+        "- finish_execution: Completes this execution and records its optional structured output.",
+        "- reply: Sends a reply to the conversation that triggered this execution. (up to 1 times).",
         "",
         "Reply pong.",
       ].join("\n"),
@@ -162,7 +162,7 @@ describe("daemon enrollment and execution", () => {
       hub.createdAgentLaunch().prompt,
       [
         "Capabilities available in this execution:",
-        "- hub.finalize: records the current agent execution as complete and returns its result to the workflow.",
+        "- finish_execution: Completes this execution and records its optional structured output.",
         "",
         "Reply pong.",
       ].join("\n"),
@@ -177,6 +177,48 @@ describe("daemon enrollment and execution", () => {
     });
 
     assert.equal(hub.createdAgentLaunch().prompt, "Reply pong.");
+  });
+
+  it("keeps a structured classifier launch inventory aligned with its MCP tools", async () => {
+    await hub.connectDaemon();
+    const result = await hub.dispatch({
+      prompt: "Classify the request.",
+      allowOutputs: [],
+      outputSchema: {
+        type: "object",
+        additionalProperties: false,
+        required: ["repo"],
+        properties: { repo: { type: "string", enum: ["paseo", "hub"] } },
+      },
+    });
+
+    const launch = hub.createdAgentLaunch();
+    if (typeof launch.prompt !== "string") throw new Error("agent prompt is unavailable");
+    const advertisedTools = launch.prompt
+      .split("\n\n", 1)[0]!
+      .split("\n")
+      .slice(1)
+      .map((line) => line.slice(2, line.indexOf(":", 2)));
+    const exposedTools = await hub.listExecutionTools(result.execution.id);
+
+    assert.deepEqual(
+      advertisedTools,
+      exposedTools.map((tool) => tool.name),
+    );
+    assert.deepEqual(exposedTools[0]?.inputSchema, {
+      type: "object",
+      additionalProperties: false,
+      required: ["output"],
+      properties: {
+        output: {
+          $id: "urn:paseo:hub:finish-execution-output",
+          type: "object",
+          additionalProperties: false,
+          required: ["repo"],
+          properties: { repo: { type: "string", enum: ["paseo", "hub"] } },
+        },
+      },
+    });
   });
 
   it("deduplicates durable fan-out per configured trigger match", async () => {

--- a/src/daemons/daemons.test.ts
+++ b/src/daemons/daemons.test.ts
@@ -198,12 +198,16 @@ describe("daemon enrollment and execution", () => {
       .split("\n\n", 1)[0]!
       .split("\n")
       .slice(1)
-      .map((line) => line.slice(2, line.indexOf(":", 2)));
+      .map((line) => {
+        const separator = line.indexOf(": ", 2);
+        if (separator < 0) throw new Error(`malformed tool inventory line: ${line}`);
+        return { name: line.slice(2, separator), description: line.slice(separator + 2) };
+      });
     const exposedTools = await hub.listExecutionTools(result.execution.id);
 
     assert.deepEqual(
       advertisedTools,
-      exposedTools.map((tool) => tool.name),
+      exposedTools.map(({ name, description }) => ({ name, description })),
     );
     assert.deepEqual(exposedTools[0]?.inputSchema, {
       type: "object",

--- a/src/daemons/lifecycle.ts
+++ b/src/daemons/lifecycle.ts
@@ -520,6 +520,7 @@ export class DaemonDispatchLifecycle {
           : { injectToolInventory: intent.injectToolInventory }),
         allowOutputs: intent.allowOutputs,
         outputContext: intent.outputContext,
+        ...(intent.outputSchema === undefined ? {} : { outputSchema: intent.outputSchema }),
         capabilities: this.executionCapabilities,
       }),
     };

--- a/src/daemons/test-utils/hub-harness.ts
+++ b/src/daemons/test-utils/hub-harness.ts
@@ -42,7 +42,6 @@ import type { WorktreeTarget } from "../../config/index.js";
 import {
   OutputExecutorRegistry,
   outputContextProvider,
-  replyCapabilityMetadata,
   replyOutputTool,
 } from "../../execution-capabilities/outputs.js";
 import type { DaemonClock } from "../registry.js";
@@ -876,6 +875,33 @@ export class HubHarness {
     return body;
   }
 
+  async listExecutionTools(
+    executionId: string,
+  ): Promise<readonly { name: string; inputSchema: unknown }[]> {
+    const token = this.requireDaemon().completionToken(executionId);
+    const response = await fetch(`${this.origin}/agent-executions/${executionId}/mcp`, {
+      method: "POST",
+      headers: {
+        accept: "application/json, text/event-stream",
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/list",
+      }),
+    });
+    assert.equal(response.status, 200);
+    return z
+      .object({
+        result: z.object({
+          tools: z.array(z.object({ name: z.string(), inputSchema: z.unknown() }).passthrough()),
+        }),
+      })
+      .parse(await response.json()).result.tools;
+  }
+
   async restartApp(): Promise<void> {
     await this.stopApp();
     await this.startApp();
@@ -1322,7 +1348,6 @@ export class HubHarness {
     const registry = new OutputExecutorRegistry();
     registry.register({
       type: "discord.reply",
-      hub: replyCapabilityMetadata,
       tool: replyOutputTool,
       available: outputContextProvider("discord"),
       execute: async () => undefined,

--- a/src/daemons/test-utils/hub-harness.ts
+++ b/src/daemons/test-utils/hub-harness.ts
@@ -877,7 +877,7 @@ export class HubHarness {
 
   async listExecutionTools(
     executionId: string,
-  ): Promise<readonly { name: string; inputSchema: unknown }[]> {
+  ): Promise<readonly { name: string; description: string; inputSchema: unknown }[]> {
     const token = this.requireDaemon().completionToken(executionId);
     const response = await fetch(`${this.origin}/agent-executions/${executionId}/mcp`, {
       method: "POST",
@@ -896,7 +896,15 @@ export class HubHarness {
     return z
       .object({
         result: z.object({
-          tools: z.array(z.object({ name: z.string(), inputSchema: z.unknown() }).passthrough()),
+          tools: z.array(
+            z
+              .object({
+                name: z.string(),
+                description: z.string(),
+                inputSchema: z.unknown(),
+              })
+              .passthrough(),
+          ),
         }),
       })
       .parse(await response.json()).result.tools;

--- a/src/e2e/harness/hub-child.ts
+++ b/src/e2e/harness/hub-child.ts
@@ -7,7 +7,6 @@ import { Client } from "pg";
 import {
   OutputExecutorRegistry,
   outputContextProvider,
-  replyCapabilityMetadata,
   replyOutputTool,
 } from "../../execution-capabilities/outputs.js";
 import { createFetchServer } from "../../http/node-server.js";
@@ -61,7 +60,6 @@ async function main(): Promise<void> {
   const outputs = new OutputExecutorRegistry();
   outputs.register({
     type: "discord.reply",
-    hub: replyCapabilityMetadata,
     tool: replyOutputTool,
     available: outputContextProvider("discord"),
     execute: async (output) => {

--- a/src/e2e/harness/index.ts
+++ b/src/e2e/harness/index.ts
@@ -317,7 +317,7 @@ export class HubE2E {
       "        agent:",
       `          provider: ${provider}`,
       `          mode: ${mode}`,
-      '        prompt: [{ text: "Call the hub.finish_execution MCP tool exactly once. Do not use curl, shell, or direct HTTP." }] ',
+      '        prompt: [{ text: "Call the finish_execution MCP tool exactly once. Do not use curl, shell, or direct HTTP." }] ',
     ].join("\n");
     const response = await fetch(`${this.requireProxy().origin}/api/configurations/install`, {
       method: "POST",
@@ -365,7 +365,7 @@ export class HubE2E {
       "        agent:",
       `          provider: ${provider}`,
       `          mode: ${mode}`,
-      '        prompt: [{ text: "Classify the request and call hub.finish_execution exactly once with output {repo: hub}. Do not use curl, shell, or direct HTTP. Request: ${{ paseo.prompt }}" }] ',
+      '        prompt: [{ text: "Classify the request and call finish_execution exactly once with output {repo: hub}. Do not use curl, shell, or direct HTTP. Request: ${{ paseo.prompt }}" }] ',
       "        output:",
       "          schema:",
       "            type: object",
@@ -384,7 +384,7 @@ export class HubE2E {
       "        agent:",
       `          provider: ${provider}`,
       `          mode: ${mode}`,
-      '        prompt: [{ text: "Call hub.finish_execution exactly once. Do not use curl, shell, or direct HTTP." }] ',
+      '        prompt: [{ text: "Call finish_execution exactly once. Do not use curl, shell, or direct HTTP." }] ',
       "      - id: work-hub",
       "        if: \"${{ values.selected == 'hub' }}\"",
       "        environment: real-agent-routing",
@@ -394,7 +394,7 @@ export class HubE2E {
       "        agent:",
       `          provider: ${provider}`,
       `          mode: ${mode}`,
-      '        prompt: [{ text: "Call hub.finish_execution exactly once. Do not use curl, shell, or direct HTTP." }] ',
+      '        prompt: [{ text: "Call finish_execution exactly once. Do not use curl, shell, or direct HTTP." }] ',
     ].join("\n");
     const response = await fetch(`${this.requireProxy().origin}/api/configurations/install`, {
       method: "POST",

--- a/src/e2e/hub-foundation.e2e.test.ts
+++ b/src/e2e/hub-foundation.e2e.test.ts
@@ -48,7 +48,7 @@ describeHubE2E("Paseo Hub cross-repository contract", () => {
     assert.deepEqual(completed, {
       prompt: [
         "Capabilities available in this execution:",
-        "- hub.finalize: records the current agent execution as complete and returns its result to the workflow.",
+        "- finish_execution: Completes this execution and records its optional structured output.",
         "",
         "Deploy requested for phase-five-operator",
       ].join("\n"),
@@ -129,7 +129,7 @@ describeHubE2E("Paseo Hub cross-repository contract", () => {
     assert.deepEqual(recovered, {
       prompt: [
         "Capabilities available in this execution:",
-        "- hub.finalize: records the current agent execution as complete and returns its result to the workflow.",
+        "- finish_execution: Completes this execution and records its optional structured output.",
         "",
         "Deploy requested for phase-five-operator",
       ].join("\n"),

--- a/src/execution-capabilities/outputs.ts
+++ b/src/execution-capabilities/outputs.ts
@@ -1,4 +1,5 @@
 import type { JsonValue } from "../config/compiler.js";
+import { compileFinishExecutionArguments } from "../workflows/json-schema.js";
 
 export interface AllowedOutput {
   type: string;
@@ -14,11 +15,6 @@ export interface OutputToolSchema extends OutputToolSchemaNode {
   readonly type: "object";
   readonly properties?: Record<string, OutputToolSchemaNode>;
   readonly required?: string[];
-}
-
-export interface HubCapabilityMetadata {
-  readonly name: `hub.${string}`;
-  readonly description: string;
 }
 
 export interface OutputToolDefinition {
@@ -39,7 +35,6 @@ export type OutputExecutor = (input: OutputExecutionInput) => Promise<void>;
 
 export interface OutputCapability {
   readonly type: string;
-  readonly hub: HubCapabilityMetadata;
   readonly tool: OutputToolDefinition;
   readonly available?: (outputContext: unknown) => boolean;
   readonly execute: OutputExecutor;
@@ -50,20 +45,13 @@ export interface MaterializedOutputCapability {
   readonly capability: OutputCapability;
 }
 
-export const finalizeCapabilityMetadata = {
-  name: "hub.finalize",
-  description:
-    "records the current agent execution as complete and returns its result to the workflow.",
-} as const satisfies HubCapabilityMetadata;
-
-export const replyCapabilityMetadata = {
-  name: "hub.reply",
-  description: "sends a message to the conversation that triggered the execution.",
-} as const satisfies HubCapabilityMetadata;
+export const finishExecutionToolName = "finish_execution" as const;
+const finishExecutionToolDescription =
+  "Completes this execution and records its optional structured output.";
 
 export const replyOutputTool: OutputToolDefinition = {
   name: "reply",
-  description: "Reply to the conversation that triggered this execution.",
+  description: "Sends a reply to the conversation that triggered this execution.",
   inputSchema: {
     type: "object",
     properties: { content: { type: "string", minLength: 1 } },
@@ -88,16 +76,6 @@ export class OutputCapabilityValidationError extends Error {
 
 export class OutputExecutorRegistry {
   private readonly capabilities = new Map<string, OutputCapability>();
-  private readonly registeredCapabilities = new Map<
-    string,
-    { metadata: HubCapabilityMetadata; outputType?: string }
-  >();
-
-  constructor() {
-    this.registeredCapabilities.set(finalizeCapabilityMetadata.name, {
-      metadata: finalizeCapabilityMetadata,
-    });
-  }
 
   register(capability: OutputCapability): void {
     if (capability.type.length === 0) throw new Error("output capability type is required");
@@ -108,10 +86,6 @@ export class OutputExecutorRegistry {
       throw new Error(`output capability is already registered: ${capability.type}`);
     }
     this.capabilities.set(capability.type, capability);
-    this.registeredCapabilities.set(capability.type, {
-      metadata: capability.hub,
-      outputType: capability.type,
-    });
   }
 
   validateRequiredOutputs(allowedOutputs: readonly AllowedOutput[], outputContext: unknown): void {
@@ -145,22 +119,6 @@ export class OutputExecutorRegistry {
     return materialized;
   }
 
-  availableCapabilities(
-    allowedOutputs: readonly AllowedOutput[],
-    outputContext: unknown,
-  ): readonly HubCapabilityMetadata[] {
-    const availableTypes = new Set(
-      this.availableOutputs(allowedOutputs, outputContext).map((output) => output.declaration.type),
-    );
-    const byName = new Map<string, HubCapabilityMetadata>();
-    for (const capability of this.registeredCapabilities.values()) {
-      if (capability.outputType !== undefined && !availableTypes.has(capability.outputType))
-        continue;
-      byName.set(capability.metadata.name, capability.metadata);
-    }
-    return [...byName.values()];
-  }
-
   private availableOutputs(
     allowedOutputs: readonly AllowedOutput[],
     outputContext: unknown,
@@ -185,4 +143,47 @@ export class OutputExecutorRegistry {
     }
     await capability.execute(input);
   }
+}
+
+export function executionToolDefinitions(
+  outputSchema: JsonValue | undefined,
+  materializedOutputs: readonly MaterializedOutputCapability[],
+): readonly OutputToolDefinition[] {
+  return [
+    {
+      name: finishExecutionToolName,
+      description: finishExecutionToolDescription,
+      inputSchema: toolSchema(compileFinishExecutionArguments(outputSchema).schema),
+    },
+    ...materializedOutputs.map(({ declaration, capability }) => ({
+      name: capability.tool.name,
+      description: `${capability.tool.description} (up to ${declaration.max} times).`,
+      inputSchema: capability.tool.inputSchema,
+    })),
+  ];
+}
+
+function toolSchema(value: JsonValue): OutputToolSchema {
+  if (!isToolSchema(value)) throw new Error("JSON Schema tool arguments must be an object");
+  return value;
+}
+
+function isToolSchema(value: JsonValue): value is OutputToolSchema {
+  if (!isSchemaNode(value) || value["type"] !== "object") return false;
+  const properties = value["properties"];
+  const required = value["required"];
+  return (
+    (properties === undefined ||
+      (isRecord(properties) && Object.values(properties).every(isSchemaNode))) &&
+    (required === undefined ||
+      (Array.isArray(required) && required.every((item) => typeof item === "string")))
+  );
+}
+
+function isSchemaNode(value: JsonValue): value is OutputToolSchemaNode {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/src/execution-capabilities/outputs.ts
+++ b/src/execution-capabilities/outputs.ts
@@ -46,8 +46,12 @@ export interface MaterializedOutputCapability {
 }
 
 export const finishExecutionToolName = "finish_execution" as const;
-const finishExecutionToolDescription =
-  "Completes this execution and records its optional structured output.";
+
+function finishExecutionToolDescription(outputSchema: JsonValue | undefined): string {
+  return outputSchema === undefined
+    ? "Completes this execution and records its optional structured output."
+    : "Completes this execution and records the configured structured output.";
+}
 
 export const replyOutputTool: OutputToolDefinition = {
   name: "reply",
@@ -152,7 +156,7 @@ export function executionToolDefinitions(
   return [
     {
       name: finishExecutionToolName,
-      description: finishExecutionToolDescription,
+      description: finishExecutionToolDescription(outputSchema),
       inputSchema: toolSchema(compileFinishExecutionArguments(outputSchema).schema),
     },
     ...materializedOutputs.map(({ declaration, capability }) => ({

--- a/src/execution-capabilities/prompt.ts
+++ b/src/execution-capabilities/prompt.ts
@@ -1,19 +1,25 @@
-import type { AllowedOutput, OutputExecutorRegistry } from "./outputs.js";
+import type { JsonValue } from "../config/compiler.js";
+import {
+  executionToolDefinitions,
+  type AllowedOutput,
+  type OutputExecutorRegistry,
+} from "./outputs.js";
 
 export interface ExecutionPromptInput {
   prompt: string;
   injectToolInventory?: boolean;
   allowOutputs: readonly AllowedOutput[];
   outputContext: unknown;
+  outputSchema?: JsonValue;
   capabilities: OutputExecutorRegistry;
 }
 
 export function composeExecutionPrompt(input: ExecutionPromptInput): string {
   if (input.injectToolInventory === false) return input.prompt;
 
-  const inventory = input.capabilities.availableCapabilities(
-    input.allowOutputs,
-    input.outputContext,
+  const inventory = executionToolDefinitions(
+    input.outputSchema,
+    input.capabilities.materialize(input.allowOutputs, input.outputContext),
   );
   return [
     "Capabilities available in this execution:",

--- a/src/execution-capabilities/server.test.ts
+++ b/src/execution-capabilities/server.test.ts
@@ -18,12 +18,8 @@ import { createMemoryDatabase } from "../db/memory.js";
 import type { LaunchMachineIntent } from "../dispatcher/launch-machine-intent.js";
 import { createFetchServer } from "../http/node-server.js";
 import { registerResponseLifecycle, takeResponseLifecycle } from "../http/response-lifecycle.js";
-import {
-  OutputExecutorRegistry,
-  replyCapabilityMetadata,
-  replyOutputTool,
-  type OutputCapability,
-} from "./outputs.js";
+import { OutputExecutorRegistry, replyOutputTool, type OutputCapability } from "./outputs.js";
+import { composeExecutionPrompt } from "./prompt.js";
 import { createExecutionCapabilityServer } from "./server.js";
 
 const RpcResponseSchema = z
@@ -167,6 +163,64 @@ describe("execution capability MCP boundary", () => {
       });
       assert.equal(result.isError, undefined);
       assert.deepEqual(fixture.completions, [{ executionId: fixture.executionId, token: "token" }]);
+    } finally {
+      await client.close();
+      await closeServer(endpoint.server);
+    }
+  });
+
+  it("keeps a structured classifier inventory aligned with the exposed MCP tools", async () => {
+    const fixture = await capabilityFixture(undefined, "succeeded", 1, {
+      type: "object",
+      additionalProperties: false,
+      required: ["repo"],
+      properties: { repo: { type: "string", enum: ["paseo", "hub"] } },
+    });
+    const endpoint = await serveFixture(fixture);
+    const client = new Client({ name: "paseo-hub-test", version: "1.0.0" });
+    const transport = new StreamableHTTPClientTransport(new URL(endpoint.url), {
+      requestInit: { headers: { authorization: "Bearer token" } },
+    });
+    try {
+      // @ts-expect-error upstream SDK exactOptionalPropertyTypes mismatch
+      await client.connect(transport);
+      const exposedTools = await client.listTools();
+      const launchedPrompt = composeExecutionPrompt({
+        prompt: "Classify the request.",
+        allowOutputs: fixture.intent.allowOutputs,
+        outputContext: fixture.intent.outputContext,
+        ...(fixture.intent.outputSchema === undefined
+          ? {}
+          : { outputSchema: fixture.intent.outputSchema }),
+        capabilities: fixture.outputs,
+      });
+      const advertisedTools = launchedPrompt
+        .split("\n\n", 1)[0]!
+        .split("\n")
+        .slice(1)
+        .map((line) => line.slice(2, line.indexOf(":", 2)));
+
+      assert.deepEqual(
+        advertisedTools,
+        exposedTools.tools.map((tool) => tool.name),
+      );
+      assert.deepEqual(
+        exposedTools.tools.find((tool) => tool.name === "finish_execution")?.inputSchema,
+        {
+          type: "object",
+          additionalProperties: false,
+          required: ["output"],
+          properties: {
+            output: {
+              $id: "urn:paseo:hub:finish-execution-output",
+              type: "object",
+              additionalProperties: false,
+              required: ["repo"],
+              properties: { repo: { type: "string", enum: ["paseo", "hub"] } },
+            },
+          },
+        },
+      );
     } finally {
       await client.close();
       await closeServer(endpoint.server);
@@ -520,7 +574,6 @@ describe("execution capability MCP boundary", () => {
       [
         {
           type: "manual.reply",
-          hub: replyCapabilityMetadata,
           tool: { ...replyOutputTool, name: "send_manual_reply" },
           execute: async () => undefined,
         },
@@ -671,6 +724,7 @@ async function capabilityFixture(
   const database = createMemoryDatabase();
   const executionId = randomUUID();
   const token = "token";
+  const intent = launchIntent(maxReplies, outputSchema, autoArchive, requiredOutputTypes);
   await database.insertAgentExecution({
     id: executionId,
     organizationId: "org-1",
@@ -680,13 +734,12 @@ async function capabilityFixture(
     outputContext: slackOutputContext,
     configurationRevisionId: randomUUID(),
     completionTokenHash: hashAgentExecutionCompletionToken(token),
-    launchIntent: launchIntent(maxReplies, outputSchema, autoArchive, requiredOutputTypes),
+    launchIntent: intent,
   });
   const outbound: Array<import("./outputs.js").OutputExecutionInput> = [];
   const outputs = new OutputExecutorRegistry();
   outputs.register({
     type: "slack.reply",
-    hub: replyCapabilityMetadata,
     tool: outputTool,
     execute: async (input) => {
       outbound.push(input);
@@ -717,7 +770,9 @@ async function capabilityFixture(
   return {
     database,
     executionId,
+    intent,
     server,
+    outputs,
     outbound,
     completions,
     async call(method: string, params?: unknown) {

--- a/src/execution-capabilities/server.test.ts
+++ b/src/execution-capabilities/server.test.ts
@@ -198,11 +198,19 @@ describe("execution capability MCP boundary", () => {
         .split("\n\n", 1)[0]!
         .split("\n")
         .slice(1)
-        .map((line) => line.slice(2, line.indexOf(":", 2)));
+        .map((line) => {
+          const separator = line.indexOf(": ", 2);
+          if (separator < 0) throw new Error(`malformed tool inventory line: ${line}`);
+          return { name: line.slice(2, separator), description: line.slice(separator + 2) };
+        });
 
       assert.deepEqual(
         advertisedTools,
-        exposedTools.tools.map((tool) => tool.name),
+        exposedTools.tools.map(({ name, description }) => ({ name, description })),
+      );
+      assert.equal(
+        exposedTools.tools.find((tool) => tool.name === "finish_execution")?.description,
+        "Completes this execution and records the configured structured output.",
       );
       assert.deepEqual(
         exposedTools.tools.find((tool) => tool.name === "finish_execution")?.inputSchema,

--- a/src/execution-capabilities/server.ts
+++ b/src/execution-capabilities/server.ts
@@ -1,32 +1,21 @@
 import type { ErrorObject } from "ajv";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
-import {
-  CallToolRequestSchema,
-  ListToolsRequestSchema,
-  type Tool,
-} from "@modelcontextprotocol/sdk/types.js";
+import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import { verifyAgentExecutionCompletionToken } from "../agent-executions/completion-token.js";
-import type { JsonValue } from "../config/compiler.js";
 import type { AgentExecutionRecord, Database } from "../db/types.js";
 import { registerResponseLifecycle } from "../http/response-lifecycle.js";
+import { compileJsonSchema, formatJsonSchemaErrors } from "../workflows/json-schema.js";
 import {
-  compileFinishExecutionArguments,
-  compileJsonSchema,
-  formatJsonSchemaErrors,
-} from "../workflows/json-schema.js";
-import type { MaterializedOutputCapability, OutputExecutorRegistry } from "./outputs.js";
+  executionToolDefinitions,
+  finishExecutionToolName,
+  type MaterializedOutputCapability,
+  type OutputExecutorRegistry,
+  type OutputToolSchema,
+} from "./outputs.js";
 
-interface JsonSchemaNode {
-  readonly [key: string]: JsonValue;
-}
-
-interface JsonSchema extends JsonSchemaNode {
-  readonly type: "object";
-  readonly properties?: Record<string, JsonSchemaNode>;
-  readonly required?: string[];
-}
+type JsonSchema = OutputToolSchema;
 
 export interface ExecutionCapabilityServer {
   handle(request: Request, executionId: string): Promise<Response>;
@@ -136,22 +125,13 @@ function createMcpServer(
     { name: "paseo-hub-execution", version: "1.0.0" },
     { capabilities: { tools: {} } },
   );
-  const finishContract = finishExecutionContract(execution.launchIntent?.outputSchema);
-  const tools: Tool[] = [
-    {
-      name: "finish_execution",
-      description: "Mark this Hub execution complete after the task is fully finished.",
-      inputSchema: finishContract.schema,
-    },
-  ];
-  for (const output of materializedOutputs) {
-    tools.push({
-      name: output.capability.tool.name,
-      description: `${output.capability.tool.description} (up to ${output.declaration.max} times).`,
-      inputSchema: output.capability.tool.inputSchema,
-    });
-  }
-  const contracts = new Map<string, JsonSchemaContract>([["finish_execution", finishContract]]);
+  const tools = executionToolDefinitions(execution.launchIntent?.outputSchema, materializedOutputs);
+  const finishTool = tools.find((tool) => tool.name === finishExecutionToolName);
+  if (finishTool === undefined) throw new Error("finish execution tool is not registered");
+  const finishContract = finishExecutionContract(finishTool.inputSchema);
+  const contracts = new Map<string, JsonSchemaContract>([
+    [finishExecutionToolName, finishContract],
+  ]);
   const outputsByToolName = new Map<string, MaterializedOutputCapability>();
   for (const output of materializedOutputs) {
     contracts.set(
@@ -170,7 +150,7 @@ function createMcpServer(
     const validation = contract.validate(args);
     if (!validation.valid) return toolFailure(validation.message);
 
-    if (toolName === "finish_execution")
+    if (toolName === finishExecutionToolName)
       return finishExecutionCall(options, execution, token, args, materializedOutputs);
     const output = outputsByToolName.get(toolName);
     return output === undefined
@@ -251,9 +231,8 @@ interface JsonSchemaContract {
   validate(args: Record<string, unknown>): { valid: true } | { valid: false; message: string };
 }
 
-function finishExecutionContract(outputSchema: JsonValue | undefined): JsonSchemaContract {
-  const compiled = compileFinishExecutionArguments(outputSchema);
-  const schema = toolSchema(compiled.schema);
+function finishExecutionContract(schema: JsonSchema): JsonSchemaContract {
+  const compiled = compileJsonSchema(schema);
   return {
     schema,
     validate(args) {
@@ -287,31 +266,6 @@ function validationMessage(errors: readonly ErrorObject[] | null | undefined): s
   return messages.length === 0
     ? "Invalid arguments for tool"
     : `Invalid arguments for tool: ${messages.join("; ")}`;
-}
-
-function isSchemaNode(value: JsonValue): value is JsonSchemaNode {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function toolSchema(value: JsonValue): JsonSchema {
-  if (!isToolSchema(value)) throw new Error("JSON Schema tool arguments must be an object");
-  return value;
-}
-
-function isToolSchema(value: JsonValue): value is JsonSchema {
-  if (!isSchemaNode(value) || value["type"] !== "object") return false;
-  const properties = value["properties"];
-  const required = value["required"];
-  return (
-    (properties === undefined ||
-      (isRecord(properties) && Object.values(properties).every(isSchemaNode))) &&
-    (required === undefined ||
-      (Array.isArray(required) && required.every((item) => typeof item === "string")))
-  );
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function missingRequiredOutputs(

--- a/src/index.bootstrap.test.ts
+++ b/src/index.bootstrap.test.ts
@@ -32,7 +32,7 @@ describe("production Hub runtime", () => {
       hub.createdAgentLaunch().prompt,
       [
         "Capabilities available in this execution:",
-        "- hub.finalize: records the current agent execution as complete and returns its result to the workflow.",
+        "- finish_execution: Completes this execution and records its optional structured output.",
         "",
         "Deploy the requested service",
       ].join("\n"),

--- a/src/providers/discord/index.ts
+++ b/src/providers/discord/index.ts
@@ -19,11 +19,7 @@ import { createDiscordGatewaySource } from "../../triggers/discord/gateway.js";
 import { createDiscordTriggerProvider } from "../../triggers/discord/provider.js";
 import { createDiscordAttachmentResolver } from "../../triggers/discord/attachments.js";
 import { createDiscordReplyExecutor } from "../../triggers/discord/reply.js";
-import {
-  outputContextProvider,
-  replyCapabilityMetadata,
-  replyOutputTool,
-} from "../../execution-capabilities/outputs.js";
+import { outputContextProvider, replyOutputTool } from "../../execution-capabilities/outputs.js";
 import {
   createDiscordConnectionClient,
   type DiscordConnectionClient,
@@ -116,7 +112,6 @@ export function createDiscordRegistration(
     outputs: [
       {
         type: "discord.reply",
-        hub: replyCapabilityMetadata,
         tool: replyOutputTool,
         available: outputContextProvider("discord"),
         execute: createDiscordReplyExecutor({ bot }),

--- a/src/providers/registration.ts
+++ b/src/providers/registration.ts
@@ -1,11 +1,7 @@
 import type { ProjectConfigurationStore } from "../configuration/store.js";
 import type { ConnectionResolutionContext, ConnectionResolver } from "../config/connections.js";
 import type { OrganizationConnectionUsage } from "../db/types.js";
-import type {
-  HubCapabilityMetadata,
-  OutputExecutor,
-  OutputToolDefinition,
-} from "../execution-capabilities/outputs.js";
+import type { OutputExecutor, OutputToolDefinition } from "../execution-capabilities/outputs.js";
 import type { TriggerProvider, TriggerSource } from "../triggers/index.js";
 import type { GitHubConfigurationProvider } from "../configuration/github-sync.js";
 import type {
@@ -42,7 +38,6 @@ export interface ProviderConnectionRegistration {
 
 export interface ProviderOutputRegistration {
   type: string;
-  hub: HubCapabilityMetadata;
   tool: OutputToolDefinition;
   available?: (outputContext: unknown) => boolean;
   execute: OutputExecutor;

--- a/src/providers/slack/index.ts
+++ b/src/providers/slack/index.ts
@@ -18,11 +18,7 @@ import { createSlackBotClient, type SlackBotClient } from "../../triggers/slack/
 import { createSlackTriggerProvider } from "../../triggers/slack/provider.js";
 import { createSlackAttachmentResolver } from "../../triggers/slack/attachments.js";
 import { createSlackReplyExecutor } from "../../triggers/slack/reply.js";
-import {
-  outputContextProvider,
-  replyCapabilityMetadata,
-  replyOutputTool,
-} from "../../execution-capabilities/outputs.js";
+import { outputContextProvider, replyOutputTool } from "../../execution-capabilities/outputs.js";
 import { createSlackWebhookSource } from "../../triggers/slack/webhook.js";
 import type { ProviderConnectionRegistration, ProviderRegistration } from "../registration.js";
 import {
@@ -133,7 +129,6 @@ export function createSlackRegistration(
     outputs: [
       {
         type: "slack.reply",
-        hub: replyCapabilityMetadata,
         tool: replyOutputTool,
         available: outputContextProvider("slack"),
         execute: createSlackReplyExecutor({ client: bot }),


### PR DESCRIPTION
## What changed, and why

The prompt inventory now uses the same callable MCP tool definitions exposed by the execution boundary. Structured-output executions advertise `finish_execution`, and allowed materialized outputs advertise their registered names such as `reply`. The separate `hub.finalize` and `hub.reply` metadata aliases are removed.

The inventory remains before the authored prompt, stays factual, and `inject_tool_inventory: false` remains unchanged.

## Goals

- Keep prompt-discovered callable names equal to the live MCP `tools/list` names.
- Make structured classifier output discover the exact completion tool and schema.
- Ensure future registered output tools use one tool definition for prompt inventory and MCP exposure.

## Non-goals

- No change to completion or output execution semantics.
- No merge or deployment.

## Risk

The change is limited to execution tool-definition composition, prompt materialization, and provider registration types. It has no database or schema changes.

## Verification

- Red-to-green boundary regression: the pre-fix test failed because the inventory advertised `hub.finalize`/`hub.reply` while MCP exposed `finish_execution`/`reply`; it passes with the shared definitions.
- `npm test` — 90 files passed, 5 skipped; 625 tests passed, 13 skipped.
- Focused MCP/daemon/provider suite — 7 files, 120 tests passed.
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm run db:check`
- `npm run docker:smoke`
- Source Hub E2E was attempted but stopped before tests because the local bootstrap state could not identify the existing organization; this is unrelated to the changed files.

## Docs

Hub public API docs are updated to use `finish_execution` and registered output-tool names. The companion `getpaseo/paseo` public docs under `public-docs/` need the same wording update in a follow-up; no second repository PR is included here.

No open Hub issue matched this bug.