### PR TITLE
Restore hostname-derived daemon slugs

### DIFF
--- a/src/daemons/daemons.test.ts
+++ b/src/daemons/daemons.test.ts
@@ -59,12 +59,24 @@ describe("daemon enrollment and execution", () => {
 
     assert.equal(enrollment.replayedDaemonId, enrollment.firstDaemonId);
     assert.deepEqual(
+      { first: enrollment.firstSlug, replay: enrollment.replayedSlug },
+      { first: "replay-host-local", replay: "replay-host-local" },
+    );
+    assert.deepEqual(
       {
         consumedTokenStatus: enrollment.consumedTokenStatus,
         persistedDaemons: enrollment.persistedDaemons,
       },
       { consumedTokenStatus: 401, persistedDaemons: 1 },
     );
+  });
+
+  it("derives unique default daemon slugs from the enrolling hostnames", async () => {
+    const first = await hub.enrollDaemon("Studio Mac.local");
+    const second = await hub.enrollDaemon("Studio Mac.local");
+
+    assert.equal(first.slug, "studio-mac-local");
+    assert.equal(second.slug, `studio-mac-local-${second.daemonId.slice(0, 8)}`);
   });
 
   it("rejects invalid and revoked credentials on reconnect", async () => {

--- a/src/daemons/registration.ts
+++ b/src/daemons/registration.ts
@@ -12,6 +12,7 @@ const enrollmentBody = z
   .object({
     daemonId: z.string().uuid(),
     idempotencyKey: z.string(),
+    hostname: z.string().trim().min(1).max(253).optional(),
     serverId: z.string(),
     daemonPublicKey: z.string(),
     credentialVerifier: z.string(),
@@ -120,8 +121,11 @@ export async function enrollDaemon(
   if (token === undefined) return Response.json({ error: "unauthorized" }, { status: 401 });
   const input = enrollmentBody.safeParse(await request.json().catch(() => undefined));
   if (!input.success) return Response.json({ error: "invalid enrollment" }, { status: 400 });
+  const fallbackSlug = `daemon-${input.data.daemonId.slice(0, 8)}`;
   const daemon = await database.enrollDaemon({
     ...input.data,
+    suggestedSlug:
+      input.data.hostname === undefined ? fallbackSlug : slugify(input.data.hostname, fallbackSlug),
     scopes: ["hub.execution.*"],
     tokenVerifier: verifier(token),
     now: clock.nowDate(),

--- a/src/daemons/test-utils/hub-harness.ts
+++ b/src/daemons/test-utils/hub-harness.ts
@@ -96,6 +96,7 @@ const IssuedEnrollmentSchema = z.object({
 });
 const EnrollmentSchema = z.object({
   daemonId: z.string(),
+  slug: z.string(),
   scopes: z.array(z.string()),
   webSocketUrl: z.string(),
 });
@@ -227,6 +228,14 @@ export class HubHarness {
     return daemon.daemonId;
   }
 
+  async enrollDaemon(hostname: string): Promise<Enrollment> {
+    const issued = await this.issueEnrollment();
+    if (issued.status !== 201 || !("token" in issued)) {
+      throw new Error("Enrollment token was not issued");
+    }
+    return TestDaemon.create(this.origin).enroll(issued.token, hostname);
+  }
+
   async renameConnectedDaemon(slug: string): Promise<void> {
     const daemon = this.requireDaemon();
     const renamed = await this.requireDatabase().renameDaemonForOrganization(
@@ -290,7 +299,9 @@ export class HubHarness {
 
   async connectWithEnrollmentReplay(): Promise<{
     firstDaemonId: string;
+    firstSlug: string;
     replayedDaemonId: string;
+    replayedSlug: string;
     consumedTokenStatus: number;
     persistedDaemons: number;
   }> {
@@ -298,8 +309,8 @@ export class HubHarness {
     if (issued.status !== 201 || !("token" in issued))
       throw new Error("Enrollment token was not issued");
     this.connectedDaemon = TestDaemon.create(this.origin);
-    const first = await this.connectedDaemon.enroll(issued.token);
-    const replay = await this.connectedDaemon.enroll(issued.token);
+    const first = await this.connectedDaemon.enroll(issued.token, "Replay Host.local");
+    const replay = await this.connectedDaemon.enroll(issued.token, "Replay Host.local");
     await this.connectedDaemon.connect(replay);
     const contender = TestDaemon.create(this.origin);
     const consumedTokenStatus = await contender.enrollmentStatus(issued.token);
@@ -309,7 +320,9 @@ export class HubHarness {
     ]);
     return {
       firstDaemonId: first.daemonId,
+      firstSlug: first.slug,
       replayedDaemonId: replay.daemonId,
+      replayedSlug: replay.slug,
       consumedTokenStatus,
       persistedDaemons: persisted.filter((daemon) => daemon !== undefined).length,
     };
@@ -1951,6 +1964,7 @@ class HubClock implements DaemonClock, ExecutionDeadlineClock {
 
 interface Enrollment {
   daemonId: string;
+  slug: string;
   webSocketUrl: string;
   scopes: string[];
 }
@@ -1994,7 +2008,7 @@ class TestDaemon {
     const id = randomUUID();
     return new TestDaemon(origin, id, `daemon-${id.slice(0, 8)}`, randomUUID());
   }
-  async enroll(token: string): Promise<Enrollment> {
+  async enroll(token: string, hostname?: string): Promise<Enrollment> {
     const response = await fetch(`${this.origin}/api/daemons/enroll`, {
       method: "POST",
       headers: {
@@ -2007,6 +2021,7 @@ class TestDaemon {
         serverId: randomUUID(),
         daemonPublicKey: "public-key",
         credentialVerifier: createHash("sha256").update(this.credential).digest("base64url"),
+        ...(hostname === undefined ? {} : { hostname }),
       }),
     });
     if (response.status !== 200) throw new Error(`Enrollment failed: ${response.status}`);

--- a/src/db/memory.ts
+++ b/src/db/memory.ts
@@ -1439,7 +1439,15 @@ class MemoryDatabase implements Database {
     if (replay) return replay;
     const token = this.enrollmentTokens.get(input.tokenVerifier);
     if (!token || token.consumedAt || token.expiresAt <= input.now) return undefined;
-    const slug = `daemon-${input.daemonId.slice(0, 8)}`;
+    const suggestedSlug = input.suggestedSlug ?? `daemon-${input.daemonId.slice(0, 8)}`;
+    const suggestedSlugTaken = Array.from(this.daemons.values()).some(
+      (daemon) =>
+        daemon.slug === suggestedSlug &&
+        this.machines.get(daemon.machineId)?.orgId === token.organizationId,
+    );
+    const slug = suggestedSlugTaken
+      ? `${suggestedSlug}-${input.daemonId.slice(0, 8)}`
+      : suggestedSlug;
     const slugTaken = Array.from(this.daemons.values()).some(
       (daemon) =>
         daemon.slug === slug && this.machines.get(daemon.machineId)?.orgId === token.organizationId,

--- a/src/db/pg.ts
+++ b/src/db/pg.ts
@@ -1672,20 +1672,21 @@ class PgDatabase implements Database {
         `insert into machines (org_id, source, status) values ($1, $2, 'alive') returning *`,
         [consumedToken.organization_id, { kind: "daemon", daemonId: input.daemonId }],
       );
-      const fallbackSlug = `daemon-${input.daemonId.slice(0, 8)}`;
-      const slug = fallbackSlug;
-      requestedSlug = slug;
-      const daemon = await client.query<DaemonRow>(
+      const suggestedSlug = input.suggestedSlug ?? `daemon-${input.daemonId.slice(0, 8)}`;
+      requestedSlug = suggestedSlug;
+      let daemon = await client.query<DaemonRow>(
         `insert into daemons
            (id, idempotency_key, enrollment_verifier, slug, machine_id, organization_id, server_id,
             daemon_public_key, credential_verifier, scopes,
             registered_by_api_key_id, registered_by_cli_credential_id, status)
-         values ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,'active') returning *`,
+         values ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,'active')
+         on conflict (organization_id, slug) do nothing
+         returning *`,
         [
           input.daemonId,
           input.idempotencyKey,
           input.tokenVerifier,
-          slug,
+          suggestedSlug,
           machine.rows[0]!.id,
           consumedToken.organization_id,
           input.serverId,
@@ -1696,6 +1697,31 @@ class PgDatabase implements Database {
           consumedToken.issued_by_cli_credential_id,
         ],
       );
+      if (daemon.rows[0] === undefined) {
+        const uniqueSlug = `${suggestedSlug}-${input.daemonId.slice(0, 8)}`;
+        requestedSlug = uniqueSlug;
+        daemon = await client.query<DaemonRow>(
+          `insert into daemons
+             (id, idempotency_key, enrollment_verifier, slug, machine_id, organization_id, server_id,
+              daemon_public_key, credential_verifier, scopes,
+              registered_by_api_key_id, registered_by_cli_credential_id, status)
+           values ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,'active') returning *`,
+          [
+            input.daemonId,
+            input.idempotencyKey,
+            input.tokenVerifier,
+            uniqueSlug,
+            machine.rows[0]!.id,
+            consumedToken.organization_id,
+            input.serverId,
+            input.daemonPublicKey,
+            input.credentialVerifier,
+            JSON.stringify(input.scopes),
+            consumedToken.issued_by_api_key_id,
+            consumedToken.issued_by_cli_credential_id,
+          ],
+        );
+      }
       await client.query("commit");
       return toDaemon(daemon.rows[0]!);
     } catch (error) {

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -709,6 +709,7 @@ export interface WorkflowAgentCompletionInput {
 export interface EnrollDaemonInput {
   daemonId: string;
   idempotencyKey: string;
+  suggestedSlug?: string;
   tokenVerifier: string;
   serverId: string;
   daemonPublicKey: string;


### PR DESCRIPTION
Daemons enrolled by current Paseo releases regain useful hostname-derived default slugs. Hub continues to keep human CLI credentials separate from daemon relationship authority, while preserving explicit renames and idempotent enrollment.

## Goals

- Accept optional hostname metadata on daemon enrollment.
- Normalize hostnames into organization-unique default daemon slugs.
- Add a deterministic daemon ID suffix when two hosts normalize to the same slug.
- Preserve generated fallbacks for existing Paseo 0.3.1 clients that do not send a hostname.
- Preserve enrollment idempotency, explicit renames, and credential/token boundaries.

## Non-goals

- Rename already-enrolled daemons.
- Re-couple daemon enrollment to durable human login.
- Change the dashboard naming layer.

## Why

The durable-login split removed the only hostname/name input from daemon enrollment, so Hub could only assign `daemon-<UUID prefix>`. Naming belongs in the enrollment data flow: Paseo supplies the host metadata and Hub owns slug normalization and organization-scoped allocation.

## Release dependency

This Hub PR must merge and be released before the coordinated Paseo PR. Released Hub v0.2.0 strictly rejects unknown enrollment fields, so shipping the Paseo producer first would make new enrollment requests fail. This change is backward-compatible with Paseo 0.3.1 because `hostname` is optional and missing values retain the generated fallback.

## Verification

- Added a failing-first PostgreSQL-backed regression for hostname-derived and duplicate-hostname slugs.
- Added hostname-bearing replay coverage.
- `npm exec vitest run src/daemons/daemons.test.ts -- --maxWorkers=1` — 91 passed.
- `npm run typecheck` — passed for node, frontend, and E2E configurations.
- Targeted lint and formatting checks passed.

## Risk surface

The enrollment request parser and initial slug allocation transaction change. Existing daemon rows, explicit rename behavior, relationship credentials, enrollment-token consumption, and organization-scoped uniqueness constraints remain unchanged.
