### PR TITLE
test: make timing and browser E2E execution deterministic

### DIFF
--- a/e2e/app.ts
+++ b/e2e/app.ts
@@ -8,12 +8,7 @@ import { test as base } from "@playwright/test";
 import { PostgreSqlContainer, type StartedPostgreSqlContainer } from "@testcontainers/postgresql";
 import { Client } from "pg";
 import { z } from "zod";
-import {
-  PaseoHub,
-  setBuiltApplicationMachineKey,
-  type BuiltApplication,
-  type BuiltApplicationOptions,
-} from "./helpers/hub.js";
+import { PaseoHub, type BuiltApplication, type BuiltApplicationOptions } from "./helpers/hub.js";
 import { createDatabase } from "../src/db/pg.js";
 import { SourcePaseo } from "./helpers/source-paseo.js";
 import type { BrowserDiscordEvent } from "../src/e2e/harness/browser-providers.js";
@@ -22,8 +17,6 @@ import type { FixtureBillingProduct } from "../src/e2e/harness/browser-billing.j
 import { ProjectExternalFacts } from "./helpers/projects/external.js";
 
 const billingInspectSchema = z.object({ reportedSeatQuantity: z.number().nullable() });
-
-let primaryApplication: BuiltApplication | undefined;
 
 export const test = base.extend<{
   hub: PaseoHub;
@@ -57,7 +50,6 @@ export const test = base.extend<{
         billing,
         providerScenario,
       });
-      primaryApplication = primary;
       await provide(
         new PaseoHub(
           primary,
@@ -75,13 +67,11 @@ export const test = base.extend<{
         });
       }
     } finally {
-      primaryApplication = undefined;
       await applications.stop();
     }
   },
-  projectExternal: async ({ hub: _hub, request }, provide) => {
-    if (primaryApplication === undefined) throw new Error("primary application is unavailable");
-    await provide(new ProjectExternalFacts(primaryApplication, request));
+  projectExternal: async ({ hub, request }, provide) => {
+    await provide(new ProjectExternalFacts(hub.primaryApplication(), request));
   },
 });
 
@@ -110,9 +100,10 @@ class BuiltApplications {
       stdio: ["pipe", "pipe", "pipe", "ipc"],
     });
     const output: string[] = [];
-    const application = {
+    const application: RunningApplication = {
       origin,
       databaseUrl,
+      machineKey: "",
       postgres,
       server,
       logs: () => output.join(""),
@@ -136,7 +127,7 @@ class BuiltApplications {
     };
     this.running.push(application);
     await serverReady(server, origin, output);
-    setBuiltApplicationMachineKey((await readFile(machineKeyFile, "utf8")).trim());
+    application.machineKey = (await readFile(machineKeyFile, "utf8")).trim();
     return application;
   }
 

--- a/e2e/helpers/hub.ts
+++ b/e2e/helpers/hub.ts
@@ -31,6 +31,7 @@ import { ProjectConfiguration } from "./projects/configuration.js";
 export interface BuiltApplication {
   origin: string;
   databaseUrl: string;
+  machineKey: string;
   logs(): string;
   deliverDiscord(event: BrowserDiscordEvent): Promise<void>;
   setGitHubConfiguration(input: {
@@ -43,12 +44,6 @@ export interface BuiltApplication {
   cancelSubscription(organizationId: string): Promise<void>;
   /** The seat quantity billing last reported to the fixture Stripe for this organization. */
   reportedSeatQuantity(organizationId: string): Promise<number | null>;
-}
-
-let MACHINE_KEY = "";
-
-export function setBuiltApplicationMachineKey(value: string): void {
-  MACHINE_KEY = value;
 }
 
 export interface BuiltApplicationOptions {
@@ -118,6 +113,10 @@ export class PaseoHub {
     private readonly startApplication: StartBuiltApplication,
     private readonly startSourcePaseo: StartSourcePaseo,
   ) {}
+
+  primaryApplication(): BuiltApplication {
+    return this.primary;
+  }
 
   async visitHome(): Promise<void> {
     await this.page.goto(this.primary.origin);
@@ -578,7 +577,7 @@ export class PaseoHub {
     const response = await this.requests.post(`${this.primary.origin}/api/v1/manual-runs`, {
       headers: {
         ...(input.apiKey === undefined
-          ? machineHeaders()
+          ? machineHeaders(this.primary.machineKey)
           : { authorization: `Bearer ${input.apiKey}` }),
         "content-type": "application/json",
       },
@@ -1915,7 +1914,7 @@ export class PaseoHub {
   }
 
   private async verifyManualApplication(application: BuiltApplication): Promise<void> {
-    await this.verifyExactContracts(application, manualFailureContracts());
+    await this.verifyExactContracts(application, manualFailureContracts(application.machineKey));
     await this.verifyLegacyCompletionCallbackAbsent(application);
     await this.verifyDocumentAndAssetContracts(application);
     await this.verifyAuthContracts(application);
@@ -2105,7 +2104,7 @@ export class PaseoHub {
       },
     });
     await this.issueEnrollmentToken(application, {
-      ...machineHeaders(),
+      ...machineHeaders(application.machineKey),
       origin: HOSTILE_ORIGIN,
     });
 
@@ -2141,7 +2140,7 @@ export class PaseoHub {
 
   private async issueEnrollmentToken(
     application: BuiltApplication,
-    headers: Record<string, string> = machineHeaders(),
+    headers: Record<string, string> = machineHeaders(application.machineKey),
   ): Promise<string> {
     const response = await this.requests.post(
       `${application.origin}/api/v1/daemons/enrollment-tokens`,
@@ -2163,7 +2162,7 @@ export class PaseoHub {
     const response = await this.requests.post(
       `${application.origin}/api/v1/configurations/install`,
       {
-        headers: machineHeaders(),
+        headers: machineHeaders(application.machineKey),
         data: {
           projectSlug: "default",
           files: configurationBundleFixture(manualConfiguration(daemonSlug)),
@@ -2189,7 +2188,7 @@ export class PaseoHub {
     versionId: string,
   ): Promise<{ executionId: string }> {
     const response = await this.requests.post(`${application.origin}/api/v1/manual-runs`, {
-      headers: machineHeaders(),
+      headers: machineHeaders(application.machineKey),
       data: {
         projectSlug: "default",
         expectedVersionId: versionId,
@@ -4579,7 +4578,7 @@ const ORGANIZATION_POST_PATHS = [
 const TEXT_TYPE = "text/plain;charset=UTF-8";
 const HTML_TYPE = "text/html; charset=utf-8";
 
-function manualFailureContracts(): readonly HttpContract[] {
+function manualFailureContracts(machineKey: string): readonly HttpContract[] {
   return [
     exact("health", "/health", "GET", 200, '{"ok":true}', JSON_TYPE),
     exact(
@@ -4676,7 +4675,7 @@ function manualFailureContracts(): readonly HttpContract[] {
       ),
       PROBLEM_TYPE,
       {
-        ...machineHeaders(),
+        ...machineHeaders(machineKey),
         "content-type": "application/json",
         "x-request-id": "phase-zero-contract",
       },
@@ -4699,7 +4698,7 @@ function manualFailureContracts(): readonly HttpContract[] {
       ),
       PROBLEM_TYPE,
       {
-        ...machineHeaders(),
+        ...machineHeaders(machineKey),
         "content-type": "application/json",
         "x-request-id": "phase-zero-contract",
       },
@@ -4795,8 +4794,8 @@ function problemBody(
   });
 }
 
-function machineHeaders(): Record<string, string> {
-  return { authorization: `Bearer ${MACHINE_KEY}` };
+function machineHeaders(machineKey: string): Record<string, string> {
+  return { authorization: `Bearer ${machineKey}` };
 }
 
 function daemonEnrollment(daemonId: string, credential: string) {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,8 +2,11 @@ import { defineConfig, devices } from "@playwright/test";
 
 export default defineConfig({
   testDir: "./e2e",
-  fullyParallel: false,
-  workers: 1,
+  fullyParallel: true,
+  // Each test owns a PostgreSQL container and a Hub process. Half of the CI runner's
+  // available CPUs leaves headroom for those services; two workers was the highest
+  // stable full-suite level measured on the local 12-CPU, 8-GB Docker host.
+  workers: process.env["CI"] === "true" ? "50%" : 2,
   retries: 0,
   projects: [
     {

--- a/src/daemons/daemons.test.ts
+++ b/src/daemons/daemons.test.ts
@@ -1401,6 +1401,7 @@ describe("daemon enrollment and execution", () => {
     hub.holdActivityRefresh(result.execution.id);
     const activity = hub.emitReplacementTurn(result.agentId);
     await hub.activityRefreshBegins();
+    await activity;
 
     const lateProcessing = hub.advanceDispatchTime(2 * 60_000);
     hub.releaseActivityRefresh();

--- a/src/db/agent-executions.integration.test.ts
+++ b/src/db/agent-executions.integration.test.ts
@@ -624,6 +624,14 @@ describe("agent execution PostgreSQL repository", () => {
   it("delivers a terminal workflow notification after restart when the crash happened before the hook", async () => {
     const fixture = await executionFixture(postgres);
     const delivered: string[] = [];
+    const restarted = createDurableWorkflowHandler({
+      database: fixture.database,
+      entitlements: createUnlimitedEntitlementsService(),
+      providers: [],
+      onWorkflowRunTerminal: async (terminalRun) => {
+        delivered.push(terminalRun.id);
+      },
+    });
     try {
       const trigger = await insertWorkflowTrigger(
         fixture.database,
@@ -649,16 +657,9 @@ describe("agent execution PostgreSQL repository", () => {
       ).run;
       await fixture.database.succeedTriggerRun(run.id);
 
-      const restarted = createDurableWorkflowHandler({
-        database: fixture.database,
-        entitlements: createUnlimitedEntitlementsService(),
-        providers: [],
-        onWorkflowRunTerminal: async (terminalRun) => {
-          delivered.push(terminalRun.id);
-        },
-      });
       await restarted.engine.processAvailable();
       await restarted.engine.processAvailable();
+      await restarted.engine.stop();
 
       assert.deepEqual(delivered, [run.id]);
       const persisted = await fixture.database.findTriggerRunById(run.id);
@@ -669,6 +670,7 @@ describe("agent execution PostgreSQL repository", () => {
         true,
       );
     } finally {
+      await restarted.engine.stop();
       await fixture.database.close();
     }
   });
@@ -678,6 +680,7 @@ describe("agent execution PostgreSQL repository", () => {
     let now = new Date("2026-08-05T12:00:00.000Z");
     const delivered: string[] = [];
     let failFirst = true;
+    const engines: Array<ReturnType<typeof createDurableWorkflowHandler>["engine"]> = [];
     try {
       const trigger = await insertWorkflowTrigger(
         fixture.database,
@@ -703,48 +706,39 @@ describe("agent execution PostgreSQL repository", () => {
       ).run;
       await fixture.database.succeedTriggerRun(run.id);
 
-      const engine = createDurableWorkflowHandler({
-        database: fixture.database,
-        entitlements: createUnlimitedEntitlementsService(),
-        providers: [],
-        now: () => now,
-        leaseMs: 1_000,
-        onWorkflowRunTerminal: async (terminalRun) => {
-          delivered.push(terminalRun.id);
-          if (failFirst) {
-            failFirst = false;
-            throw new Error("provider unavailable");
-          }
-        },
-      }).engine;
-      const processUntilDelivered = async (count: number) => {
-        for (let attempt = 0; attempt < 100; attempt += 1) {
-          await engine.processAvailable();
-          if (delivered.length === count) return;
-          await new Promise<void>((resolve) => setImmediate(resolve));
-        }
-        assert.fail(`terminal notification delivery count did not reach ${count}`);
+      const createEngine = () => {
+        const engine = createDurableWorkflowHandler({
+          database: fixture.database,
+          entitlements: createUnlimitedEntitlementsService(),
+          providers: [],
+          now: () => now,
+          leaseMs: 1_000,
+          onWorkflowRunTerminal: async (terminalRun) => {
+            delivered.push(terminalRun.id);
+            if (failFirst) {
+              failFirst = false;
+              throw new Error("provider unavailable");
+            }
+          },
+        }).engine;
+        engines.push(engine);
+        return engine;
       };
 
-      await processUntilDelivered(1);
+      const firstEngine = createEngine();
+      await firstEngine.processAvailable();
+      await firstEngine.stop();
       assert.deepEqual(delivered, [run.id]);
       const failedDelivery = await fixture.database.findTriggerRunById(run.id);
       assert.equal(failedDelivery?.outcome, "accepted");
       assert.equal(failedDelivery.terminalNotificationDeliveredAt, null);
 
       now = new Date("2026-08-05T12:00:01.001Z");
-      await processUntilDelivered(2);
+      const retryEngine = createEngine();
+      await retryEngine.processAvailable();
+      await retryEngine.stop();
 
-      let persisted = await fixture.database.findTriggerRunById(run.id);
-      for (let attempt = 0; attempt < 100; attempt += 1) {
-        if (persisted?.outcome === "accepted" && persisted.terminalNotificationDeliveredAt !== null)
-          break;
-        await new Promise<void>((resolve) => setImmediate(resolve));
-        persisted = await fixture.database.findTriggerRunById(run.id);
-      }
-
-      await engine.processAvailable();
-      await engine.stop();
+      const persisted = await fixture.database.findTriggerRunById(run.id);
 
       assert.deepEqual(delivered, [run.id, run.id]);
       assert.equal(
@@ -754,6 +748,7 @@ describe("agent execution PostgreSQL repository", () => {
         true,
       );
     } finally {
+      for (const engine of engines) await engine.stop();
       await fixture.database.close();
     }
   });


### PR DESCRIPTION
## Goals

- Make the activity-receipt/idle-deadline regression establish its producer-before-deadline and processing-after-deadline ordering deterministically.
- Make terminal workflow notification recovery tests wait at the existing engine lifecycle boundary for the durable delivery mark.
- Run isolated browser fixtures fully in parallel and use the highest measured stable worker level for this suite.

## Root-cause evidence

### Activity deadline

The failure was a test/harness ordering race. emitReplacementTurn() returned while the WebSocket producer could still be between sending turn_started and yielding. activityRefreshBegins() only observed the database refresh gate; the test then advanced the fake clock before awaiting the producer promise. The producer receipt and idle-expiration processing could therefore be ordered differently. The fix awaits that producer promise before advancing the clock. Production lifecycle behavior is unchanged: it keeps the registry ingress timestamp for the receipt-time deadline decision, so activity received before the deadline can extend it even when processing is later, while activity received at/after the deadline cannot resurrect the run.

### Terminal workflow notification

processAvailable() intentionally starts terminal notification recovery without waiting for it; this non-blocking behavior is covered by the engine tests and remains unchanged. The callback appends to delivered before the recovery worker persists terminalNotificationDeliveredAt, so the old assertion could observe the callback and race the database mark. The tests now await engine.stop(), which is the existing lifecycle boundary that waits for in-flight recovery and its durable mark. The retry test creates a fresh engine after the deterministic lease expiry, modeling the restart/retry boundary directly. The old polling loops were removed; assertions and failure behavior are unchanged.

## Browser E2E concurrency

The initial config serialized the suite with fullyParallel false and one worker. The fixture audit found each hub fixture is test-scoped and owns a fresh PostgreSQL container/database, built Hub child process, dynamically selected localhost port, unique machine-key file, and any source daemon process; teardown tracks and stops every resource. Provider fixtures and static test secrets are per-app/immutable. The parallel run exposed two mutable helper globals: the primary application pointer and MACHINE_KEY. Both were removed; each BuiltApplication carries its own machine key, and projectExternal resolves the primary application from the hub fixture.

The config now uses fullyParallel true and workers=50% when CI=true, which tracks available CPUs, with two workers locally. Measurements:

- Baseline exact CI run 31387199503: 72/72 passed, one worker, 12.5 minutes: https://github.com/getpaseo/hub/actions/runs/31387199503
- Local baseline on a 12-logical-CPU host with an 8-GB Docker limit: 630.93 seconds with one worker.
- Local two-worker exact command: 72 tests using two workers, 69 passed and the same three source-daemon cases failed because the local companion checkout is 781274ed while CI pins Paseo 5f127d1; wall clock 322.12 seconds. The remaining 69 tests passed.
- Three workers reduced one run to about 277 seconds but the exact default-three run also hit resource-sensitive PostgreSQL/UI failures. Four workers saturated the local Docker/host resources during startup. Two workers was the highest stable full-suite level measured locally.

The PR CI browser job uses the exact pinned companion checkout and will record the actual GitHub-hosted worker count in Playwright output. No retries were added; retries remains 0.

## Non-goals

- No production deadline, workflow-engine, deployment, or GitHub production behavior changes.
- No assertion weakening, skipped tests, arbitrary waits/timeouts, or retries.
- No source companion changes and no change to the current Hub deployment.

## Verification

- Focused activity regression: repeated 5 times.
- Focused terminal-notification pair: repeated 3 times.
- npm run typecheck
- npm run lint
- npm run format:check
- npm test: 98 files passed, 5 skipped; 693 tests passed, 15 skipped.
- Exact browser command run locally with the configured companion path; CI will run the same npm run test:e2e:browser command against the pinned source commit.