### PR TITLE
Restore scoped GitHub credentials for workflow steps

### DIFF
--- a/src/auth/github.test.ts
+++ b/src/auth/github.test.ts
@@ -109,6 +109,7 @@ describe("GitHub App authentication", () => {
       fetch: async (input, init) => {
         const request =
           input instanceof Request && init === undefined ? input : new Request(input, init);
+        assert.equal(request.headers.get("authorization"), null);
         requests.push(`${request.method} ${new URL(request.url).pathname}`);
         return Response.json({ id: 9876, login: "paseo[bot]" });
       },

--- a/src/auth/github.ts
+++ b/src/auth/github.ts
@@ -130,7 +130,7 @@ export function createGitHubAuth(options: CreateGitHubAuthOptions = {}): GitHubA
     const cached = appBotIdentityCache.get(appSlug);
     if (cached !== undefined) return cached;
     const pending = (async () => {
-      const octokit = await getAppOctokit();
+      const octokit = new Octokit({ request: githubRequestOptions(options.fetch) });
       const response = await octokit.request("GET /users/{username}", {
         username: `${appSlug}[bot]`,
       });


### PR DESCRIPTION
Scoped GitHub workflow authority can now materialize credentials successfully. Hub resolves the public GitHub App bot account without sending an App JWT to an endpoint that does not accept it.

## Goals

- Allow scoped GitHub credentials to reach eligible workflow steps.
- Keep GitHub App JWTs limited to App API endpoints.
- Preserve the existing cached bot identity behavior.
- Reproduce the credential-boundary failure in an automated test.

## Non-goals

- Change authored workflow configuration or authority scopes.
- Change token minting, revocation, or lease behavior.
- Change the GitHub App connection flow.

## Verification

- `npx vitest run src/auth/github.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `git diff --check`

## Risk surface

The change affects only the public bot-user identity lookup. App-authenticated installation and token endpoints are unchanged.