### PR TITLE
Scope provider reactions to workflow runs

### DIFF
--- a/drizzle/0033_tense_joseph.sql
+++ b/drizzle/0033_tense_joseph.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "agent_executions" ADD COLUMN "reaction_state" jsonb;--> statement-breakpoint
+ALTER TABLE "trigger_runs" ADD COLUMN "reaction_state" jsonb;

--- a/drizzle/meta/0033_snapshot.json
+++ b/drizzle/meta/0033_snapshot.json
@@ -1,0 +1,4992 @@
+{
+  "id": "a3e663d2-f414-44b5-ae30-f9b1b43f484d",
+  "prevId": "0fa8fa17-7feb-423d-9d2a-f5d18ca23242",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_executions": {
+      "name": "agent_executions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "machine_id": {
+          "name": "machine_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_execution_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_by_agent_at": {
+          "name": "completed_by_agent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deadline_at": {
+          "name": "deadline_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idle_deadline_at": {
+          "name": "idle_deadline_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_context": {
+          "name": "trigger_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_context": {
+          "name": "output_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reaction_state": {
+          "name": "reaction_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "configuration_revision_id": {
+          "name": "configuration_revision_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completion_token_hash": {
+          "name": "completion_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_claimed_at": {
+          "name": "reply_claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_claim_count": {
+          "name": "reply_claim_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_emissions": {
+          "name": "output_emissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "output_delivery_attempts": {
+          "name": "output_delivery_attempts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "launch_intent": {
+          "name": "launch_intent",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daemon_id": {
+          "name": "daemon_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daemon_agent_id": {
+          "name": "daemon_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_step_run_id": {
+          "name": "workflow_step_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hub_action": {
+          "name": "hub_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hub_action_completed_at": {
+          "name": "hub_action_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hub_action_ready_at": {
+          "name": "hub_action_ready_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hub_action_acknowledgements": {
+          "name": "hub_action_acknowledgements",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"terminal_at\":null,\"idle_at\":null,\"finish_execution_call\":null}'::jsonb"
+        }
+      },
+      "indexes": {
+        "agent_executions_machine_id_idx": {
+          "name": "agent_executions_machine_id_idx",
+          "columns": [
+            {
+              "expression": "machine_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_executions_project_started_at_idx": {
+          "name": "agent_executions_project_started_at_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_executions_status_idx": {
+          "name": "agent_executions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_executions_project_organization_fk": {
+          "name": "agent_executions_project_organization_fk",
+          "tableFrom": "agent_executions",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id", "organization_id"],
+          "columnsTo": ["id", "organization_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agent_executions_revision_project_organization_fk": {
+          "name": "agent_executions_revision_project_organization_fk",
+          "tableFrom": "agent_executions",
+          "tableTo": "project_configuration_revisions",
+          "columnsFrom": ["configuration_revision_id", "project_id", "organization_id"],
+          "columnsTo": ["id", "project_id", "organization_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agent_executions_machine_organization_fk": {
+          "name": "agent_executions_machine_organization_fk",
+          "tableFrom": "agent_executions",
+          "tableTo": "machines",
+          "columnsFrom": ["machine_id", "organization_id"],
+          "columnsTo": ["id", "org_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agent_executions_daemon_organization_fk": {
+          "name": "agent_executions_daemon_organization_fk",
+          "tableFrom": "agent_executions",
+          "tableTo": "daemons",
+          "columnsFrom": ["daemon_id", "organization_id"],
+          "columnsTo": ["id", "organization_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agent_executions_workflow_step_run_fk": {
+          "name": "agent_executions_workflow_step_run_fk",
+          "tableFrom": "agent_executions",
+          "tableTo": "workflow_step_runs",
+          "columnsFrom": ["workflow_step_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agent_executions_hub_action_check": {
+          "name": "agent_executions_hub_action_check",
+          "value": "\"agent_executions\".\"hub_action\" is null or \"agent_executions\".\"hub_action\" in ('interrupt', 'archive')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.attachment_capabilities": {
+      "name": "attachment_capabilities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider_event_receipt_id": {
+          "name": "provider_event_receipt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locator": {
+          "name": "locator",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "attachment_capabilities_receipt_provider_source_unique": {
+          "name": "attachment_capabilities_receipt_provider_source_unique",
+          "columns": [
+            {
+              "expression": "provider_event_receipt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attachment_capabilities_receipt_idx": {
+          "name": "attachment_capabilities_receipt_idx",
+          "columns": [
+            {
+              "expression": "provider_event_receipt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "attachment_capabilities_organization_id_organization_id_fk": {
+          "name": "attachment_capabilities_organization_id_organization_id_fk",
+          "tableFrom": "attachment_capabilities",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attachment_capabilities_receipt_organization_fk": {
+          "name": "attachment_capabilities_receipt_organization_fk",
+          "tableFrom": "attachment_capabilities",
+          "tableTo": "provider_event_receipts",
+          "columnsFrom": ["provider_event_receipt_id", "organization_id"],
+          "columnsTo": ["id", "organization_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "attachment_capabilities_provider_check": {
+          "name": "attachment_capabilities_provider_check",
+          "value": "\"attachment_capabilities\".\"provider\" in ('slack', 'discord')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_kind": {
+          "name": "actor_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_identity": {
+          "name": "actor_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_events_organization_created_idx": {
+          "name": "audit_events_organization_created_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_events_project_created_idx": {
+          "name": "audit_events_project_created_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_events_organization_id_organization_id_fk": {
+          "name": "audit_events_organization_id_organization_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audit_events_project_id_projects_id_fk": {
+          "name": "audit_events_project_id_projects_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audit_events_project_organization_fk": {
+          "name": "audit_events_project_organization_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id", "organization_id"],
+          "columnsTo": ["id", "organization_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "audit_events_actor_kind_check": {
+          "name": "audit_events_actor_kind_check",
+          "value": "\"audit_events\".\"actor_kind\" in ('user', 'github', 'system')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.billing_plan_prices": {
+      "name": "billing_plan_prices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lookup_key": {
+          "name": "lookup_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interval": {
+          "name": "interval",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_amount": {
+          "name": "unit_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "billing_plan_prices_plan_id_idx": {
+          "name": "billing_plan_prices_plan_id_idx",
+          "columns": [
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "billing_plan_prices_plan_id_billing_plans_id_fk": {
+          "name": "billing_plan_prices_plan_id_billing_plans_id_fk",
+          "tableFrom": "billing_plan_prices",
+          "tableTo": "billing_plans",
+          "columnsFrom": ["plan_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "billing_plan_prices_interval_check": {
+          "name": "billing_plan_prices_interval_check",
+          "value": "\"billing_plan_prices\".\"interval\" in ('monthly', 'annual')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.billing_plans": {
+      "name": "billing_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template": {
+          "name": "template",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_hash": {
+          "name": "template_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "marketing": {
+          "name": "marketing",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "billing_plans_slug_unique": {
+          "name": "billing_plans_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cli_authorizations": {
+      "name": "cli_authorizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_verifier": {
+          "name": "device_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code_verifier": {
+          "name": "user_code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint_verifier": {
+          "name": "fingerprint_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "poll_interval_seconds": {
+          "name": "poll_interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_poll_at": {
+          "name": "next_poll_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_organization_id": {
+          "name": "approved_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by_user_id": {
+          "name": "approved_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "cli_authorizations_fingerprint_idx": {
+          "name": "cli_authorizations_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "fingerprint_verifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cli_authorizations_status_expiry_idx": {
+          "name": "cli_authorizations_status_expiry_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cli_authorizations_device_verifier_unique": {
+          "name": "cli_authorizations_device_verifier_unique",
+          "nullsNotDistinct": false,
+          "columns": ["device_verifier"]
+        },
+        "cli_authorizations_user_code_verifier_unique": {
+          "name": "cli_authorizations_user_code_verifier_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_code_verifier"]
+        },
+        "cli_authorizations_credential_id_unique": {
+          "name": "cli_authorizations_credential_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["credential_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "cli_authorizations_status_check": {
+          "name": "cli_authorizations_status_check",
+          "value": "\"cli_authorizations\".\"status\" in ('pending', 'approved', 'denied', 'expired', 'disclosed')"
+        },
+        "cli_authorizations_poll_interval_check": {
+          "name": "cli_authorizations_poll_interval_check",
+          "value": "\"cli_authorizations\".\"poll_interval_seconds\" >= 5"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.configuration_sync_attempts": {
+      "name": "configuration_sync_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_connection_id": {
+          "name": "github_connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_repository_id": {
+          "name": "github_repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_delivery_id": {
+          "name": "webhook_delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "configuration_sync_attempts_project_created_idx": {
+          "name": "configuration_sync_attempts_project_created_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "configuration_sync_attempts_project_organization_fk": {
+          "name": "configuration_sync_attempts_project_organization_fk",
+          "tableFrom": "configuration_sync_attempts",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id", "organization_id"],
+          "columnsTo": ["id", "organization_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "configuration_sync_attempts_github_connection_organization_fk": {
+          "name": "configuration_sync_attempts_github_connection_organization_fk",
+          "tableFrom": "configuration_sync_attempts",
+          "tableTo": "github_connections",
+          "columnsFrom": ["github_connection_id", "organization_id"],
+          "columnsTo": ["id", "organization_id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daemon_enrollment_tokens": {
+      "name": "daemon_enrollment_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "verifier": {
+          "name": "verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_by_api_key_id": {
+          "name": "issued_by_api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_by_cli_credential_id": {
+          "name": "issued_by_cli_credential_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "daemon_enrollment_tokens_issued_by_cli_credential_id_organization_cli_credentials_id_fk": {
+          "name": "daemon_enrollment_tokens_issued_by_cli_credential_id_organization_cli_credentials_id_fk",
+          "tableFrom": "daemon_enrollment_tokens",
+          "tableTo": "organization_cli_credentials",
+          "columnsFrom": ["issued_by_cli_credential_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "daemon_enrollment_tokens_verifier_unique": {
+          "name": "daemon_enrollment_tokens_verifier_unique",
+          "nullsNotDistinct": false,
+          "columns": ["verifier"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daemons": {
+      "name": "daemons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enrollment_verifier": {
+          "name": "enrollment_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "machine_id": {
+          "name": "machine_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "daemon_public_key": {
+          "name": "daemon_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_verifier": {
+          "name": "credential_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registered_by_api_key_id": {
+          "name": "registered_by_api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registered_by_cli_credential_id": {
+          "name": "registered_by_cli_credential_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "presence": {
+          "name": "presence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'offline'"
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disconnected_at": {
+          "name": "disconnected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "daemons_machine_id_unique": {
+          "name": "daemons_machine_id_unique",
+          "columns": [
+            {
+              "expression": "machine_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "daemons_id_organization_unique": {
+          "name": "daemons_id_organization_unique",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "daemons_organization_slug_unique": {
+          "name": "daemons_organization_slug_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daemons_registered_by_cli_credential_id_organization_cli_credentials_id_fk": {
+          "name": "daemons_registered_by_cli_credential_id_organization_cli_credentials_id_fk",
+          "tableFrom": "daemons",
+          "tableTo": "organization_cli_credentials",
+          "columnsFrom": ["registered_by_cli_credential_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "daemons_machine_organization_fk": {
+          "name": "daemons_machine_organization_fk",
+          "tableFrom": "daemons",
+          "tableTo": "machines",
+          "columnsFrom": ["machine_id", "organization_id"],
+          "columnsTo": ["id", "org_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "daemons_idempotency_key_unique": {
+          "name": "daemons_idempotency_key_unique",
+          "nullsNotDistinct": false,
+          "columns": ["idempotency_key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "daemons_status_check": {
+          "name": "daemons_status_check",
+          "value": "\"daemons\".\"status\" in ('active', 'revoked')"
+        },
+        "daemons_presence_check": {
+          "name": "daemons_presence_check",
+          "value": "\"daemons\".\"presence\" in ('offline', 'connected')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.discord_connections": {
+      "name": "discord_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guild_name": {
+          "name": "guild_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connected_by_user_id": {
+          "name": "connected_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discord_connections_id_organization_unique": {
+          "name": "discord_connections_id_organization_unique",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discord_connections_organization_slug_unique": {
+          "name": "discord_connections_organization_slug_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_connections_organization_id_organization_id_fk": {
+          "name": "discord_connections_organization_id_organization_id_fk",
+          "tableFrom": "discord_connections",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "discord_connections_connected_by_user_id_user_id_fk": {
+          "name": "discord_connections_connected_by_user_id_user_id_fk",
+          "tableFrom": "discord_connections",
+          "tableTo": "user",
+          "columnsFrom": ["connected_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discord_connections_guild_id_unique": {
+          "name": "discord_connections_guild_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["guild_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entitlement_changes": {
+      "name": "entitlement_changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "before": {
+          "name": "before",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after": {
+          "name": "after",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "entitlement_changes_organization_created_idx": {
+          "name": "entitlement_changes_organization_created_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entitlement_changes_organization_id_organization_id_fk": {
+          "name": "entitlement_changes_organization_id_organization_id_fk",
+          "tableFrom": "entitlement_changes",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "entitlement_changes_source_check": {
+          "name": "entitlement_changes_source_check",
+          "value": "\"entitlement_changes\".\"source\" in ('provisioning', 'plan_stamp', 'override')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.github_connections": {
+      "name": "github_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connected_by_user_id": {
+          "name": "connected_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "github_connections_installation_unique": {
+          "name": "github_connections_installation_unique",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_connections_organization_slug_unique": {
+          "name": "github_connections_organization_slug_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_connections_id_organization_unique": {
+          "name": "github_connections_id_organization_unique",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_connections_organization_idx": {
+          "name": "github_connections_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_connections_organization_id_organization_id_fk": {
+          "name": "github_connections_organization_id_organization_id_fk",
+          "tableFrom": "github_connections",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_connections_connected_by_user_id_user_id_fk": {
+          "name": "github_connections_connected_by_user_id_user_id_fk",
+          "tableFrom": "github_connections",
+          "tableTo": "user",
+          "columnsFrom": ["connected_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "github_connections_installation_id_unique": {
+          "name": "github_connections_installation_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["installation_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "github_connections_status_check": {
+          "name": "github_connections_status_check",
+          "value": "\"github_connections\".\"status\" in ('active', 'suspended')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.github_repositories": {
+      "name": "github_repositories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discovered_at": {
+          "name": "discovered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_repositories_connection_repository_unique": {
+          "name": "github_repositories_connection_repository_unique",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_repositories_organization_idx": {
+          "name": "github_repositories_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_repositories_connection_organization_fk": {
+          "name": "github_repositories_connection_organization_fk",
+          "tableFrom": "github_repositories",
+          "tableTo": "github_connections",
+          "columnsFrom": ["connection_id", "organization_id"],
+          "columnsTo": ["id", "organization_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instance_bootstrap": {
+      "name": "instance_bootstrap",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "instance_bootstrap_organization_id_organization_id_fk": {
+          "name": "instance_bootstrap_organization_id_organization_id_fk",
+          "tableFrom": "instance_bootstrap",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "instance_bootstrap_owner_user_id_user_id_fk": {
+          "name": "instance_bootstrap_owner_user_id_user_id_fk",
+          "tableFrom": "instance_bootstrap",
+          "tableTo": "user",
+          "columnsFrom": ["owner_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "instance_bootstrap_completion_check": {
+          "name": "instance_bootstrap_completion_check",
+          "value": "\"instance_bootstrap\".\"completed_at\" is null or (\"instance_bootstrap\".\"organization_id\" is not null and \"instance_bootstrap\".\"owner_user_id\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitations_organization_status_idx": {
+          "name": "invitations_organization_status_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitations_pending_organization_email_unique": {
+          "name": "invitations_pending_organization_email_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invitation\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": ["inviter_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "invitations_role_check": {
+          "name": "invitations_role_check",
+          "value": "\"invitation\".\"role\" in ('admin', 'member')"
+        },
+        "invitations_status_check": {
+          "name": "invitations_status_check",
+          "value": "\"invitation\".\"status\" in ('pending', 'accepted', 'rejected', 'canceled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.machines": {
+      "name": "machines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "machine_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "terminated_at": {
+          "name": "terminated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shutdown_reason": {
+          "name": "shutdown_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_name": {
+          "name": "trigger_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_context": {
+          "name": "trigger_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "specs": {
+          "name": "specs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "machines_id_org_id_unique": {
+          "name": "machines_id_org_id_unique",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "machines_org_id_idx": {
+          "name": "machines_org_id_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "machines_status_idx": {
+          "name": "machines_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "members_organization_user_unique": {
+          "name": "members_organization_user_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "members_user_id_idx": {
+          "name": "members_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "members_organization_id_idx": {
+          "name": "members_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "members_role_check": {
+          "name": "members_role_check",
+          "value": "\"member\".\"role\" in ('owner', 'admin', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_api_keys": {
+      "name": "organization_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verifier": {
+          "name": "verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "organization_api_keys_prefix_unique": {
+          "name": "organization_api_keys_prefix_unique",
+          "columns": [
+            {
+              "expression": "prefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organization_api_keys_organization_created_idx": {
+          "name": "organization_api_keys_organization_created_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_api_keys_organization_id_organization_id_fk": {
+          "name": "organization_api_keys_organization_id_organization_id_fk",
+          "tableFrom": "organization_api_keys",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_api_keys_created_by_user_id_user_id_fk": {
+          "name": "organization_api_keys_created_by_user_id_user_id_fk",
+          "tableFrom": "organization_api_keys",
+          "tableTo": "user",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "organization_api_keys_scopes_check": {
+          "name": "organization_api_keys_scopes_check",
+          "value": "\"organization_api_keys\".\"scopes\" <@ ARRAY['projects:read', 'configuration:validate', 'configuration:install', 'runs:dispatch', 'daemons:enroll']::text[] and cardinality(\"organization_api_keys\".\"scopes\") > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_cli_credentials": {
+      "name": "organization_cli_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verifier": {
+          "name": "verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "organization_cli_credentials_prefix_unique": {
+          "name": "organization_cli_credentials_prefix_unique",
+          "columns": [
+            {
+              "expression": "prefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organization_cli_credentials_organization_created_idx": {
+          "name": "organization_cli_credentials_organization_created_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_cli_credentials_organization_id_organization_id_fk": {
+          "name": "organization_cli_credentials_organization_id_organization_id_fk",
+          "tableFrom": "organization_cli_credentials",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_cli_credentials_created_by_user_id_user_id_fk": {
+          "name": "organization_cli_credentials_created_by_user_id_user_id_fk",
+          "tableFrom": "organization_cli_credentials",
+          "tableTo": "user",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_connection_attempts": {
+      "name": "organization_connection_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_verifier": {
+          "name": "state_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "return_route": {
+          "name": "return_route",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_external_id": {
+          "name": "candidate_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pkce_verifier": {
+          "name": "pkce_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "organization_connection_attempts_expiry_idx": {
+          "name": "organization_connection_attempts_expiry_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_connection_attempts_organization_id_organization_id_fk": {
+          "name": "organization_connection_attempts_organization_id_organization_id_fk",
+          "tableFrom": "organization_connection_attempts",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_connection_attempts_user_id_user_id_fk": {
+          "name": "organization_connection_attempts_user_id_user_id_fk",
+          "tableFrom": "organization_connection_attempts",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_connection_attempts_session_id_session_id_fk": {
+          "name": "organization_connection_attempts_session_id_session_id_fk",
+          "tableFrom": "organization_connection_attempts",
+          "tableTo": "session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_connection_attempts_state_verifier_unique": {
+          "name": "organization_connection_attempts_state_verifier_unique",
+          "nullsNotDistinct": false,
+          "columns": ["state_verifier"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "organization_connection_attempts_provider_check": {
+          "name": "organization_connection_attempts_provider_check",
+          "value": "\"organization_connection_attempts\".\"provider\" in ('github', 'discord', 'slack')"
+        },
+        "organization_connection_attempts_phase_check": {
+          "name": "organization_connection_attempts_phase_check",
+          "value": "\"organization_connection_attempts\".\"phase\" in ('github_setup', 'github_user_authorization', 'discord_authorization', 'slack_authorization')"
+        },
+        "organization_connection_attempts_shape_check": {
+          "name": "organization_connection_attempts_shape_check",
+          "value": "(\"organization_connection_attempts\".\"phase\" = 'github_setup' and \"organization_connection_attempts\".\"provider\" = 'github' and \"organization_connection_attempts\".\"candidate_external_id\" is null and \"organization_connection_attempts\".\"pkce_verifier\" is null)\n        or (\"organization_connection_attempts\".\"phase\" = 'github_user_authorization' and \"organization_connection_attempts\".\"provider\" = 'github' and \"organization_connection_attempts\".\"candidate_external_id\" is not null and (\"organization_connection_attempts\".\"pkce_verifier\" is not null or \"organization_connection_attempts\".\"consumed_at\" is not null))\n        or (\"organization_connection_attempts\".\"phase\" = 'discord_authorization' and \"organization_connection_attempts\".\"provider\" = 'discord' and \"organization_connection_attempts\".\"candidate_external_id\" is null and \"organization_connection_attempts\".\"pkce_verifier\" is null)\n        or (\"organization_connection_attempts\".\"phase\" = 'slack_authorization' and \"organization_connection_attempts\".\"provider\" = 'slack' and \"organization_connection_attempts\".\"candidate_external_id\" is null and \"organization_connection_attempts\".\"pkce_verifier\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_entitlements": {
+      "name": "organization_entitlements",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "granted": {
+          "name": "granted",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overrides": {
+          "name": "overrides",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_version": {
+          "name": "plan_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stamped_at": {
+          "name": "stamped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_entitlements_organization_id_organization_id_fk": {
+          "name": "organization_entitlements_organization_id_organization_id_fk",
+          "tableFrom": "organization_entitlements",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_subscriptions": {
+      "name": "organization_subscriptions",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_subscriptions_organization_id_organization_id_fk": {
+          "name": "organization_subscriptions_organization_id_organization_id_fk",
+          "tableFrom": "organization_subscriptions",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_subscriptions_stripe_subscription_id_unique": {
+          "name": "organization_subscriptions_stripe_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["stripe_subscription_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_usage": {
+      "name": "organization_usage",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meter": {
+          "name": "meter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used": {
+          "name": "used",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "organization_usage_organization_meter_idx": {
+          "name": "organization_usage_organization_meter_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "meter",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_usage_organization_id_organization_id_fk": {
+          "name": "organization_usage_organization_id_organization_id_fk",
+          "tableFrom": "organization_usage",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "organization_usage_organization_id_meter_period_start_pk": {
+          "name": "organization_usage_organization_id_meter_period_start_pk",
+          "columns": ["organization_id", "meter", "period_start"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "organization_usage_used_non_negative": {
+          "name": "organization_usage_used_non_negative",
+          "value": "\"organization_usage\".\"used\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_configuration_revisions": {
+      "name": "project_configuration_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_evidence": {
+          "name": "source_evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_yaml": {
+          "name": "raw_yaml",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "normalized_configuration": {
+          "name": "normalized_configuration",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "validation_errors": {
+          "name": "validation_errors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_repository_id": {
+          "name": "github_repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_repository_full_name": {
+          "name": "github_repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_commit_sha": {
+          "name": "github_commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_commit_url": {
+          "name": "github_commit_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_ref": {
+          "name": "github_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_webhook_delivery_id": {
+          "name": "github_webhook_delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_sender": {
+          "name": "github_sender",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_author": {
+          "name": "github_author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_committer": {
+          "name": "github_committer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "validated_at": {
+          "name": "validated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "project_configuration_revisions_project_version_unique": {
+          "name": "project_configuration_revisions_project_version_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_configuration_revisions_id_project_organization_unique": {
+          "name": "project_configuration_revisions_id_project_organization_unique",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_configuration_revisions_project_created_idx": {
+          "name": "project_configuration_revisions_project_created_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_configuration_revisions_created_by_user_id_user_id_fk": {
+          "name": "project_configuration_revisions_created_by_user_id_user_id_fk",
+          "tableFrom": "project_configuration_revisions",
+          "tableTo": "user",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "project_configuration_revisions_project_organization_fk": {
+          "name": "project_configuration_revisions_project_organization_fk",
+          "tableFrom": "project_configuration_revisions",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id", "organization_id"],
+          "columnsTo": ["id", "organization_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "project_configuration_revisions_source_kind_check": {
+          "name": "project_configuration_revisions_source_kind_check",
+          "value": "\"project_configuration_revisions\".\"source_kind\" in ('github', 'manual')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_configuration_sources": {
+      "name": "project_configuration_sources",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_connection_id": {
+          "name": "github_connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_repository_id": {
+          "name": "github_repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_repository_full_name": {
+          "name": "github_repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_default_branch": {
+          "name": "github_default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "automatic_deployment_enabled": {
+          "name": "automatic_deployment_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "selected_by_user_id": {
+          "name": "selected_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_configuration_sources_selected_by_user_id_user_id_fk": {
+          "name": "project_configuration_sources_selected_by_user_id_user_id_fk",
+          "tableFrom": "project_configuration_sources",
+          "tableTo": "user",
+          "columnsFrom": ["selected_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "project_configuration_sources_project_organization_fk": {
+          "name": "project_configuration_sources_project_organization_fk",
+          "tableFrom": "project_configuration_sources",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id", "organization_id"],
+          "columnsTo": ["id", "organization_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_configuration_sources_github_connection_organization_fk": {
+          "name": "project_configuration_sources_github_connection_organization_fk",
+          "tableFrom": "project_configuration_sources",
+          "tableTo": "github_connections",
+          "columnsFrom": ["github_connection_id", "organization_id"],
+          "columnsTo": ["id", "organization_id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "project_configuration_sources_authority_shape_check": {
+          "name": "project_configuration_sources_authority_shape_check",
+          "value": "(\"project_configuration_sources\".\"kind\" = 'manual' and \"project_configuration_sources\".\"github_connection_id\" is null and \"project_configuration_sources\".\"github_repository_id\" is null and not \"project_configuration_sources\".\"automatic_deployment_enabled\") or (\"project_configuration_sources\".\"kind\" = 'github' and \"project_configuration_sources\".\"github_connection_id\" is not null and \"project_configuration_sources\".\"github_repository_id\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_trigger_routes": {
+      "name": "project_trigger_routes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configuration_revision_id": {
+          "name": "configuration_revision_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_name": {
+          "name": "trigger_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "project_trigger_routes_shape_unique": {
+          "name": "project_trigger_routes_shape_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "configuration_revision_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trigger_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_trigger_routes_resource_idx": {
+          "name": "project_trigger_routes_resource_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_trigger_routes_project_organization_fk": {
+          "name": "project_trigger_routes_project_organization_fk",
+          "tableFrom": "project_trigger_routes",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id", "organization_id"],
+          "columnsTo": ["id", "organization_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_trigger_routes_revision_project_organization_fk": {
+          "name": "project_trigger_routes_revision_project_organization_fk",
+          "tableFrom": "project_trigger_routes",
+          "tableTo": "project_configuration_revisions",
+          "columnsFrom": ["configuration_revision_id", "project_id", "organization_id"],
+          "columnsTo": ["id", "project_id", "organization_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "project_trigger_routes_provider_check": {
+          "name": "project_trigger_routes_provider_check",
+          "value": "\"project_trigger_routes\".\"provider\" in ('github', 'slack', 'discord')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_configuration_revision_id": {
+          "name": "active_configuration_revision_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "projects_organization_slug_unique": {
+          "name": "projects_organization_slug_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_id_organization_unique": {
+          "name": "projects_id_organization_unique",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_organization_status_idx": {
+          "name": "projects_organization_status_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_organization_id_organization_id_fk": {
+          "name": "projects_organization_id_organization_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "projects_created_by_user_id_user_id_fk": {
+          "name": "projects_created_by_user_id_user_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "user",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "projects_active_configuration_revision_id_project_configuration_revisions_id_fk": {
+          "name": "projects_active_configuration_revision_id_project_configuration_revisions_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "project_configuration_revisions",
+          "columnsFrom": ["active_configuration_revision_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "projects_status_check": {
+          "name": "projects_status_check",
+          "value": "\"projects\".\"status\" in ('active', 'archived')"
+        },
+        "projects_archive_shape_check": {
+          "name": "projects_archive_shape_check",
+          "value": "(\"projects\".\"status\" = 'active' and \"projects\".\"archived_at\" is null) or (\"projects\".\"status\" = 'archived' and \"projects\".\"archived_at\" is not null and \"projects\".\"active_configuration_revision_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.provider_event_receipts": {
+      "name": "provider_event_receipts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signature_hash": {
+          "name": "signature_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "dropped_reason": {
+          "name": "dropped_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_routes": {
+          "name": "accepted_routes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "provider_event_receipts_id_organization_unique": {
+          "name": "provider_event_receipts_id_organization_unique",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "provider_event_receipts_organization_delivery_unique": {
+          "name": "provider_event_receipts_organization_delivery_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "delivery_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "provider_event_receipts_signature_unique": {
+          "name": "provider_event_receipts_signature_unique",
+          "columns": [
+            {
+              "expression": "signature_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"provider_event_receipts\".\"signature_hash\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "provider_event_receipts_organization_received_idx": {
+          "name": "provider_event_receipts_organization_received_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "provider_event_receipts_resource_idx": {
+          "name": "provider_event_receipts_resource_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provider_event_receipts_organization_id_organization_id_fk": {
+          "name": "provider_event_receipts_organization_id_organization_id_fk",
+          "tableFrom": "provider_event_receipts",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "provider_event_receipts_provider_check": {
+          "name": "provider_event_receipts_provider_check",
+          "value": "\"provider_event_receipts\".\"provider\" in ('github', 'slack', 'discord', 'manual')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sessions_active_organization_id_idx": {
+          "name": "sessions_active_organization_id_idx",
+          "columns": [
+            {
+              "expression": "active_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_connections": {
+      "name": "slack_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_name": {
+          "name": "team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_access_token": {
+          "name": "bot_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "connected_by_user_id": {
+          "name": "connected_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "slack_connections_id_organization_unique": {
+          "name": "slack_connections_id_organization_unique",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "slack_connections_organization_slug_unique": {
+          "name": "slack_connections_organization_slug_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_connections_organization_id_organization_id_fk": {
+          "name": "slack_connections_organization_id_organization_id_fk",
+          "tableFrom": "slack_connections",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slack_connections_connected_by_user_id_user_id_fk": {
+          "name": "slack_connections_connected_by_user_id_user_id_fk",
+          "tableFrom": "slack_connections",
+          "tableTo": "user",
+          "columnsFrom": ["connected_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "slack_connections_team_id_unique": {
+          "name": "slack_connections_team_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["team_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trigger_runs": {
+      "name": "trigger_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configuration_revision_id": {
+          "name": "configuration_revision_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_event_receipt_id": {
+          "name": "provider_event_receipt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configured_trigger_name": {
+          "name": "configured_trigger_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'accepted'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_prompt": {
+          "name": "raw_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inputs": {
+          "name": "inputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "values": {
+          "name": "values",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "trigger_context": {
+          "name": "trigger_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "output_context": {
+          "name": "output_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "deadline_at": {
+          "name": "deadline_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deadline_kind": {
+          "name": "deadline_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reaction_state": {
+          "name": "reaction_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_notification_pending_at": {
+          "name": "terminal_notification_pending_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_notification_delivered_at": {
+          "name": "terminal_notification_delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_notification_lease_expires_at": {
+          "name": "terminal_notification_lease_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection": {
+          "name": "rejection",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "trigger_runs_receipt_project_configured_unique": {
+          "name": "trigger_runs_receipt_project_configured_unique",
+          "columns": [
+            {
+              "expression": "provider_event_receipt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "configured_trigger_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trigger_runs_status_deadline_idx": {
+          "name": "trigger_runs_status_deadline_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deadline_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trigger_runs_project_created_idx": {
+          "name": "trigger_runs_project_created_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trigger_runs_terminal_notification_idx": {
+          "name": "trigger_runs_terminal_notification_idx",
+          "columns": [
+            {
+              "expression": "terminal_notification_delivered_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "terminal_notification_lease_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trigger_runs_organization_fk": {
+          "name": "trigger_runs_organization_fk",
+          "tableFrom": "trigger_runs",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trigger_runs_project_organization_fk": {
+          "name": "trigger_runs_project_organization_fk",
+          "tableFrom": "trigger_runs",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id", "organization_id"],
+          "columnsTo": ["id", "organization_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trigger_runs_revision_project_organization_fk": {
+          "name": "trigger_runs_revision_project_organization_fk",
+          "tableFrom": "trigger_runs",
+          "tableTo": "project_configuration_revisions",
+          "columnsFrom": ["configuration_revision_id", "project_id", "organization_id"],
+          "columnsTo": ["id", "project_id", "organization_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "trigger_runs_receipt_organization_fk": {
+          "name": "trigger_runs_receipt_organization_fk",
+          "tableFrom": "trigger_runs",
+          "tableTo": "provider_event_receipts",
+          "columnsFrom": ["provider_event_receipt_id", "organization_id"],
+          "columnsTo": ["id", "organization_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "trigger_runs_status_check": {
+          "name": "trigger_runs_status_check",
+          "value": "\"trigger_runs\".\"status\" in ('running', 'succeeded', 'failed', 'timed_out', 'rejected')"
+        },
+        "trigger_runs_outcome_check": {
+          "name": "trigger_runs_outcome_check",
+          "value": "(\"trigger_runs\".\"outcome\" = 'accepted' and \"trigger_runs\".\"status\" <> 'rejected' and \"trigger_runs\".\"rejection\" is null)\n        or (\"trigger_runs\".\"outcome\" = 'rejected' and \"trigger_runs\".\"status\" = 'rejected' and \"trigger_runs\".\"rejection\" is not null)"
+        },
+        "trigger_runs_deadline_kind_check": {
+          "name": "trigger_runs_deadline_kind_check",
+          "value": "\"trigger_runs\".\"deadline_kind\" is null or \"trigger_runs\".\"deadline_kind\" in ('step_hard', 'step_idle', 'whole_run')"
+        },
+        "trigger_runs_deadline_shape_check": {
+          "name": "trigger_runs_deadline_shape_check",
+          "value": "(\"trigger_runs\".\"outcome\" = 'accepted' and \"trigger_runs\".\"deadline_at\" is not null)\n        or (\"trigger_runs\".\"outcome\" = 'rejected' and \"trigger_runs\".\"deadline_at\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "must_change_password": {
+          "name": "must_change_password",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_instance_operator": {
+          "name": "is_instance_operator",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_step_runs": {
+      "name": "workflow_step_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trigger_run_id": {
+          "name": "trigger_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_id": {
+          "name": "step_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_execution_id": {
+          "name": "agent_execution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deadline_kind": {
+          "name": "deadline_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deadline_at": {
+          "name": "deadline_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idle_deadline_at": {
+          "name": "idle_deadline_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatch_intent": {
+          "name": "dispatch_intent",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflow_step_runs_trigger_ordinal_unique": {
+          "name": "workflow_step_runs_trigger_ordinal_unique",
+          "columns": [
+            {
+              "expression": "trigger_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ordinal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_step_runs_trigger_step_unique": {
+          "name": "workflow_step_runs_trigger_step_unique",
+          "columns": [
+            {
+              "expression": "trigger_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "step_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_step_runs_agent_execution_unique": {
+          "name": "workflow_step_runs_agent_execution_unique",
+          "columns": [
+            {
+              "expression": "agent_execution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workflow_step_runs\".\"agent_execution_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_step_runs_trigger_status_idx": {
+          "name": "workflow_step_runs_trigger_status_idx",
+          "columns": [
+            {
+              "expression": "trigger_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_step_runs_trigger_run_fk": {
+          "name": "workflow_step_runs_trigger_run_fk",
+          "tableFrom": "workflow_step_runs",
+          "tableTo": "trigger_runs",
+          "columnsFrom": ["trigger_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_step_runs_status_check": {
+          "name": "workflow_step_runs_status_check",
+          "value": "\"workflow_step_runs\".\"status\" in ('pending', 'running', 'succeeded', 'skipped', 'failed', 'timed_out')"
+        },
+        "workflow_step_runs_deadline_kind_check": {
+          "name": "workflow_step_runs_deadline_kind_check",
+          "value": "\"workflow_step_runs\".\"deadline_kind\" is null or \"workflow_step_runs\".\"deadline_kind\" in ('step_hard', 'step_idle', 'whole_run')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_wakeups": {
+      "name": "workflow_wakeups",
+      "schema": "",
+      "columns": {
+        "trigger_run_id": {
+          "name": "trigger_run_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "available_at": {
+          "name": "available_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflow_wakeups_available_lease_idx": {
+          "name": "workflow_wakeups_available_lease_idx",
+          "columns": [
+            {
+              "expression": "available_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lease_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_wakeups_trigger_run_fk": {
+          "name": "workflow_wakeups_trigger_run_fk",
+          "tableFrom": "workflow_wakeups",
+          "tableTo": "trigger_runs",
+          "columnsFrom": ["trigger_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.agent_execution_status": {
+      "name": "agent_execution_status",
+      "schema": "public",
+      "values": ["spawning", "running", "succeeded", "failed"]
+    },
+    "public.machine_status": {
+      "name": "machine_status",
+      "schema": "public",
+      "values": ["spawning", "alive", "terminated"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -232,6 +232,13 @@
       "when": 1786190843844,
       "tag": "0032_tired_bulldozer",
       "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "7",
+      "when": 1786372632385,
+      "tag": "0033_tense_joseph",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -7,7 +7,12 @@ import {
   type AttachmentResolver,
 } from "./attachments/capabilities.js";
 import { ProjectConfigurationStore } from "./configuration/store.js";
-import type { Database, TriggerRunRecord, WorkflowDeadlineRecovery } from "./db/types.js";
+import type {
+  AcceptedTriggerRunRecord,
+  Database,
+  TriggerRunRecord,
+  WorkflowDeadlineRecovery,
+} from "./db/types.js";
 import { DatabaseUnavailableError } from "./db/errors.js";
 import {
   ActiveDaemonRegistry,
@@ -191,6 +196,10 @@ export function createHubApplication(options: HubRuntimeOptions): HubApplication
           onWorkflowDeadlineExceeded: async (recovery: WorkflowDeadlineRecovery) => {
             await daemonModule.lifecycle.recoverWorkflowDeadlineExecutions(recovery.executionIds);
           },
+          onWorkflowRunAccepted: (run: AcceptedTriggerRunRecord) =>
+            daemonModule.lifecycle.notifyWorkflowRunAccepted(run),
+          onWorkflowRunStarted: (run: AcceptedTriggerRunRecord) =>
+            daemonModule.lifecycle.notifyWorkflowRunStarted(run),
           onWorkflowRunTerminal: (run: TriggerRunRecord) =>
             daemonModule.lifecycle.notifyWorkflowRunTerminal(run),
         }),

--- a/src/daemons/daemons.test.ts
+++ b/src/daemons/daemons.test.ts
@@ -413,29 +413,6 @@ describe("daemon enrollment and execution", () => {
     assert.equal(hub.createdAgentRequestCount(), 2);
   });
 
-  it("registers durable fan-out before provider notification and waits to spawn", async () => {
-    await hub.connectDaemon();
-    await hub.installConfiguration({ yaml: hub.manualConfigurationYaml() });
-    hub.holdAcceptanceHook();
-
-    try {
-      const batch = await hub.handoffBatch(["first", "second"]);
-
-      assert.equal(batch.executions.length, 2);
-      assert.equal(await hub.pendingExecutionCount(), 2);
-      assert.equal(hub.createdAgentRequestCount(), 0);
-      assert.equal(hub.terminalHookCount(), 0);
-
-      hub.releaseAcceptanceHook();
-      await Promise.all(
-        batch.executions.map((execution) => hub.waitForRecoveredExecution(execution.id)),
-      );
-      assert.equal(hub.createdAgentRequestCount(), 2);
-    } finally {
-      hub.releaseAcceptanceHook();
-    }
-  });
-
   it("materializes provider-owned environment values without rewriting the authored prompt", async () => {
     const daemonId = await hub.connectDaemon();
     await hub.installConfiguration({ yaml: hub.manualConfigurationYaml() });
@@ -711,7 +688,7 @@ describe("daemon enrollment and execution", () => {
     assert.equal(hub.hookContexts().completed.length, 1);
 
     await hub.startExecution(second.daemonAgentId);
-    assert.equal(hub.hookContexts().started.length, 2);
+    assert.equal(hub.hookContexts().started.length, 0);
     await hub.completeExecution(second.id);
     await hub.waitForCompletionHookCount(2);
     assert.equal(hub.hookContexts().completed.length, 2);
@@ -1308,7 +1285,7 @@ describe("daemon enrollment and execution", () => {
     const execution = await hub.execution(result.execution.id);
     assert.deepEqual(
       { status: execution.status, result: execution.result },
-      { status: "failed", result: { status: "failed", reason: "whole_run_timeout" } },
+      { status: "failed", result: { status: "failed", reason: "timeout" } },
     );
     await hub.drainWorkflowOutbox();
     await hub.failureNotified();
@@ -1330,7 +1307,7 @@ describe("daemon enrollment and execution", () => {
     const execution = await hub.execution(result.execution.id);
     assert.deepEqual(
       { status: execution.status, result: execution.result },
-      { status: "failed", result: { status: "failed", reason: "step_idle_timeout" } },
+      { status: "failed", result: { status: "failed", reason: "idle_timeout" } },
     );
     assert.deepEqual(hub.controlActions(), ["interrupt"]);
   });
@@ -1448,7 +1425,7 @@ describe("daemon enrollment and execution", () => {
     const afterActivity = await hub.execution(result.execution.id);
     assert.deepEqual(
       { status: afterActivity.status, result: afterActivity.result },
-      { status: "failed", result: { status: "failed", reason: "step_idle_timeout" } },
+      { status: "failed", result: { status: "failed", reason: "idle_timeout" } },
     );
   });
 
@@ -1533,7 +1510,7 @@ describe("daemon enrollment and execution", () => {
     const execution = await hub.execution(result.execution.id);
     assert.deepEqual(execution.result, {
       status: "failed",
-      reason: "step_idle_timeout",
+      reason: "idle_timeout",
     });
   });
 
@@ -1550,7 +1527,7 @@ describe("daemon enrollment and execution", () => {
     await hub.advanceDispatchTime(60_000);
 
     const execution = await hub.execution(result.execution.id);
-    assert.deepEqual(execution.result, { status: "failed", reason: "whole_run_timeout" });
+    assert.deepEqual(execution.result, { status: "failed", reason: "timeout" });
   });
 
   it("keeps authenticated completion authoritative while idle", async () => {
@@ -1586,7 +1563,7 @@ describe("daemon enrollment and execution", () => {
     const execution = await hub.execution(result.execution.id);
     assert.deepEqual(execution.result, {
       status: "failed",
-      reason: "step_idle_timeout",
+      reason: "idle_timeout",
     });
   });
 

--- a/src/daemons/lifecycle.ts
+++ b/src/daemons/lifecycle.ts
@@ -13,6 +13,7 @@ import type {
   HubAction,
   TransitionAgentExecutionFields,
   TransitionAgentExecutionResult,
+  AcceptedTriggerRunRecord,
   TriggerRunRecord,
   WorkflowDeadlineKind,
   WorkflowAgentCompletionInput,
@@ -28,8 +29,10 @@ import {
   notifyAgentExecutionFailed,
   notifyAgentExecutionStarted,
   notifyAgentExecutionTerminal,
+  notifyDispatchAccepted,
   notifyMachineTerminated,
 } from "../triggers/lifecycle.js";
+import type { TriggerProviderReactionState } from "../triggers/index.js";
 import {
   DaemonCreateRejectedError,
   DaemonCreateResponseLostError,
@@ -205,34 +208,61 @@ export class DaemonDispatchLifecycle {
       }
       const resumable = await this.prepareClaimedDurableDispatch(execution);
       if (resumable !== undefined) {
-        this.startDurableDispatch(resumable, this.notifyDispatchAccepted(intent));
+        this.startDurableDispatch(resumable, this.notifyDispatchAccepted(intent, true));
       }
       return { execution };
     }
-    this.startDurableDispatch(prepared, this.notifyDispatchAccepted(intent));
+    this.startDurableDispatch(prepared, this.notifyDispatchAccepted(intent, true));
     return { execution: prepared.execution };
   }
 
-  async notifyWorkflowRunTerminal(run: TriggerRunRecord): Promise<void> {
-    if (run.outcome !== "accepted" || run.status === "running") return;
+  async notifyWorkflowRunAccepted(
+    run: AcceptedTriggerRunRecord,
+  ): Promise<TriggerProviderReactionState> {
     const provider = this.findProviderForTriggerContext(run.triggerContext);
-    if (provider === undefined) return;
+    if (provider === undefined) return run.reactionState;
+    return notifyDispatchAccepted({
+      provider,
+      triggerContext: run.triggerContext,
+      outputContext: run.outputContext,
+      reactionState: run.reactionState,
+    });
+  }
+
+  async notifyWorkflowRunStarted(
+    run: AcceptedTriggerRunRecord,
+  ): Promise<TriggerProviderReactionState> {
+    const provider = this.findProviderForTriggerContext(run.triggerContext);
+    if (provider === undefined) return run.reactionState;
+    return notifyAgentExecutionStarted({
+      provider,
+      triggerContext: run.triggerContext,
+      outputContext: run.outputContext,
+      reactionState: run.reactionState,
+    });
+  }
+
+  async notifyWorkflowRunTerminal(run: TriggerRunRecord): Promise<TriggerProviderReactionState> {
+    if (run.outcome !== "accepted" || run.status === "running") return null;
+    const provider = this.findProviderForTriggerContext(run.triggerContext);
+    if (provider === undefined) return run.reactionState;
     if (run.status === "succeeded") {
-      await notifyAgentExecutionCompleted({
+      return notifyAgentExecutionCompleted({
         provider,
         triggerContext: run.triggerContext,
         outputContext: run.outputContext,
         result: { status: "succeeded" },
+        reactionState: run.reactionState,
       });
-      return;
     }
-    await notifyAgentExecutionFailed({
+    return notifyAgentExecutionFailed({
       provider,
       triggerContext: run.triggerContext,
       outputContext: run.outputContext,
       reason:
         run.failureReason ??
         (run.status === "timed_out" ? "workflow_timed_out" : "workflow_failed"),
+      reactionState: run.reactionState,
     });
   }
 
@@ -470,9 +500,8 @@ export class DaemonDispatchLifecycle {
   ): Promise<DaemonDispatchResult> {
     const { intent, daemon, execution, completionToken, deadlineAt, publicBaseUrl } = prepared;
     try {
-      const provider = this.findProviderForTriggerContext(intent.triggerContext);
       if (notifyAccepted) {
-        await provider?.onDispatchAccepted?.(intent.triggerContext, intent.outputContext);
+        await this.notifyDispatchAccepted(intent, false, execution.id);
       }
 
       const agentId = await this.acquireAndSpawnAgent(
@@ -1310,27 +1339,46 @@ export class DaemonDispatchLifecycle {
     await this.options.database.completeHubAction(execution.id, action);
   }
 
-  private async notifyMachineTerminated(triggerContext: unknown, reason: string): Promise<void> {
+  private async notifyMachineTerminated(
+    triggerContext: unknown,
+    reason: string,
+    reactionState?: TriggerProviderReactionState,
+  ): Promise<TriggerProviderReactionState> {
     const provider = this.findProviderForTriggerContext(triggerContext);
     if (provider === undefined) {
-      return;
+      return reactionState ?? null;
     }
 
-    await notifyMachineTerminated({
+    return notifyMachineTerminated({
       provider,
       triggerContext,
       reason,
+      ...(reactionState === undefined ? {} : { reactionState }),
     });
   }
 
-  private notifyDispatchAccepted(intent: LaunchMachineIntent): Promise<void> {
+  private async notifyDispatchAccepted(
+    intent: LaunchMachineIntent,
+    swallowErrors = false,
+    executionId = durableExecutionId(intent),
+  ): Promise<void> {
+    if (intent.workflowStepRunId !== undefined && intent.workflowStepRunId !== null) return;
     const provider = this.findProviderForTriggerContext(intent.triggerContext);
-    if (provider?.onDispatchAccepted === undefined) return Promise.resolve();
-    return Promise.resolve()
-      .then(() => provider.onDispatchAccepted!(intent.triggerContext, intent.outputContext))
-      .catch((error: unknown) => {
-        this.logger.error({ err: error }, "provider acceptance hook failed");
+    if (provider === undefined) return;
+    const execution = await this.options.database.findAgentExecutionById(executionId);
+    if (execution === undefined) return;
+    try {
+      const reactionState = await notifyDispatchAccepted({
+        provider,
+        triggerContext: intent.triggerContext,
+        outputContext: intent.outputContext,
+        reactionState: execution.reactionState,
       });
+      await this.options.database.setAgentExecutionReactionState(execution.id, reactionState);
+    } catch (error: unknown) {
+      this.logger.error({ err: error }, "provider acceptance hook failed");
+      if (!swallowErrors) throw error;
+    }
   }
 
   private async notifyExecutionLifecycle(
@@ -1340,16 +1388,10 @@ export class DaemonDispatchLifecycle {
     const provider = this.findProviderForTriggerContext(execution.triggerContext);
     if (provider === undefined) return;
     if (execution.workflowStepRunId !== null) {
-      if (execution.status === "running") {
-        await notifyAgentExecutionStarted({
-          provider,
-          triggerContext: execution.triggerContext,
-          outputContext: execution.outputContext,
-        });
-      }
       return;
     }
-    await notifyIndividualExecution(provider, execution, failureReason);
+    const reactionState = await notifyIndividualExecution(provider, execution, failureReason);
+    await this.options.database.setAgentExecutionReactionState(execution.id, reactionState);
   }
 
   private async notifyExecutionTerminal(execution: AgentExecutionRecord): Promise<void> {
@@ -1387,10 +1429,14 @@ export class DaemonDispatchLifecycle {
     reason: string,
   ): Promise<void> {
     if (execution.workflowStepRunId !== null && execution.workflowStepRunId !== undefined) {
-      await this.notifyExecutionLifecycle(execution, reason);
       return;
     }
-    await this.notifyMachineTerminated(execution.triggerContext, reason);
+    const reactionState = await this.notifyMachineTerminated(
+      execution.triggerContext,
+      reason,
+      execution.reactionState,
+    );
+    await this.options.database.setAgentExecutionReactionState(execution.id, reactionState);
   }
 
   private findProviderForTriggerContext(triggerContext: unknown): TriggerProvider | undefined {
@@ -1807,26 +1853,29 @@ async function notifyIndividualExecution(
   provider: TriggerProvider,
   execution: AgentExecutionRecord,
   failureReason?: string,
-): Promise<void> {
+): Promise<TriggerProviderReactionState> {
   if (execution.status === "failed") {
-    await notifyAgentExecutionFailed({
+    return notifyAgentExecutionFailed({
       provider,
       triggerContext: execution.triggerContext,
       outputContext: execution.outputContext,
       reason: failureReason ?? executionFailureReason(execution) ?? "agent_execution_failed",
+      reactionState: execution.reactionState,
     });
   } else if (execution.status === "succeeded") {
-    await notifyAgentExecutionCompleted({
+    return notifyAgentExecutionCompleted({
       provider,
       triggerContext: execution.triggerContext,
       outputContext: execution.outputContext,
       result: { status: "succeeded" },
+      reactionState: execution.reactionState,
     });
   } else {
-    await notifyAgentExecutionStarted({
+    return notifyAgentExecutionStarted({
       provider,
       triggerContext: execution.triggerContext,
       outputContext: execution.outputContext,
+      reactionState: execution.reactionState,
     });
   }
 }

--- a/src/daemons/test-utils/hub-harness.ts
+++ b/src/daemons/test-utils/hub-harness.ts
@@ -419,7 +419,23 @@ export class HubHarness {
     const module = this.requireHub().daemonModule;
     if (!module) throw new Error("Daemon module is unavailable");
     const requested = { ...this.intent(), ...overrides };
-    const intent = await this.attachDispatchRun(requested, await this.insertTestReceipt(requested));
+    const run = await this.requireDatabase().createRejectedTriggerRun({
+      organizationId: requested.organizationId,
+      projectId: requested.projectId,
+      configurationRevisionId: requested.configurationRevisionId,
+      providerEventReceiptId: await this.insertTestReceipt(requested),
+      configuredTriggerName: requested.triggerName,
+      rawPrompt: requested.prompt,
+      prompt: requested.prompt,
+      inputs: {},
+      triggerContext: requested.triggerContext,
+      outputContext: requested.outputContext,
+      rejection: { code: "invalid_type", inputName: "individual", expectedType: "string" },
+    });
+    const { workflowStepRunId: _workflowStepRunId, ...intent } = {
+      ...requested,
+      triggerRunId: run.run.id,
+    };
     return dispatchLaunchMachineIntent(module, intent);
   }
   async handoff(

--- a/src/db/mappers.ts
+++ b/src/db/mappers.ts
@@ -144,6 +144,7 @@ export function toAgentExecutionRecord(row: AgentExecutionRow): AgentExecutionRe
     result: row.result,
     triggerContext: row.trigger_context,
     outputContext: row.output_context,
+    reactionState: row.reaction_state,
     configurationRevisionId: row.configuration_revision_id,
     completionTokenHash: row.completion_token_hash,
     replyClaimedAt: row.reply_claimed_at,

--- a/src/db/memory.ts
+++ b/src/db/memory.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type { AgentExecutionStatus, MachineStatus } from "./schema.js";
+import type { JsonValue } from "../config/compiler.js";
 import type { LaunchMachineIntent } from "../dispatcher/launch-machine-intent.js";
 import type {
   AgentExecutionRecord,
@@ -234,6 +235,7 @@ class MemoryDatabase implements Database {
       deadlineAt: input.deadlineAt,
       deadlineKind: null,
       failureReason: null,
+      reactionState: null,
       terminalNotificationPendingAt: null,
       terminalNotificationDeliveredAt: null,
       terminalNotificationLeaseExpiresAt: null,
@@ -942,7 +944,11 @@ class MemoryDatabase implements Database {
     return updated;
   }
 
-  async markWorkflowRunTerminalNotificationDelivered(triggerRunId: string, deliveredAt: Date) {
+  async markWorkflowRunTerminalNotificationDelivered(
+    triggerRunId: string,
+    deliveredAt: Date,
+    reactionState: JsonValue | null,
+  ) {
     const run = this.triggerRuns.get(triggerRunId);
     if (
       run === undefined ||
@@ -954,9 +960,18 @@ class MemoryDatabase implements Database {
     }
     this.triggerRuns.set(run.id, {
       ...run,
+      reactionState,
       terminalNotificationDeliveredAt: deliveredAt,
       terminalNotificationLeaseExpiresAt: null,
     });
+  }
+
+  async setWorkflowRunReactionState(triggerRunId: string, reactionState: JsonValue | null) {
+    const run = this.triggerRuns.get(triggerRunId);
+    if (run === undefined || run.outcome !== "accepted") return undefined;
+    const updated = { ...run, reactionState };
+    this.triggerRuns.set(run.id, updated);
+    return updated;
   }
 
   async markProviderEventDropped(
@@ -1290,6 +1305,7 @@ class MemoryDatabase implements Database {
       result: input.result ?? null,
       triggerContext: input.triggerContext,
       outputContext: input.outputContext,
+      reactionState: input.reactionState ?? null,
       configurationRevisionId: input.configurationRevisionId,
       completionTokenHash: input.completionTokenHash ?? null,
       replyClaimedAt: null,
@@ -1602,6 +1618,16 @@ class MemoryDatabase implements Database {
 
   async findAgentExecutionById(id: string): Promise<AgentExecutionRecord | undefined> {
     return this.agentExecutions.get(id);
+  }
+
+  async setAgentExecutionReactionState(
+    executionId: string,
+    reactionState: JsonValue | null,
+  ): Promise<AgentExecutionRecord> {
+    const execution = this.readAgentExecution(executionId);
+    const updated = { ...execution, reactionState };
+    this.agentExecutions.set(executionId, updated);
+    return updated;
   }
   async findAgentExecutionForOrganization(
     organizationId: string,

--- a/src/db/migrations.integration.test.ts
+++ b/src/db/migrations.integration.test.ts
@@ -304,7 +304,7 @@ describe("database migration application", () => {
     assert.deepEqual(after, before);
     assert.deepEqual(await historicalShape(fixture.url), {
       authTables: 7,
-      drizzleMigrations: 33,
+      drizzleMigrations: 34,
       legacyArtifacts: null,
       legacyOperatorPrincipals: null,
       bootstrapOrganizationId: fixture.organizationId,

--- a/src/db/pg.ts
+++ b/src/db/pg.ts
@@ -5,6 +5,7 @@ import { migrate } from "drizzle-orm/node-postgres/migrator";
 import { Pool } from "pg";
 import type { PoolClient, PoolConfig, QueryResultRow } from "pg";
 import type { LaunchMachineIntent } from "../dispatcher/launch-machine-intent.js";
+import type { JsonValue } from "../config/compiler.js";
 import { parseInvocationInputs, parseInvocationRejection } from "../triggers/invocation.js";
 import type { ProviderEventDropReasonCode } from "../triggers/drop-reason.js";
 import { logger } from "../logger.js";
@@ -331,7 +332,8 @@ class PgDatabase implements Database {
             launch_intent,
             workflow_step_run_id,
             result,
-            completed_at
+            completed_at,
+            reaction_state
           )
           select coalesce($1, gen_random_uuid()), $2, $3, $4, $5, $6::agent_execution_status, coalesce($7, now()), $8, $9, $10, $11,
                  $12,
@@ -341,7 +343,8 @@ class PgDatabase implements Database {
                    else least($12::timestamptz, $13::timestamptz)
                  end,
                  $14, $15, $16,
-                 case when $6 = 'failed'::agent_execution_status then coalesce($7, now()) else null end
+                 case when $6 = 'failed'::agent_execution_status then coalesce($7, now()) else null end,
+                 $17
           from projects
           where projects.id = $3 and projects.organization_id = $2 and projects.status = 'active'
             and exists (
@@ -375,6 +378,7 @@ class PgDatabase implements Database {
           input.launchIntent ?? null,
           input.workflowStepRunId ?? null,
           input.result ?? null,
+          input.reactionState ?? null,
         ],
       );
       const execution = rows.rows[0];
@@ -1223,17 +1227,38 @@ class PgDatabase implements Database {
     }
   }
 
-  async markWorkflowRunTerminalNotificationDelivered(triggerRunId: string, deliveredAt: Date) {
+  async markWorkflowRunTerminalNotificationDelivered(
+    triggerRunId: string,
+    deliveredAt: Date,
+    reactionState: JsonValue | null,
+  ) {
     await query(
       this.pool,
       `update trigger_runs
-       set terminal_notification_delivered_at = coalesce(terminal_notification_delivered_at, $2),
+       set reaction_state = $3,
+           terminal_notification_delivered_at = coalesce(terminal_notification_delivered_at, $2),
            terminal_notification_lease_expires_at = null
        where id = $1
          and terminal_notification_pending_at is not null
          and terminal_notification_delivered_at is null`,
-      [triggerRunId, deliveredAt],
+      [triggerRunId, deliveredAt, reactionState],
     );
+  }
+
+  async setWorkflowRunReactionState(triggerRunId: string, reactionState: JsonValue | null) {
+    const rows = await query<TriggerRunRow>(
+      this.pool,
+      `update trigger_runs
+       set reaction_state = $2
+       where id = $1 and outcome = 'accepted'
+       returning *`,
+      [triggerRunId, reactionState],
+    );
+    const row = rows.rows[0];
+    if (row === undefined) return undefined;
+    const run = toTriggerRunRecord(row);
+    if (run.outcome !== "accepted") throw new Error("trigger branch outcome conflict");
+    return run;
   }
 
   async recoverWorkflowDeadlines(now: Date): Promise<readonly WorkflowDeadlineRecovery[]> {
@@ -1960,6 +1985,23 @@ class PgDatabase implements Database {
     } catch (error) {
       throw toDatabaseError(error);
     }
+  }
+
+  async setAgentExecutionReactionState(
+    executionId: string,
+    reactionState: JsonValue | null,
+  ): Promise<AgentExecutionRecord> {
+    const rows = await query<AgentExecutionRow>(
+      this.pool,
+      `update agent_executions
+       set reaction_state = $2
+       where id = $1
+       returning *`,
+      [executionId, reactionState],
+    );
+    const row = rows.rows[0];
+    if (row === undefined) throw new Error(`agent execution not found: ${executionId}`);
+    return toAgentExecutionRecord(row);
   }
 
   async findAgentExecutionForOrganization(
@@ -4089,6 +4131,7 @@ interface TriggerRunRow extends QueryResultRow {
   deadline_at: Date | null;
   deadline_kind: WorkflowDeadlineKind | null;
   failure_reason: string | null;
+  reaction_state: JsonValue | null;
   terminal_notification_pending_at: Date | null;
   terminal_notification_delivered_at: Date | null;
   terminal_notification_lease_expires_at: Date | null;
@@ -4186,6 +4229,7 @@ function toTriggerRunRecord(row: TriggerRunRow): TriggerRunRecord {
     deadlineAt: row.deadline_at,
     deadlineKind: row.deadline_kind,
     failureReason: row.failure_reason,
+    reactionState: row.reaction_state,
     terminalNotificationPendingAt: row.terminal_notification_pending_at,
     terminalNotificationDeliveredAt: row.terminal_notification_delivered_at,
     terminalNotificationLeaseExpiresAt: row.terminal_notification_lease_expires_at,
@@ -4252,6 +4296,7 @@ export interface AgentExecutionRow extends QueryResultRow {
   result: unknown;
   trigger_context: unknown;
   output_context: unknown;
+  reaction_state: JsonValue | null;
   configuration_revision_id: string;
   completion_token_hash: string | null;
   reply_claimed_at: Date | null;

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -276,6 +276,7 @@ export const triggerRuns = pgTable(
     deadlineAt: timestamp("deadline_at", { withTimezone: true }),
     deadlineKind: text("deadline_kind").$type<"step_hard" | "step_idle" | "whole_run">(),
     failureReason: text("failure_reason"),
+    reactionState: jsonb("reaction_state"),
     terminalNotificationPendingAt: timestamp("terminal_notification_pending_at", {
       withTimezone: true,
     }),
@@ -550,6 +551,7 @@ export const agentExecutions = pgTable(
     result: jsonb(),
     triggerContext: jsonb("trigger_context"),
     outputContext: jsonb("output_context"),
+    reactionState: jsonb("reaction_state"),
     configurationRevisionId: uuid("configuration_revision_id").notNull(),
     completionTokenHash: text("completion_token_hash"),
     replyClaimedAt: timestamp("reply_claimed_at", { withTimezone: true }),

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -1,4 +1,5 @@
 import type { AgentExecutionStatus, MachineSource, MachineStatus } from "./schema.js";
+import type { JsonValue } from "../config/compiler.js";
 import type { LaunchMachineIntent } from "../dispatcher/launch-machine-intent.js";
 import type { InvocationRejection } from "../triggers/invocation.js";
 import type { ProviderEventDropReasonCode } from "../triggers/drop-reason.js";
@@ -102,6 +103,7 @@ export interface AgentExecutionRecord {
   result: unknown;
   triggerContext: unknown;
   outputContext: unknown;
+  reactionState: JsonValue | null;
   configurationRevisionId: string;
   completionTokenHash: string | null;
   replyClaimedAt: Date | null;
@@ -549,6 +551,7 @@ export interface InsertAgentExecutionInput {
   launchIntent?: LaunchMachineIntent | null;
   status?: "spawning" | "failed";
   result?: unknown;
+  reactionState?: JsonValue | null;
 }
 
 interface TriggerRunEvidence {
@@ -573,6 +576,7 @@ export interface AcceptedTriggerRunRecord extends TriggerRunEvidence {
   deadlineAt: Date;
   deadlineKind: WorkflowDeadlineKind | null;
   failureReason: string | null;
+  reactionState: JsonValue | null;
   terminalNotificationPendingAt: Date | null;
   terminalNotificationDeliveredAt: Date | null;
   terminalNotificationLeaseExpiresAt: Date | null;
@@ -1046,7 +1050,12 @@ export interface Database {
   markWorkflowRunTerminalNotificationDelivered(
     triggerRunId: string,
     deliveredAt: Date,
+    reactionState: JsonValue | null,
   ): Promise<void>;
+  setWorkflowRunReactionState(
+    triggerRunId: string,
+    reactionState: JsonValue | null,
+  ): Promise<AcceptedTriggerRunRecord | undefined>;
   recoverWorkflowDeadlines(now: Date): Promise<readonly WorkflowDeadlineRecovery[]>;
   recoverWorkflowWakeups(now: Date): Promise<void>;
   markProviderEventDropped(
@@ -1170,6 +1179,10 @@ export interface Database {
     toStatus: AgentExecutionStatus,
     fields?: TransitionAgentExecutionFields,
   ): Promise<TransitionAgentExecutionResult>;
+  setAgentExecutionReactionState(
+    executionId: string,
+    reactionState: JsonValue | null,
+  ): Promise<AgentExecutionRecord>;
   findRunningAgentExecutionsForMachine(machineId: string): Promise<AgentExecutionRecord[]>;
   findPendingAgentExecutions(): Promise<AgentExecutionRecord[]>;
   findPendingHubActions(daemonId?: string): Promise<AgentExecutionRecord[]>;

--- a/src/dispatcher/index.ts
+++ b/src/dispatcher/index.ts
@@ -22,6 +22,8 @@ export interface DispatcherOptions {
   workerIntervalMs?: number;
   now?: () => Date;
   onWorkflowDeadlineExceeded?: DurableWorkflowEngineOptions["onWorkflowDeadlineExceeded"];
+  onWorkflowRunAccepted?: DurableWorkflowEngineOptions["onWorkflowRunAccepted"];
+  onWorkflowRunStarted?: DurableWorkflowEngineOptions["onWorkflowRunStarted"];
   onWorkflowRunTerminal?: DurableWorkflowEngineOptions["onWorkflowRunTerminal"];
 }
 
@@ -56,6 +58,12 @@ export function createDispatcherWithEngine(options: DispatcherOptions): {
     ...(options.onWorkflowDeadlineExceeded === undefined
       ? {}
       : { onWorkflowDeadlineExceeded: options.onWorkflowDeadlineExceeded }),
+    ...(options.onWorkflowRunAccepted === undefined
+      ? {}
+      : { onWorkflowRunAccepted: options.onWorkflowRunAccepted }),
+    ...(options.onWorkflowRunStarted === undefined
+      ? {}
+      : { onWorkflowRunStarted: options.onWorkflowRunStarted }),
     ...(options.onWorkflowRunTerminal === undefined
       ? {}
       : { onWorkflowRunTerminal: options.onWorkflowRunTerminal }),

--- a/src/triggers/discord/provider.ts
+++ b/src/triggers/discord/provider.ts
@@ -4,7 +4,11 @@ import type {
   AttachmentDescriptor,
 } from "../../attachments/capabilities.js";
 import { logger } from "../../logger.js";
-import { type TriggerProvider, type TriggerProviderMatch } from "../index.js";
+import {
+  type TriggerProvider,
+  type TriggerProviderMatch,
+  type TriggerProviderReactionState,
+} from "../index.js";
 import type { DiscordBotClient } from "./bot.js";
 import {
   matchDiscordTriggers,
@@ -80,6 +84,8 @@ export interface DiscordOutputContext {
   threadId: string | null;
   messageId: string;
 }
+
+type DiscordReactionPhase = "accepted" | "started";
 
 export function createDiscordTriggerProvider(options: {
   configurationStoreForProject: (projectId: string) => ProjectConfigurationStore;
@@ -192,36 +198,71 @@ export function createDiscordTriggerProvider(options: {
         },
       };
     },
-    async onDispatchAccepted(triggerContext) {
+    async onDispatchAccepted(triggerContext, _outputContext, reactionState) {
+      if (discordReactionPhase(reactionState) !== undefined) return reactionState;
       await reactSafely(options.bot, triggerContext.target, "eyes");
+      return { phase: "accepted" };
     },
-    async onAgentExecutionStarted(triggerContext) {
+    async onAgentExecutionStarted(triggerContext, _outputContext, reactionState) {
+      if (discordReactionPhase(reactionState) === "started") return reactionState;
       await deleteReactionSafely(options.bot, triggerContext.target, "eyes");
       await reactSafely(options.bot, triggerContext.target, "hourglass");
+      return { phase: "started" };
     },
-    async onAgentExecutionCompleted(triggerContext) {
-      await deleteReactionSafely(options.bot, triggerContext.target, "hourglass");
+    async onAgentExecutionCompleted(triggerContext, _outputContext, _result, reactionState) {
+      await deleteReactionForPhase(options.bot, triggerContext.target, reactionState, "started");
       await react(options.bot, triggerContext.target, "white_check_mark");
+      return null;
     },
-    async onAgentExecutionFailed(triggerContext, _outputContext, reason) {
-      await deleteReactionSafely(options.bot, triggerContext.target, "eyes");
-      await deleteReactionSafely(options.bot, triggerContext.target, "hourglass");
+    async onAgentExecutionFailed(triggerContext, _outputContext, reason, reactionState) {
+      await deleteReactionForPhase(options.bot, triggerContext.target, reactionState);
       await react(options.bot, triggerContext.target, "x");
       await postThreadNotice(options.bot, triggerContext.target, `Paseo agent failed: ${reason}`);
+      return null;
     },
-    async onMachineTerminated(triggerContext, reason) {
+    async onMachineTerminated(triggerContext, reason, reactionState) {
       if (reason === "launch_failed" || reason === "daemon_disconnected") {
-        await deleteReactionSafely(options.bot, triggerContext.target, "eyes");
-        await deleteReactionSafely(options.bot, triggerContext.target, "hourglass");
+        await deleteReactionForPhase(options.bot, triggerContext.target, reactionState);
         await react(options.bot, triggerContext.target, "x");
         await postThreadNotice(
           options.bot,
           triggerContext.target,
           `Paseo machine terminated before the agent could complete: ${reason}`,
         );
+        return null;
       }
+      return reactionState;
     },
   };
+}
+
+async function deleteReactionForPhase(
+  bot: DiscordBotClient,
+  target: DiscordOutputContext,
+  reactionState: TriggerProviderReactionState | undefined,
+  fallbackPhase?: DiscordReactionPhase,
+): Promise<void> {
+  const phase = discordReactionPhase(reactionState) ?? fallbackPhase;
+  if (phase === "accepted") {
+    await deleteReactionSafely(bot, target, "eyes");
+    return;
+  }
+  if (phase === "started") {
+    await deleteReactionSafely(bot, target, "hourglass");
+    return;
+  }
+  await deleteReactionSafely(bot, target, "eyes");
+  await deleteReactionSafely(bot, target, "hourglass");
+}
+
+function discordReactionPhase(
+  reactionState: TriggerProviderReactionState | undefined,
+): DiscordReactionPhase | undefined {
+  if (typeof reactionState !== "object" || reactionState === null || Array.isArray(reactionState)) {
+    return undefined;
+  }
+  const phase = reactionState["phase"];
+  return phase === "accepted" || phase === "started" ? phase : undefined;
 }
 
 function buildDiscordMergeData(

--- a/src/triggers/github/provider.test.ts
+++ b/src/triggers/github/provider.test.ts
@@ -134,11 +134,20 @@ describe("GitHub Phase 1 trigger provider", () => {
     const provider = createProvider(store, reactions);
     const match = (await provider.match(external(project.id, revision.id, createEvent())))[0];
     if (!isAcceptedTriggerProviderMatch(match)) throw new Error("expected accepted match");
-    await provider.onDispatchAccepted?.(match.triggerContext, match.outputContext);
-    await provider.onAgentExecutionStarted?.(match.triggerContext, match.outputContext);
-    await provider.onAgentExecutionCompleted?.(match.triggerContext, match.outputContext, {
-      status: "succeeded",
-    });
+    let reactionState =
+      (await provider.onDispatchAccepted?.(match.triggerContext, match.outputContext)) ?? null;
+    reactionState =
+      (await provider.onAgentExecutionStarted?.(
+        match.triggerContext,
+        match.outputContext,
+        reactionState,
+      )) ?? reactionState;
+    await provider.onAgentExecutionCompleted?.(
+      match.triggerContext,
+      match.outputContext,
+      { status: "succeeded" },
+      reactionState,
+    );
     assert.deepEqual(
       reactions.created.map((call) => call.content),
       ["eyes", "rocket", "+1"],
@@ -152,8 +161,14 @@ describe("GitHub Phase 1 trigger provider", () => {
     const match = (await provider.match(external(project.id, revision.id, createEvent())))[0];
     if (!isAcceptedTriggerProviderMatch(match)) throw new Error("expected accepted match");
 
-    await provider.onDispatchAccepted?.(match.triggerContext, match.outputContext);
-    await provider.onAgentExecutionFailed?.(match.triggerContext, match.outputContext, "boom");
+    const reactionState =
+      (await provider.onDispatchAccepted?.(match.triggerContext, match.outputContext)) ?? null;
+    await provider.onAgentExecutionFailed?.(
+      match.triggerContext,
+      match.outputContext,
+      "boom",
+      reactionState,
+    );
 
     assert.deepEqual(
       reactions.created.map((call) => call.content),

--- a/src/triggers/github/provider.ts
+++ b/src/triggers/github/provider.ts
@@ -1,5 +1,10 @@
 import type { ProjectConfigurationStore } from "../../configuration/store.js";
-import { type TriggerProvider, type TriggerProviderMatch } from "../index.js";
+import type { JsonValue } from "../../config/compiler.js";
+import {
+  type TriggerProvider,
+  type TriggerProviderMatch,
+  type TriggerProviderReactionState,
+} from "../index.js";
 import type { GitHubAuth } from "../../auth/github.js";
 import { logger } from "../../logger.js";
 import {
@@ -114,7 +119,11 @@ export interface GitHubTriggerContext {
   target: { installationId: number; repository: string };
   event: GitHubMergeData;
   reactionSubject: GitHubReactionSubject | null;
-  inProgressReactionId?: number;
+}
+
+interface GitHubReactionState {
+  readonly [key: string]: JsonValue;
+  readonly reactionId: number;
 }
 
 export function createGitHubTriggerProvider(options: {
@@ -193,27 +202,28 @@ export function createGitHubTriggerProvider(options: {
     async materializeContext(launch) {
       return launch.triggerContext.event;
     },
-    async onDispatchAccepted(triggerContext) {
-      if (triggerContext.reactionSubject === null) return;
+    async onDispatchAccepted(triggerContext, _outputContext, reactionState) {
+      if (triggerContext.reactionSubject === null) return null;
+      if (githubReactionId(reactionState) !== undefined) return reactionState;
       const reaction = await options.reactions.createReaction({
         installationId: triggerContext.target.installationId,
         repo: triggerContext.target.repository,
         subject: triggerContext.reactionSubject,
         content: "eyes",
       });
-      triggerContext.inProgressReactionId = reaction.id;
+      return { reactionId: reaction.id } satisfies GitHubReactionState;
     },
-    async onAgentExecutionStarted(triggerContext) {
-      await reactToLifecycle(options.reactions, triggerContext, "rocket");
+    async onAgentExecutionStarted(triggerContext, _outputContext, reactionState) {
+      return reactToLifecycle(options.reactions, triggerContext, "rocket", reactionState);
     },
-    async onAgentExecutionCompleted(triggerContext) {
-      await createLifecycleReaction(options.reactions, triggerContext, "+1");
+    async onAgentExecutionCompleted(triggerContext, _outputContext, _result, reactionState) {
+      return reactToLifecycle(options.reactions, triggerContext, "+1", reactionState);
     },
-    async onAgentExecutionFailed(triggerContext) {
-      await reactToLifecycle(options.reactions, triggerContext, "-1");
+    async onAgentExecutionFailed(triggerContext, _outputContext, _reason, reactionState) {
+      return reactToLifecycle(options.reactions, triggerContext, "-1", reactionState);
     },
-    async onMachineTerminated(triggerContext) {
-      await reactToLifecycle(options.reactions, triggerContext, "-1");
+    async onMachineTerminated(triggerContext, _reason, reactionState) {
+      return reactToLifecycle(options.reactions, triggerContext, "-1", reactionState);
     },
   };
 }
@@ -276,46 +286,29 @@ async function reactToLifecycle(
   reactions: GitHubReactionClient,
   triggerContext: GitHubTriggerContext,
   content: GitHubReactionContent,
-): Promise<void> {
+  reactionState?: TriggerProviderReactionState,
+): Promise<GitHubReactionState | null> {
   if (triggerContext.reactionSubject === null) {
-    return;
+    return null;
   }
 
-  await deleteInProgressReactionSafely(reactions, triggerContext);
+  await deleteReactionSafely(reactions, triggerContext, githubReactionId(reactionState));
 
-  await reactions.createReaction({
+  const reaction = await reactions.createReaction({
     installationId: triggerContext.target.installationId,
     repo: triggerContext.target.repository,
     subject: triggerContext.reactionSubject,
     content,
   });
+  return { reactionId: reaction.id } satisfies GitHubReactionState;
 }
 
-async function createLifecycleReaction(
+async function deleteReactionSafely(
   reactions: GitHubReactionClient,
   triggerContext: GitHubTriggerContext,
-  content: GitHubReactionContent,
+  reactionId: number | undefined,
 ): Promise<void> {
-  if (triggerContext.reactionSubject === null) {
-    return;
-  }
-
-  await reactions.createReaction({
-    installationId: triggerContext.target.installationId,
-    repo: triggerContext.target.repository,
-    subject: triggerContext.reactionSubject,
-    content,
-  });
-}
-
-async function deleteInProgressReactionSafely(
-  reactions: GitHubReactionClient,
-  triggerContext: GitHubTriggerContext,
-): Promise<void> {
-  if (
-    triggerContext.reactionSubject === null ||
-    triggerContext.inProgressReactionId === undefined
-  ) {
+  if (triggerContext.reactionSubject === null || reactionId === undefined) {
     return;
   }
 
@@ -324,7 +317,7 @@ async function deleteInProgressReactionSafely(
       installationId: triggerContext.target.installationId,
       repo: triggerContext.target.repository,
       subject: triggerContext.reactionSubject,
-      reactionId: triggerContext.inProgressReactionId,
+      reactionId,
     });
   } catch (error) {
     logger.warn(
@@ -332,11 +325,19 @@ async function deleteInProgressReactionSafely(
         err: error,
         repo: triggerContext.target.repository,
         subject: triggerContext.reactionSubject,
-        reactionId: triggerContext.inProgressReactionId,
+        reactionId,
       },
       "github reaction cleanup failed",
     );
   }
+}
+
+function githubReactionId(state: TriggerProviderReactionState | undefined): number | undefined {
+  if (typeof state !== "object" || state === null || Array.isArray(state)) return undefined;
+  const reactionId = state["reactionId"];
+  return typeof reactionId === "number" && Number.isSafeInteger(reactionId)
+    ? reactionId
+    : undefined;
 }
 
 function reactionSubjectForEvent(event: NormalizedGitHubEvent): GitHubReactionSubject | null {

--- a/src/triggers/index.ts
+++ b/src/triggers/index.ts
@@ -97,6 +97,9 @@ export interface TriggerProviderLifecycleResult {
   summary?: string;
 }
 
+export type TriggerProviderReactionState = JsonValue | null;
+export type TriggerProviderReactionResult = void | TriggerProviderReactionState;
+
 export interface TriggerLaunchMaterialization<TriggerContext = unknown> {
   executionId: string;
   organizationId: string;
@@ -139,23 +142,34 @@ export interface TriggerProvider<
   materializeContext?(
     launch: TriggerContextMaterialization<TriggerContext>,
   ): Promise<MaterializedContext>;
-  onDispatchAccepted?(triggerContext: TriggerContext, outputContext: OutputContext): Promise<void>;
+  onDispatchAccepted?(
+    triggerContext: TriggerContext,
+    outputContext: OutputContext,
+    reactionState?: TriggerProviderReactionState,
+  ): Promise<TriggerProviderReactionResult>;
   onAgentExecutionStarted?(
     triggerContext: TriggerContext,
     outputContext: OutputContext,
-  ): Promise<void>;
+    reactionState?: TriggerProviderReactionState,
+  ): Promise<TriggerProviderReactionResult>;
   onAgentExecutionCompleted?(
     triggerContext: TriggerContext,
     outputContext: OutputContext,
     result: TriggerProviderLifecycleResult,
-  ): Promise<void>;
+    reactionState?: TriggerProviderReactionState,
+  ): Promise<TriggerProviderReactionResult>;
   onAgentExecutionFailed?(
     triggerContext: TriggerContext,
     outputContext: OutputContext,
     reason: string,
-  ): Promise<void>;
+    reactionState?: TriggerProviderReactionState,
+  ): Promise<TriggerProviderReactionResult>;
   onAgentExecutionTerminal?(executionId: string, triggerContext: TriggerContext): Promise<void>;
-  onMachineTerminated?(triggerContext: TriggerContext, reason: string): Promise<void>;
+  onMachineTerminated?(
+    triggerContext: TriggerContext,
+    reason: string,
+    reactionState?: TriggerProviderReactionState,
+  ): Promise<TriggerProviderReactionResult>;
 }
 
 function isJsonValue(value: unknown): value is JsonValue {

--- a/src/triggers/lifecycle.ts
+++ b/src/triggers/lifecycle.ts
@@ -1,11 +1,35 @@
-import type { TriggerProvider, TriggerProviderLifecycleResult } from "./index.js";
+import type {
+  TriggerProvider,
+  TriggerProviderLifecycleResult,
+  TriggerProviderReactionState,
+} from "./index.js";
+
+export async function notifyDispatchAccepted(input: {
+  provider: TriggerProvider;
+  triggerContext: unknown;
+  outputContext: unknown;
+  reactionState?: TriggerProviderReactionState;
+}): Promise<TriggerProviderReactionState> {
+  const result = await input.provider.onDispatchAccepted?.(
+    input.triggerContext,
+    input.outputContext,
+    input.reactionState,
+  );
+  return retainReactionState(input.reactionState, result);
+}
 
 export async function notifyAgentExecutionStarted(input: {
   provider: TriggerProvider;
   triggerContext: unknown;
   outputContext: unknown;
-}): Promise<void> {
-  await input.provider.onAgentExecutionStarted?.(input.triggerContext, input.outputContext);
+  reactionState?: TriggerProviderReactionState;
+}): Promise<TriggerProviderReactionState> {
+  const result = await input.provider.onAgentExecutionStarted?.(
+    input.triggerContext,
+    input.outputContext,
+    input.reactionState,
+  );
+  return retainReactionState(input.reactionState, result);
 }
 
 export async function notifyAgentExecutionCompleted(input: {
@@ -13,12 +37,15 @@ export async function notifyAgentExecutionCompleted(input: {
   triggerContext: unknown;
   outputContext: unknown;
   result: TriggerProviderLifecycleResult;
-}): Promise<void> {
-  await input.provider.onAgentExecutionCompleted?.(
+  reactionState?: TriggerProviderReactionState;
+}): Promise<TriggerProviderReactionState> {
+  const result = await input.provider.onAgentExecutionCompleted?.(
     input.triggerContext,
     input.outputContext,
     input.result,
+    input.reactionState,
   );
+  return retainReactionState(input.reactionState, result);
 }
 
 export async function notifyAgentExecutionFailed(input: {
@@ -26,12 +53,15 @@ export async function notifyAgentExecutionFailed(input: {
   triggerContext: unknown;
   outputContext: unknown;
   reason: string;
-}): Promise<void> {
-  await input.provider.onAgentExecutionFailed?.(
+  reactionState?: TriggerProviderReactionState;
+}): Promise<TriggerProviderReactionState> {
+  const result = await input.provider.onAgentExecutionFailed?.(
     input.triggerContext,
     input.outputContext,
     input.reason,
+    input.reactionState,
   );
+  return retainReactionState(input.reactionState, result);
 }
 
 export async function notifyAgentExecutionTerminal(input: {
@@ -46,6 +76,19 @@ export async function notifyMachineTerminated(input: {
   provider: TriggerProvider;
   triggerContext: unknown;
   reason: string;
-}): Promise<void> {
-  await input.provider.onMachineTerminated?.(input.triggerContext, input.reason);
+  reactionState?: TriggerProviderReactionState;
+}): Promise<TriggerProviderReactionState> {
+  const result = await input.provider.onMachineTerminated?.(
+    input.triggerContext,
+    input.reason,
+    input.reactionState,
+  );
+  return retainReactionState(input.reactionState, result);
+}
+
+function retainReactionState(
+  previous: TriggerProviderReactionState | undefined,
+  result: TriggerProviderReactionState | void,
+): TriggerProviderReactionState {
+  return result === undefined ? (previous ?? null) : result;
 }

--- a/src/triggers/slack/provider.ts
+++ b/src/triggers/slack/provider.ts
@@ -4,7 +4,11 @@ import type {
   AttachmentDescriptor,
 } from "../../attachments/capabilities.js";
 import { logger } from "../../logger.js";
-import { type TriggerProvider, type TriggerProviderMatch } from "../index.js";
+import {
+  type TriggerProvider,
+  type TriggerProviderMatch,
+  type TriggerProviderReactionState,
+} from "../index.js";
 import type { SlackBotClient, SlackThreadMessage } from "./client.js";
 import { NormalizedSlackMentionEventSchema, type NormalizedSlackMentionEvent } from "./events.js";
 import {
@@ -89,6 +93,8 @@ export interface SlackOutputContext {
   threadTs: string;
   messageTs: string;
 }
+
+type SlackReactionPhase = "accepted" | "started";
 
 export function createSlackTriggerProvider(options: {
   configurationStoreForProject: (projectId: string) => ProjectConfigurationStore;
@@ -226,23 +232,63 @@ export function createSlackTriggerProvider(options: {
         },
       };
     },
-    async onAgentExecutionStarted(context) {
+    async onDispatchAccepted(_triggerContext, _outputContext, reactionState) {
+      if (slackReactionPhase(reactionState) !== undefined) return reactionState;
+      return { phase: "accepted" };
+    },
+    async onAgentExecutionStarted(context, _outputContext, reactionState) {
+      if (slackReactionPhase(reactionState) === "started") return reactionState;
       await replaceReaction(options.client, context.target, "eyes", "hourglass_flowing_sand");
+      return { phase: "started" };
     },
-    async onAgentExecutionCompleted(context) {
-      await removeReactionSafely(options.client, context.target, "hourglass_flowing_sand");
+    async onAgentExecutionCompleted(context, _outputContext, _result, reactionState) {
+      await removeReactionForPhase(options.client, context.target, reactionState, "started");
       await addReaction(options.client, context.target, "white_check_mark");
+      return null;
     },
-    async onAgentExecutionFailed(context, _output, reason) {
-      await failWithNotice(options.client, context.target, reason);
+    async onAgentExecutionFailed(context, _output, reason, reactionState) {
+      await failWithNotice(options.client, context.target, reason, reactionState);
+      return null;
     },
-    async onMachineTerminated(context, reason) {
+    async onMachineTerminated(context, reason, reactionState) {
       if (reason === "launch_failed" || reason === "daemon_disconnected") {
-        await failWithNotice(options.client, context.target, reason);
+        await failWithNotice(options.client, context.target, reason, reactionState);
+        return null;
       }
+      return reactionState;
     },
   };
 }
+
+async function removeReactionForPhase(
+  client: SlackBotClient,
+  target: SlackOutputContext,
+  reactionState: TriggerProviderReactionState | undefined,
+  fallbackPhase?: SlackReactionPhase,
+): Promise<void> {
+  const phase = slackReactionPhase(reactionState) ?? fallbackPhase;
+  if (phase === "accepted") {
+    await removeReactionSafely(client, target, "eyes");
+    return;
+  }
+  if (phase === "started") {
+    await removeReactionSafely(client, target, "hourglass_flowing_sand");
+    return;
+  }
+  await removeReactionSafely(client, target, "eyes");
+  await removeReactionSafely(client, target, "hourglass_flowing_sand");
+}
+
+function slackReactionPhase(
+  reactionState: TriggerProviderReactionState | undefined,
+): SlackReactionPhase | undefined {
+  if (typeof reactionState !== "object" || reactionState === null || Array.isArray(reactionState)) {
+    return undefined;
+  }
+  const phase = reactionState["phase"];
+  return phase === "accepted" || phase === "started" ? phase : undefined;
+}
+
 function buildSlackMergeData(
   event: NormalizedSlackMentionEvent,
   botUserId: string,
@@ -331,9 +377,9 @@ async function failWithNotice(
   client: SlackBotClient,
   event: SlackOutputContext,
   reason: string,
+  reactionState?: TriggerProviderReactionState,
 ): Promise<void> {
-  await removeReactionSafely(client, event, "eyes");
-  await removeReactionSafely(client, event, "hourglass_flowing_sand");
+  await removeReactionForPhase(client, event, reactionState);
   await addReaction(client, event, "x");
   await client.sendMessage({
     organizationId: event.organizationId,

--- a/src/workflows/engine.ts
+++ b/src/workflows/engine.ts
@@ -5,6 +5,7 @@ import type {
   DurableProviderEvent,
   MeterReservation,
   MeterReservationDenied,
+  AcceptedTriggerRunRecord,
   TriggerRunRecord,
   WorkflowWakeupRecord,
   WorkflowDeadlineRecovery,
@@ -70,7 +71,9 @@ export interface DurableWorkflowEngineOptions {
   workerIntervalMs?: number;
   now?: () => Date;
   onWorkflowDeadlineExceeded?: (recovery: WorkflowDeadlineRecovery) => Promise<void>;
-  onWorkflowRunTerminal?: (run: TriggerRunRecord) => Promise<void>;
+  onWorkflowRunAccepted?: (run: AcceptedTriggerRunRecord) => Promise<JsonValue | null | void>;
+  onWorkflowRunStarted?: (run: AcceptedTriggerRunRecord) => Promise<JsonValue | null | void>;
+  onWorkflowRunTerminal?: (run: TriggerRunRecord) => Promise<JsonValue | null | void>;
 }
 
 export class DurableWorkflowEngine {
@@ -163,7 +166,7 @@ export class DurableWorkflowEngine {
         // Accepting a trigger reserves nothing: a trigger can skip every step, and multi-step
         // workflows create several executions. Metering happens per execution, at creation time
         // (see processWakeup), so the meter is genuinely per-execution and atomic with the work.
-        await this.options.database!.createAcceptedTriggerRun({
+        const created = await this.options.database!.createAcceptedTriggerRun({
           organizationId: trigger.organizationId,
           projectId: trigger.projectId,
           configurationRevisionId,
@@ -178,6 +181,7 @@ export class DurableWorkflowEngine {
           stepIds: compiledTrigger.steps.map((step) => step.id),
           createdAt,
         });
+        if (created.created) await this.deliverWorkflowRunAccepted(created.run);
       }),
     );
     return { providerEventReceiptId: trigger.providerEventReceiptId };
@@ -217,7 +221,7 @@ export class DurableWorkflowEngine {
     if (database === null) return;
     const prepared = await this.prepareWorkflowWakeup(wakeup);
     if (prepared === undefined) return;
-    const { run, configuration, trigger, next, step, context, recoverPreHandoffDispatch } =
+    const { run, configuration, trigger, steps, next, step, context, recoverPreHandoffDispatch } =
       prepared;
     let shouldRun = true;
     try {
@@ -296,7 +300,14 @@ export class DurableWorkflowEngine {
       await database.deleteWorkflowWakeup(run.id);
       return;
     }
-    await database.linkWorkflowStepRunExecution(next.id, created.execution.id, intent);
+    await this.linkWorkflowStepAndNotifyStart(
+      database,
+      run.id,
+      steps,
+      next.id,
+      created.execution.id,
+      intent,
+    );
     if (!created.created) {
       await this.handleExistingWorkflowExecution(
         created.execution,
@@ -313,6 +324,20 @@ export class DurableWorkflowEngine {
     }
     await this.finishPersistedExecution(execution);
     await database.deleteWorkflowWakeup(run.id);
+  }
+
+  private async linkWorkflowStepAndNotifyStart(
+    database: Database,
+    triggerRunId: string,
+    steps: readonly WorkflowStepRun[],
+    stepRunId: string,
+    executionId: string,
+    intent: LaunchMachineIntent,
+  ): Promise<void> {
+    await database.linkWorkflowStepRunExecution(stepRunId, executionId, intent);
+    if (steps.some((candidate) => candidate.startedAt !== null)) return;
+    const started = await database.findTriggerRunById(triggerRunId);
+    if (started?.outcome === "accepted") await this.deliverWorkflowRunStarted(started);
   }
 
   /**
@@ -600,6 +625,34 @@ export class DurableWorkflowEngine {
     return Promise.resolve();
   }
 
+  private async deliverWorkflowRunAccepted(run: AcceptedTriggerRunRecord): Promise<void> {
+    const callback = this.options.onWorkflowRunAccepted;
+    if (callback === undefined || this.options.database === null) return;
+    try {
+      const result = await callback(run);
+      await this.options.database.setWorkflowRunReactionState(
+        run.id,
+        result === undefined ? run.reactionState : result,
+      );
+    } catch (error: unknown) {
+      this.logger.error({ err: error, triggerRunId: run.id }, "workflow accepted reaction failed");
+    }
+  }
+
+  private async deliverWorkflowRunStarted(run: AcceptedTriggerRunRecord): Promise<void> {
+    const callback = this.options.onWorkflowRunStarted;
+    if (callback === undefined || this.options.database === null) return;
+    try {
+      const result = await callback(run);
+      await this.options.database.setWorkflowRunReactionState(
+        run.id,
+        result === undefined ? run.reactionState : result,
+      );
+    } catch (error: unknown) {
+      this.logger.error({ err: error, triggerRunId: run.id }, "workflow started reaction failed");
+    }
+  }
+
   private kickTerminalNotificationRecovery(): void {
     if (this.options.database === null || this.stopped) return;
     if (this.terminalNotificationProcessing !== undefined) return;
@@ -622,8 +675,14 @@ export class DurableWorkflowEngine {
       );
       if (run === undefined) return;
       try {
-        await this.options.onWorkflowRunTerminal?.(run);
-        await database.markWorkflowRunTerminalNotificationDelivered(run.id, this.now());
+        const reactionState = await this.options.onWorkflowRunTerminal?.(run);
+        const deliveredReactionState =
+          reactionState === undefined ? terminalReactionState(run) : reactionState;
+        await database.markWorkflowRunTerminalNotificationDelivered(
+          run.id,
+          this.now(),
+          deliveredReactionState,
+        );
       } catch (error) {
         this.logger.error(
           { err: error, triggerRunId: run.id },
@@ -953,6 +1012,11 @@ function asProjectConfiguration(
 
 function truthy(value: unknown): boolean {
   return value !== false && value !== null && value !== undefined && value !== 0 && value !== "";
+}
+
+function terminalReactionState(run: TriggerRunRecord): JsonValue | null {
+  if (run.outcome === "accepted") return run.reactionState;
+  return null;
 }
 
 async function collectProviderMatches(

--- a/src/workflows/reactions.test.ts
+++ b/src/workflows/reactions.test.ts
@@ -1,0 +1,534 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { describe, it } from "vitest";
+import { deriveAgentExecutionCompletionToken } from "../agent-executions/completion-token.js";
+import { ProjectConfigurationStore } from "../configuration/store.js";
+import { createMemoryDatabase } from "../db/memory.js";
+import type { Database } from "../db/types.js";
+import {
+  createDaemonDispatchLifecycle,
+  type DaemonDispatchLifecycle,
+} from "../daemons/lifecycle.js";
+import type { DaemonConnection } from "../daemons/protocol.js";
+import { createUnlimitedEntitlementsService } from "../entitlements/test-utils.js";
+import {
+  createActiveProjectConfiguration,
+  TEST_DAEMON_ID,
+  TEST_DAEMON_SLUG,
+} from "../test-utils/project-configuration.js";
+import type { DiscordBotClient } from "../triggers/discord/bot.js";
+import { createDiscordTriggerProvider } from "../triggers/discord/provider.js";
+import type { GitHubReactionClient } from "../triggers/github/provider.js";
+import { createGitHubTriggerProvider } from "../triggers/github/provider.js";
+import type { SlackBotClient } from "../triggers/slack/client.js";
+import { createSlackTriggerProvider } from "../triggers/slack/provider.js";
+import type { TriggerProvider } from "../triggers/index.js";
+import { createDurableWorkflowHandler } from "./engine.js";
+
+describe("workflow-owned provider reactions", () => {
+  it("uses one reaction sequence for a two-step Discord workflow", async () => {
+    const result = await runTwoStepWorkflow(createDiscordReactionFixture());
+
+    assert.deepEqual(result.visible(), ["✅"]);
+    assert.deepEqual(result.calls(), {
+      created: ["👀", "⏳", "✅"],
+      deleted: ["👀", "⏳"],
+    });
+    assert.equal(result.run.status, "succeeded");
+  });
+
+  it("uses one reaction sequence for a two-step Slack workflow", async () => {
+    const result = await runTwoStepWorkflow(createSlackReactionFixture());
+
+    assert.deepEqual(result.visible(), ["white_check_mark"]);
+    assert.deepEqual(result.calls(), [
+      "remove:eyes",
+      "add:hourglass_flowing_sand",
+      "remove:hourglass_flowing_sand",
+      "add:white_check_mark",
+    ]);
+    assert.equal(result.run.status, "succeeded");
+  });
+
+  it("removes the accepted reaction when every workflow step is skipped", async () => {
+    const result = await runTwoStepWorkflow(createDiscordReactionFixture(), {
+      skipAllSteps: true,
+    });
+
+    assert.deepEqual(result.visible(), ["✅"]);
+    assert.deepEqual(result.calls(), {
+      created: ["👀", "✅"],
+      deleted: ["👀"],
+    });
+  });
+
+  it("keeps GitHub reaction state out of immutable trigger context", async () => {
+    const fixture = createGitHubReactionFixture();
+    const original = structuredClone(fixture.triggerContext);
+    const result = await runTwoStepWorkflow(fixture);
+
+    assert.deepEqual(fixture.triggerContext, original);
+    assert.deepEqual(result.visible(), ["+1"]);
+    assert.deepEqual(result.calls(), {
+      created: ["eyes", "rocket", "+1"],
+      deleted: [1, 2],
+    });
+  });
+
+  it("uses one reaction sequence for a two-step GitHub workflow", async () => {
+    const result = await runTwoStepWorkflow(createGitHubReactionFixture());
+
+    assert.deepEqual(result.visible(), ["+1"]);
+    assert.deepEqual(result.calls(), {
+      created: ["eyes", "rocket", "+1"],
+      deleted: [1, 2],
+    });
+    assert.deepEqual(result.run.reactionState, { reactionId: 3 });
+    assert.equal(result.run.status, "succeeded");
+  });
+
+  it.each(["step_failure", "timeout", "prelaunch_failure"] as const)(
+    "converges %s to one terminal workflow reaction",
+    async (outcome) => {
+      const fixture = createDiscordReactionFixture();
+      const result = await runTwoStepWorkflow(fixture, { outcome });
+
+      assert.deepEqual(result.visible(), ["❌"]);
+      const calls = result.calls();
+      assert.equal(calls.created.filter((emoji) => emoji === "❌").length, 1);
+      assert.equal(calls.created.filter((emoji) => emoji === "👀").length, 1);
+      assert.equal(calls.created.filter((emoji) => emoji === "⏳").length, 1);
+    },
+  );
+
+  it.each(["step_failure", "timeout", "prelaunch_failure"] as const)(
+    "converges Slack %s without a stale workflow reaction",
+    async (outcome) => {
+      const result = await runTwoStepWorkflow(createSlackReactionFixture(), { outcome });
+
+      assert.deepEqual(result.visible(), ["x"]);
+      assert.deepEqual(result.calls(), [
+        "remove:eyes",
+        "add:hourglass_flowing_sand",
+        "remove:hourglass_flowing_sand",
+        "add:x",
+      ]);
+    },
+  );
+
+  it.each(["step_failure", "timeout", "prelaunch_failure"] as const)(
+    "converges GitHub %s without a stale workflow reaction",
+    async (outcome) => {
+      const result = await runTwoStepWorkflow(createGitHubReactionFixture(), { outcome });
+
+      assert.deepEqual(result.visible(), ["-1"]);
+      assert.deepEqual(result.calls(), {
+        created: ["eyes", "rocket", "-1"],
+        deleted: [1, 2],
+      });
+      assert.deepEqual(result.run.reactionState, { reactionId: 3 });
+    },
+  );
+});
+
+function createDiscordReactionFixture() {
+  const bot = new RecordingDiscordBot();
+  const provider = createDiscordTriggerProvider({
+    configurationStoreForProject: () =>
+      new ProjectConfigurationStore(createMemoryDatabase(), "unused"),
+    bot,
+  });
+  return {
+    provider,
+    triggerContext: {
+      provider: "discord",
+      target: {
+        provider: "discord",
+        guildId: "guild-1",
+        channelId: "channel-1",
+        threadId: null,
+        messageId: "message-1",
+      },
+      event: {},
+    },
+    outputContext: {
+      provider: "discord",
+      guildId: "guild-1",
+      channelId: "channel-1",
+      threadId: null,
+      messageId: "message-1",
+    },
+    visible: () => visibleDiscordReactions(bot),
+    calls: () => ({
+      created: bot.reactions.map((reaction) => reaction.emoji),
+      deleted: bot.deletedOwnReactions.map((reaction) => reaction.emoji),
+    }),
+  };
+}
+
+function createSlackReactionFixture() {
+  const client = new RecordingSlackClient();
+  const provider = createSlackTriggerProvider({
+    configurationStoreForProject: () =>
+      new ProjectConfigurationStore(createMemoryDatabase(), "unused"),
+    botUserIdForWorkspace: async () => "bot-1",
+    client,
+  });
+  return {
+    provider,
+    triggerContext: {
+      provider: "slack",
+      target: {
+        provider: "slack",
+        organizationId: "org-reactions",
+        teamId: "team-1",
+        channelId: "channel-1",
+        threadTs: "1700000000.000001",
+        messageTs: "1700000000.000001",
+      },
+      event: {},
+    },
+    outputContext: {
+      provider: "slack",
+      organizationId: "org-reactions",
+      teamId: "team-1",
+      channelId: "channel-1",
+      threadTs: "1700000000.000001",
+      messageTs: "1700000000.000001",
+    },
+    visible: () => visibleSlackReactions(client),
+    calls: () => client.reactions,
+  };
+}
+
+function createGitHubReactionFixture() {
+  const reactions = new RecordingGitHubReactions();
+  const provider = createGitHubTriggerProvider({
+    configurationStoreForProject: () =>
+      new ProjectConfigurationStore(createMemoryDatabase(), "unused"),
+    reactions,
+  });
+  return {
+    provider,
+    triggerContext: {
+      provider: "github",
+      target: { installationId: 42, repository: "owner/repository" },
+      event: {},
+      reactionSubject: { kind: "issue_comment" as const, commentId: 123 },
+    },
+    outputContext: undefined,
+    visible: () => visibleGitHubReactions(reactions),
+    calls: () => ({
+      created: reactions.created.map((reaction) => reaction.content),
+      deleted: reactions.deleted,
+    }),
+  };
+}
+
+type WorkflowOutcome = "step_failure" | "timeout" | "prelaunch_failure";
+
+interface WorkflowScenarioOptions {
+  outcome?: WorkflowOutcome;
+  skipAllSteps?: boolean;
+}
+
+async function runTwoStepWorkflow<
+  Name extends string,
+  TriggerContext,
+  OutputContext,
+  MaterializedContext,
+  Calls,
+>(
+  input: {
+    provider: TriggerProvider<Name, TriggerContext, OutputContext, MaterializedContext>;
+    triggerContext: unknown;
+    outputContext: unknown;
+    visible: () => readonly string[];
+    calls: () => Calls;
+  },
+  options: WorkflowScenarioOptions = {},
+) {
+  let now = new Date();
+  const organizationId = `org-reactions-${randomUUID()}`;
+  const database = createMemoryDatabase({ organizationIds: [organizationId], now: () => now });
+  const tokenVerifier = `verifier-${randomUUID()}`;
+  await database.issueEnrollmentToken({
+    id: randomUUID(),
+    verifier: tokenVerifier,
+    organizationId,
+    expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+    consumedAt: null,
+  });
+  await database.enrollDaemon({
+    tokenVerifier,
+    daemonId: TEST_DAEMON_ID,
+    idempotencyKey: `runner-${organizationId}`,
+    serverId: "server-1",
+    daemonPublicKey: "public-key",
+    credentialVerifier: "credential-verifier",
+    scopes: ["hub.execution.*"],
+    now: new Date("2026-08-10T00:00:00.000Z"),
+  });
+  const { project, revision } = await createActiveProjectConfiguration(
+    database,
+    {
+      environments: [
+        {
+          name: "runner",
+          kind: "daemon",
+          daemon: TEST_DAEMON_SLUG,
+          cwd: "/workspace",
+        },
+      ],
+      triggers: [
+        {
+          name: "multi",
+          on: "manual.run",
+          max_runtime: "1h",
+          steps: [
+            {
+              id: "first",
+              environment: "runner",
+              max_runtime: "10m",
+              idle_timeout: "1m",
+              agent: { provider: "codex" },
+              prompt: [{ text: "first" }],
+              ...(options.skipAllSteps === true ? { if: "${{ false }}" } : {}),
+            },
+            {
+              id: "second",
+              environment: "runner",
+              max_runtime: "10m",
+              idle_timeout: "1m",
+              agent: { provider: "codex" },
+              prompt: [{ text: "second" }],
+              ...(options.skipAllSteps === true ? { if: "${{ false }}" } : {}),
+            },
+          ],
+        },
+      ],
+    },
+    { organizationId },
+  );
+  const { run } = await database.createAcceptedTriggerRun({
+    organizationId,
+    projectId: project.id,
+    configurationRevisionId: revision.id,
+    providerEventReceiptId: randomUUID(),
+    configuredTriggerName: "multi",
+    rawPrompt: "run",
+    prompt: "run",
+    inputs: {},
+    triggerContext: input.triggerContext,
+    outputContext: input.outputContext,
+    deadlineAt:
+      options.outcome === "timeout"
+        ? new Date(now.getTime() + 1_000)
+        : new Date("2099-01-01T00:00:00.000Z"),
+    stepIds: ["first", "second"],
+    createdAt: now,
+  });
+  const connection: DaemonConnection = {
+    on: () => () => undefined,
+    createAgent: async (agentOptions) => {
+      if (options.outcome === "prelaunch_failure") {
+        throw new Error("daemon rejected agent");
+      }
+      return { id: agentOptions.executionId };
+    },
+    controlExecution: async () => undefined,
+  };
+  const lifecycle = createDaemonDispatchLifecycle({
+    database,
+    connectionForDaemon: (daemonId) => (daemonId === TEST_DAEMON_ID ? connection : undefined),
+    providers: [input.provider],
+    publicBaseUrl: "https://hub.test",
+    completionTokenSecret: "reaction-secret",
+  });
+  const createEngine = () =>
+    createDurableWorkflowHandler({
+      database,
+      entitlements: createUnlimitedEntitlementsService(),
+      providers: [input.provider],
+      now: () => now,
+      leaseMs: 1_000,
+      dispatchLaunchMachineIntent: (intent) => lifecycle.handoffLaunchMachineIntent(intent),
+      onWorkflowRunAccepted: (accepted) => lifecycle.notifyWorkflowRunAccepted(accepted),
+      onWorkflowRunStarted: (started) => lifecycle.notifyWorkflowRunStarted(started),
+      onWorkflowRunTerminal: (terminal) => lifecycle.notifyWorkflowRunTerminal(terminal),
+    }).engine;
+  const engine = createEngine();
+
+  try {
+    const acceptedState = await lifecycle.notifyWorkflowRunAccepted(run);
+    await database.setWorkflowRunReactionState(run.id, acceptedState);
+    await engine.processAvailable();
+    if (options.skipAllSteps === true) {
+      await waitForTerminalRun(database, run.id);
+    } else if (options.outcome === "step_failure") {
+      const first = await runningStepExecution(database, run.id, "first");
+      assert.ok(first.machineId);
+      await lifecycle.failPendingExecutionsForDisconnectedMachine(
+        first.machineId,
+        "daemon_disconnected",
+      );
+    } else if (options.outcome === "timeout") {
+      now = new Date(now.getTime() + 2_000);
+      await database.recoverWorkflowDeadlines(now);
+    } else if (options.outcome === "prelaunch_failure") {
+      await waitForTerminalRun(database, run.id);
+    } else {
+      await completeStep(database, lifecycle, run.id, "first");
+      now = new Date();
+      await database.recoverWorkflowWakeups(new Date());
+      await engine.processAvailable();
+      await completeStep(database, lifecycle, run.id, "second");
+      now = new Date();
+      await engine.processAvailable();
+    }
+    await waitForTerminalRun(database, run.id);
+    now = new Date();
+    await engine.processAvailable();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    await engine.stop();
+    await lifecycle.stop();
+    const terminalRun = await database.findTriggerRunById(run.id);
+    if (terminalRun?.outcome !== "accepted") throw new Error("accepted workflow run not found");
+    return {
+      run: terminalRun,
+      visible: input.visible,
+      calls: input.calls,
+    };
+  } catch (error) {
+    await engine.stop();
+    await lifecycle.stop();
+    throw error;
+  }
+}
+
+async function runningStepExecution(database: Database, triggerRunId: string, stepId: string) {
+  const steps = await database.listWorkflowStepRunsForTriggerRun(triggerRunId);
+  const step = steps.find((candidate) => candidate.stepId === stepId);
+  assert.ok(step);
+  return waitFor(async () => {
+    const execution = await database.findAgentExecutionByWorkflowStepRunId(step.id);
+    return execution?.status === "running" ? execution : undefined;
+  });
+}
+
+async function waitForTerminalRun(database: Database, triggerRunId: string) {
+  return waitFor(async () => {
+    const run = await database.findTriggerRunById(triggerRunId);
+    return run?.status !== "running" ? run : undefined;
+  });
+}
+
+async function completeStep(
+  database: Database,
+  lifecycle: DaemonDispatchLifecycle,
+  triggerRunId: string,
+  stepId: string,
+): Promise<void> {
+  const steps = await database.listWorkflowStepRunsForTriggerRun(triggerRunId);
+  const step = steps.find((candidate) => candidate.stepId === stepId);
+  assert.ok(step);
+  const execution = await waitFor(async () => {
+    const candidate = await database.findAgentExecutionByWorkflowStepRunId(step.id);
+    return candidate?.status === "running" ? candidate : undefined;
+  });
+  await lifecycle.completeAgentExecutionFromCallback({
+    executionId: execution.id,
+    token: deriveAgentExecutionCompletionToken("reaction-secret", execution.id),
+  });
+}
+
+async function waitFor<T>(read: () => Promise<T | undefined>): Promise<T> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const value = await read();
+    if (value !== undefined) return value;
+    await new Promise<void>((resolve) => setImmediate(resolve));
+  }
+  throw new Error("timed out waiting for workflow execution");
+}
+
+function visibleDiscordReactions(client: RecordingDiscordBot): readonly string[] {
+  const visible = new Set<string>();
+  for (const reaction of client.reactions) visible.add(reaction.emoji);
+  for (const reaction of client.deletedOwnReactions) visible.delete(reaction.emoji);
+  return [...visible];
+}
+
+function visibleSlackReactions(client: RecordingSlackClient): readonly string[] {
+  const visible = new Set<string>();
+  for (const reaction of client.reactions) {
+    const [operation, name] = reaction.split(":");
+    if (operation === "add") visible.add(name!);
+    if (operation === "remove") visible.delete(name!);
+  }
+  return [...visible];
+}
+
+function visibleGitHubReactions(client: RecordingGitHubReactions): readonly string[] {
+  const deleted = new Set(client.deleted);
+  return client.created
+    .filter((reaction) => !deleted.has(reaction.id))
+    .map((reaction) => reaction.content);
+}
+
+class RecordingDiscordBot implements DiscordBotClient {
+  readonly reactions: Array<{ emoji: string }> = [];
+  readonly deletedOwnReactions: Array<{ emoji: string }> = [];
+
+  async createReaction(input: { emoji: string }): Promise<void> {
+    this.reactions.push({ emoji: input.emoji });
+  }
+
+  async deleteOwnReaction(input: { emoji: string }): Promise<void> {
+    this.deletedOwnReactions.push({ emoji: input.emoji });
+  }
+
+  async sendChannelMessage(): Promise<void> {}
+  async readThreadMessages(): Promise<never[]> {
+    return [];
+  }
+  async start(): Promise<void> {}
+  async stop(): Promise<void> {}
+  getSelfUserId(): string {
+    return "bot-1";
+  }
+  onMessageCreate(): () => void {
+    return () => undefined;
+  }
+  onGuildDelete(): () => void {
+    return () => undefined;
+  }
+}
+
+class RecordingSlackClient implements SlackBotClient {
+  readonly reactions: string[] = [];
+
+  async sendMessage(): Promise<void> {}
+
+  async addReaction(input: { name: string }): Promise<void> {
+    this.reactions.push(`add:${input.name}`);
+  }
+
+  async removeReaction(input: { name: string }): Promise<void> {
+    this.reactions.push(`remove:${input.name}`);
+  }
+}
+
+class RecordingGitHubReactions implements GitHubReactionClient {
+  readonly created: Array<{ id: number; content: string }> = [];
+  readonly deleted: number[] = [];
+
+  async createReaction(input: { content: string }): Promise<{ id: number }> {
+    const reaction = { id: this.created.length + 1, content: input.content };
+    this.created.push(reaction);
+    return reaction;
+  }
+
+  async deleteReaction(input: { reactionId: number }): Promise<void> {
+    this.deleted.push(input.reactionId);
+  }
+}


### PR DESCRIPTION
## What changed

Multi-step workflows now expose one coherent accepted-to-terminal reaction lifecycle owned by the durable workflow run. Step executions no longer publish per-agent reaction hooks, while individual non-workflow executions retain their existing lifecycle.

## Goals

- Keep accepted, running, and terminal workflow reactions coherent across Discord, Slack, and GitHub.
- Persist only opaque provider reaction state needed for continuity, including GitHub reaction identifiers.
- Reuse the existing durable terminal notification boundary for terminal delivery and recovery.
- Keep provider-specific reaction behavior behind the trigger lifecycle boundary.

## Non-goals

- No accepted/running reaction outboxes, leases, claim indexes, or exactly-once coordination layer.
- No first-step ownership, in-memory deduplication, trigger-context mutation, or provider checks in workflow callers.
- No intermediate accepted/running restart guarantees.

## Why

Per-step lifecycle notifications let each step independently mutate the provider reaction, which produced duplicate or contradictory visible state for one workflow. The workflow run is the smallest durable owner that spans all steps, and the existing terminal outbox already provides the required terminal recovery boundary.

## Verification

- Behavior-level two-step, skip, prelaunch-failure, step-failure, timeout, and GitHub persistence tests for Discord, Slack, and GitHub.
- Focused reaction/provider suite: 93 passed.
- PostgreSQL migration and terminal restart/retry coverage: 38 passed.
- Full suite: 708 passed, 15 skipped.
- Lint, format check, typecheck, and Drizzle schema check pass.

## Risk surface

The migration adds opaque `reaction_state` to workflow runs and individual executions. Provider transition implementations now replace and clean up their own reaction state through the existing lifecycle boundary; terminal delivery continues through the existing durable outbox.