### PR TITLE
Allow self-hosted sign-in over remote HTTP

### DIFF
--- a/src/root-head.test.tsx
+++ b/src/root-head.test.tsx
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { it } from "vitest";
+import { Route } from "./routes/__root.js";
+
+it("limits referrers to same-origin requests so CSRF checks work over HTTP", async () => {
+  const head = await Route.options.head?.(undefined!);
+
+  assert.equal(
+    head?.meta?.find((meta) => meta?.name === "referrer")?.content,
+    "same-origin",
+  );
+});

--- a/src/root-head.test.tsx
+++ b/src/root-head.test.tsx
@@ -5,8 +5,5 @@ import { Route } from "./routes/__root.js";
 it("limits referrers to same-origin requests so CSRF checks work over HTTP", async () => {
   const head = await Route.options.head?.(undefined!);
 
-  assert.equal(
-    head?.meta?.find((meta) => meta?.name === "referrer")?.content,
-    "same-origin",
-  );
+  assert.equal(head?.meta?.find((meta) => meta?.name === "referrer")?.content, "same-origin");
 });

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -7,7 +7,7 @@ export const Route = createRootRoute({
     meta: [
       { charSet: "utf-8" },
       { name: "viewport", content: "width=device-width, initial-scale=1" },
-      { name: "referrer", content: "no-referrer" },
+      { name: "referrer", content: "same-origin" },
       { title: "Paseo Hub" },
     ],
   }),


### PR DESCRIPTION
Self-hosted Hub instances can now load the sign-in flow when accessed over plain HTTP from another machine, including LAN and private-network hostnames. Cross-origin navigation details remain undisclosed.

## Goals

- Allow account server functions to pass CSRF validation over non-loopback HTTP.
- Preserve referrer privacy for every cross-origin request.
- Lock the required root referrer policy with a regression test.

## Non-goals

- Change authentication, session, or CSRF middleware behavior.
- Change external provider configuration or HTTPS recommendations.

## Why

Browsers omit Fetch Metadata headers on non-loopback HTTP. The previous global `no-referrer` policy also removed TanStack Start’s same-origin `Referer` fallback, so the initial account request was rejected with `403` before authentication ran. A `same-origin` policy supplies the fallback only to Hub itself and continues suppressing referrers cross-origin.

## Verification

- Reproduced `403` on the real dev server through a Tailscale hostname with `no-referrer`.
- Confirmed the identical request returns `200` and renders sign-in with `same-origin`.
- Confirmed a cross-origin probe receives no `Referer`.
- `npx vitest run src/root-head.test.tsx`
- `npm run typecheck:start`
- `npm run lint:start -- --quiet`
- `npm run build:start`

## Risk surface

Limited to the document referrer policy. Same-origin requests may carry their referring Hub URL to Hub itself; cross-origin requests continue receiving no referrer.