### PR TITLE
Make main CI reliable under concurrent workflow and browser load

### DIFF
--- a/e2e/authentication.spec.ts
+++ b/e2e/authentication.spec.ts
@@ -1,15 +1,15 @@
 import { test } from "./app.js";
 
-test("operator bootstraps, replaces the temporary password, and manages an API key", async ({
-  hub,
-}) => {
+test("operator bootstraps and replaces the temporary password", async ({ hub }) => {
   const owner = {
     name: "Bootstrap Owner",
     email: "bootstrap-owner@example.com",
     password: "temporary-bootstrap-password",
   };
   await hub.proveBootstrapJourney(owner, "Bootstrap Organization", "permanent-owner-password");
+});
 
+test("operator manages an API key", async ({ hub }) => {
   await hub.signUpAs("api-owner", {
     name: "API Owner",
     email: "api-owner@example.com",

--- a/src/workflows/engine.test.ts
+++ b/src/workflows/engine.test.ts
@@ -292,6 +292,48 @@ describe("durable multi-step workflow engine", () => {
     );
   });
 
+  it("does not lose a terminal notification requested during an empty recovery pass", async () => {
+    const fixture = await workflowFixture({ rawConfiguration: allSkippedConfiguration() });
+    let releaseInitialClaim!: () => void;
+    const initialClaimRelease = new Promise<void>((resolve) => {
+      releaseInitialClaim = resolve;
+    });
+    let markInitialClaimStarted!: () => void;
+    const initialClaimStarted = new Promise<void>((resolve) => {
+      markInitialClaimStarted = resolve;
+    });
+    const controlledDatabase = delayFirstEmptyTerminalClaim(
+      fixture.database,
+      markInitialClaimStarted,
+      initialClaimRelease,
+    );
+    const delivered: string[] = [];
+    const { handler, engine } = engineFor(
+      { ...fixture, database: controlledDatabase },
+      [],
+      undefined,
+      undefined,
+      async (run) => {
+        delivered.push(run.id);
+      },
+    );
+
+    await handler(fixture.trigger("run"));
+    const processing = engine.processAvailable();
+    await initialClaimStarted;
+    const run = (
+      await fixture.database.findTriggerRunsByProviderEventReceiptId(fixture.providerEventReceiptId)
+    )[0]!;
+    await waitUntil(
+      async () => (await fixture.database.findTriggerRunById(run.id))?.status === "succeeded",
+    );
+    releaseInitialClaim();
+    await processing;
+    await waitUntil(() => Promise.resolve(delivered.length === 1));
+
+    assert.deepEqual(delivered, [run.id]);
+  });
+
   it("keeps processing ready wakeups while a terminal provider hook is held", async () => {
     const fixture = await workflowFixture({ rawConfiguration: deadlineConfiguration() });
     let releaseTerminalHook: (() => void) | undefined;
@@ -1909,6 +1951,39 @@ async function settlesQuickly<T>(promise: Promise<T>): Promise<boolean> {
     promise.then(() => true),
     new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 25)),
   ]);
+}
+
+async function waitUntil(observation: () => Promise<boolean>): Promise<void> {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    if (await observation()) return;
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  }
+  throw new Error("Timed out waiting for workflow state");
+}
+
+function delayFirstEmptyTerminalClaim(
+  database: Database,
+  markStarted: () => void,
+  release: Promise<void>,
+): Database {
+  let firstClaim = true;
+  return new Proxy(database, {
+    get(target, property) {
+      if (property === "claimPendingWorkflowRunTerminalNotification") {
+        return async (now: Date, leaseMs: number) => {
+          if (firstClaim) {
+            firstClaim = false;
+            markStarted();
+            await release;
+            return undefined;
+          }
+          return target.claimPendingWorkflowRunTerminalNotification(now, leaseMs);
+        };
+      }
+      const value: unknown = Reflect.get(target, property, target);
+      return value;
+    },
+  });
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/workflows/engine.ts
+++ b/src/workflows/engine.ts
@@ -84,6 +84,7 @@ export class DurableWorkflowEngine {
   private workerTimer: NodeJS.Timeout | undefined;
   private processing: Promise<void> | undefined;
   private terminalNotificationProcessing: Promise<void> | undefined;
+  private terminalNotificationRecoveryRequested = false;
   private stopped = false;
 
   constructor(private readonly options: DurableWorkflowEngineOptions) {
@@ -655,14 +656,25 @@ export class DurableWorkflowEngine {
 
   private kickTerminalNotificationRecovery(): void {
     if (this.options.database === null || this.stopped) return;
+    this.terminalNotificationRecoveryRequested = true;
     if (this.terminalNotificationProcessing !== undefined) return;
-    this.terminalNotificationProcessing = this.recoverPendingWorkflowRunTerminalNotifications()
+    this.terminalNotificationProcessing = this.recoverRequestedWorkflowRunTerminalNotifications()
       .catch((error: unknown) => {
         this.logger.error({ err: error }, "workflow terminal notification recovery failed");
       })
       .finally(() => {
         this.terminalNotificationProcessing = undefined;
+        if (this.terminalNotificationRecoveryRequested) {
+          this.kickTerminalNotificationRecovery();
+        }
       });
+  }
+
+  private async recoverRequestedWorkflowRunTerminalNotifications(): Promise<void> {
+    do {
+      this.terminalNotificationRecoveryRequested = false;
+      await this.recoverPendingWorkflowRunTerminalNotifications();
+    } while (this.terminalNotificationRecoveryRequested && !this.stopped);
   }
 
   private async recoverPendingWorkflowRunTerminalNotifications(): Promise<void> {


### PR DESCRIPTION
Main CI now handles concurrent workflow terminal delivery reliably, while authentication browser coverage runs as two focused journeys with independent timing budgets.

## Goals

- Deliver every workflow terminal notification promptly, including when a run becomes terminal as an empty recovery pass finishes.
- Preserve durable recovery across shutdowns and transient delivery errors.
- Keep bootstrap/password replacement and API-key lifecycle browser coverage stable under CI runner load.
- Retain the full API-key revocation assertions, including revoked status, removed actions, and rejected credentials.

## Non-goals

- Change API-key product behavior or add optimistic UI state.
- Increase test timeouts or add retries.
- Redesign the durable workflow worker or provider reaction model.

## Why

The terminal notification worker had a lost-wakeup window: a new request could arrive while an existing recovery pass was already concluding, leaving delivery to the next periodic sweep. A request latch closes that scheduler race at its producer. The browser failure was separate and test-only: one case combined two independent user journeys under one 30-second budget, so splitting them removes the timing coupling without weakening coverage.

## Verification

- Full npm test: 100 files passed, 709 tests passed, 15 skipped.
- Complete workflow and daemon suites: 130 tests passed.
- Authentication browser stress: 10 repeated split journeys passed.
- Typecheck, lint, and formatting checks passed.
- Deterministic regression test fails without the recovery latch and passes with it.

## Risk surface

Review the terminal recovery single-flight/latch interaction, especially shutdown and error recovery. The browser change only splits an existing scenario and does not change application behavior.

No open issue directly matches these CI failures.