### PR TITLE
Keep conversation replies threaded with their Discord context

### DIFF
--- a/src/triggers/discord/bot.test.ts
+++ b/src/triggers/discord/bot.test.ts
@@ -26,7 +26,7 @@ describe("Discord bot client", () => {
     ]);
   });
 
-  it("starts a thread on the trigger message when replying from a channel", async () => {
+  it("creates one thread and sends repeated conversation replies into it", async () => {
     const channel = new FakeSendableChannel({
       message: new FakeMessage("<@123456789012345678> summarize the release notes and next steps"),
     });
@@ -36,19 +36,60 @@ describe("Discord bot client", () => {
       client: createFakeClient(channel),
     });
 
-    await bot.sendChannelMessage({
+    await Promise.all([
+      bot.sendConversationReply({
+        channelId: "200",
+        threadId: null,
+        messageId: "300",
+        content: "done",
+      }),
+      bot.sendConversationReply({
+        channelId: "200",
+        threadId: null,
+        messageId: "300",
+        content: "more detail",
+      }),
+    ]);
+    await bot.sendConversationReply({
       channelId: "200",
       threadId: null,
       messageId: "300",
-      content: "done",
+      content: "final detail",
     });
 
     assert.deepEqual(channel.sentPayloads, []);
     assert.deepEqual(channel.message?.startedThreads, [
       { name: "summarize the release notes and next steps" },
     ]);
-    assert.deepEqual(channel.message?.thread.sentPayloads, [
+    const createdThread = channel.message?.thread;
+    assert.ok(createdThread);
+    assert.deepEqual(createdThread.sentPayloads, [
       { content: "done", allowedMentions: { parse: [] } },
+      { content: "more detail", allowedMentions: { parse: [] } },
+      { content: "final detail", allowedMentions: { parse: [] } },
+    ]);
+  });
+
+  it("reuses a thread already attached to the triggering channel message", async () => {
+    const existingThread = new FakeSendableChannel();
+    const message = new FakeMessage("question", existingThread);
+    const channel = new FakeSendableChannel({ message });
+    const bot = createDiscordBotClient({
+      token: "token",
+      clientId: "900",
+      client: createFakeClient(channel),
+    });
+
+    await bot.sendConversationReply({
+      channelId: "200",
+      threadId: null,
+      messageId: "300",
+      content: "existing thread reply",
+    });
+
+    assert.deepEqual(message.startedThreads, []);
+    assert.deepEqual(existingThread.sentPayloads, [
+      { content: "existing thread reply", allowedMentions: { parse: [] } },
     ]);
   });
 
@@ -61,16 +102,23 @@ describe("Discord bot client", () => {
       client: createFakeClient(channel, thread),
     });
 
-    await bot.sendChannelMessage({
+    await bot.sendConversationReply({
       channelId: "200",
       threadId: "207",
       messageId: "300",
       content: "thread reply",
     });
+    await bot.sendConversationReply({
+      channelId: "200",
+      threadId: "207",
+      messageId: "300",
+      content: "second thread reply",
+    });
 
     assert.deepEqual(channel.sentPayloads, []);
     assert.deepEqual(thread.sentPayloads, [
       { content: "thread reply", allowedMentions: { parse: [] } },
+      { content: "second thread reply", allowedMentions: { parse: [] } },
     ]);
   });
 
@@ -121,12 +169,19 @@ class FakeSendableChannel {
 
 class FakeMessage {
   readonly startedThreads: unknown[] = [];
-  readonly thread = new FakeSendableChannel();
 
-  constructor(readonly content: string) {}
+  constructor(
+    readonly content: string,
+    public thread: FakeSendableChannel | null = null,
+  ) {}
+
+  get hasThread(): boolean {
+    return this.thread !== null;
+  }
 
   async startThread(input: unknown): Promise<FakeSendableChannel> {
     this.startedThreads.push(input);
+    this.thread = new FakeSendableChannel();
     return this.thread;
   }
 }
@@ -141,6 +196,9 @@ function createFakeClient(channel: FakeSendableChannel, thread?: FakeSendableCha
         if (channelId === "207" && thread !== undefined) {
           return thread;
         }
+        const attachedThread = channel.message?.thread;
+        if (channelId === "300" && attachedThread !== undefined && attachedThread !== null)
+          return attachedThread;
         assert.equal(channelId, "200");
         return channel;
       },

--- a/src/triggers/discord/bot.ts
+++ b/src/triggers/discord/bot.ts
@@ -20,8 +20,11 @@ export interface DiscordReactionInput {
 export interface DiscordPostInput {
   channelId: string;
   threadId?: string | null;
-  messageId?: string;
   content: string;
+}
+
+export interface DiscordConversationReplyInput extends DiscordPostInput {
+  messageId: string;
 }
 
 export interface DiscordBotClient {
@@ -31,6 +34,11 @@ export interface DiscordBotClient {
   createReaction(input: DiscordReactionInput): Promise<void>;
   deleteOwnReaction(input: DiscordReactionInput): Promise<void>;
   sendChannelMessage(input: DiscordPostInput): Promise<void>;
+  sendConversationReply(input: DiscordConversationReplyInput): Promise<void>;
+  readMessage(input: {
+    channelId: string;
+    messageId: string;
+  }): Promise<NormalizedDiscordContextMessage>;
   readThreadMessages(input: {
     channelId: string;
     beforeMessageId: string;
@@ -44,6 +52,10 @@ export type DiscordGuildDeleteHandler = (guild: {
   id: string;
   unavailable: boolean;
 }) => Promise<void>;
+
+type DiscordSendableChannel = TextBasedChannel & {
+  send: (...args: unknown[]) => Promise<unknown>;
+};
 
 export interface CreateDiscordBotClientOptions {
   token: string;
@@ -63,6 +75,7 @@ export function createDiscordBotClient(options: CreateDiscordBotClientOptions): 
     });
   const handlers = new Set<DiscordRawMessageHandler>();
   const guildDeleteHandlers = new Set<DiscordGuildDeleteHandler>();
+  const pendingReplyDestinations = new Map<string, Promise<DiscordSendableChannel>>();
   let started = false;
 
   client.on("messageCreate", (message: Message) => {
@@ -117,33 +130,27 @@ export function createDiscordBotClient(options: CreateDiscordBotClientOptions): 
       await client.rest.delete(Routes.channelMessageOwnReaction(channelId, messageId, input.emoji));
     },
     async sendChannelMessage(input) {
-      if (input.threadId !== undefined && input.threadId !== null) {
-        const threadId = DiscordSnowflakeSchema.parse(input.threadId);
-        const channel = await client.channels.fetch(threadId);
-        if (channel === null || !isSendableChannel(channel)) {
-          throw new Error(`discord channel not sendable: ${input.threadId}`);
-        }
-        await channel.send({ content: input.content, allowedMentions: { parse: [] } });
-        return;
-      }
-
-      if (input.messageId !== undefined) {
-        const message = await fetchMessage(
-          client,
-          DiscordSnowflakeSchema.parse(input.channelId),
-          DiscordSnowflakeSchema.parse(input.messageId),
-        );
-        const thread = await message.startThread({ name: createThreadName(message.content) });
-        await thread.send({ content: input.content, allowedMentions: { parse: [] } });
-        return;
-      }
-
-      const channelId = DiscordSnowflakeSchema.parse(input.channelId);
+      const channelId = DiscordSnowflakeSchema.parse(input.threadId ?? input.channelId);
       const channel = await client.channels.fetch(channelId);
       if (channel === null || !isSendableChannel(channel)) {
-        throw new Error(`discord channel not sendable: ${input.channelId}`);
+        throw new Error(`discord channel not sendable: ${channelId}`);
       }
       await channel.send({ content: input.content, allowedMentions: { parse: [] } });
+    },
+    async sendConversationReply(input) {
+      const channel =
+        input.threadId === undefined || input.threadId === null
+          ? await resolveReplyDestination(client, input, pendingReplyDestinations)
+          : await fetchSendableChannel(client, input.threadId);
+      await channel.send({ content: input.content, allowedMentions: { parse: [] } });
+    },
+    async readMessage(input) {
+      const message = await fetchMessage(
+        client,
+        DiscordSnowflakeSchema.parse(input.channelId),
+        DiscordSnowflakeSchema.parse(input.messageId),
+      );
+      return normalizeContextMessage(message);
     },
     async readThreadMessages(input) {
       const channelId = DiscordSnowflakeSchema.parse(input.channelId);
@@ -155,7 +162,7 @@ export function createDiscordBotClient(options: CreateDiscordBotClientOptions): 
       const page = await channel.messages.fetch({ before: beforeMessageId, limit: 50 });
       return Array.from(page.values())
         .filter((message) => message.id !== beforeMessageId)
-        .map(normalizeThreadMessage)
+        .map(normalizeContextMessage)
         .sort(compareThreadMessages);
     },
     onMessageCreate(handler) {
@@ -169,6 +176,45 @@ export function createDiscordBotClient(options: CreateDiscordBotClientOptions): 
       return () => guildDeleteHandlers.delete(handler);
     },
   };
+}
+
+async function resolveReplyDestination(
+  client: Client,
+  input: DiscordConversationReplyInput,
+  pending: Map<string, Promise<DiscordSendableChannel>>,
+): Promise<DiscordSendableChannel> {
+  const channelId = DiscordSnowflakeSchema.parse(input.channelId);
+  const messageId = DiscordSnowflakeSchema.parse(input.messageId);
+  const key = `${channelId}:${messageId}`;
+  const existing = pending.get(key);
+  if (existing !== undefined) return existing;
+
+  const resolution = (async () => {
+    const message = await fetchMessage(client, channelId, messageId);
+    const thread = message.hasThread
+      ? await fetchSendableChannel(client, messageId)
+      : await message.startThread({ name: createThreadName(message.content) });
+    if (!isSendableChannel(thread)) throw new Error(`discord channel not sendable: ${thread.id}`);
+    return thread;
+  })();
+  pending.set(key, resolution);
+  try {
+    return await resolution;
+  } finally {
+    pending.delete(key);
+  }
+}
+
+async function fetchSendableChannel(
+  client: Client,
+  channelId: string,
+): Promise<DiscordSendableChannel> {
+  const parsedChannelId = DiscordSnowflakeSchema.parse(channelId);
+  const channel = await client.channels.fetch(parsedChannelId);
+  if (channel === null || !isSendableChannel(channel)) {
+    throw new Error(`discord channel not sendable: ${parsedChannelId}`);
+  }
+  return channel;
 }
 
 async function fetchMessage(
@@ -195,7 +241,7 @@ function isThreadChannel(
 
 function isSendableChannel(
   channel: GuildBasedChannel | TextBasedChannel,
-): channel is TextBasedChannel & { send: (...args: unknown[]) => Promise<unknown> } {
+): channel is DiscordSendableChannel {
   return "send" in channel && typeof Reflect.get(channel, "send") === "function";
 }
 
@@ -210,7 +256,7 @@ function createThreadName(content: string): string {
   return name.length === 0 ? "paseo response" : name;
 }
 
-function normalizeThreadMessage(message: Message): NormalizedDiscordContextMessage {
+function normalizeContextMessage(message: Message): NormalizedDiscordContextMessage {
   return NormalizedDiscordContextMessageSchema.parse({
     id: message.id,
     channelId: message.channelId,

--- a/src/triggers/discord/memory-bot.ts
+++ b/src/triggers/discord/memory-bot.ts
@@ -1,6 +1,7 @@
 import type { Message } from "discord.js";
 import type {
   DiscordBotClient,
+  DiscordConversationReplyInput,
   DiscordGuildDeleteHandler,
   DiscordPostInput,
   DiscordRawMessageHandler,
@@ -12,6 +13,7 @@ import type { NormalizedDiscordContextMessage } from "./events.js";
 export interface MemoryDiscordBotOptions {
   selfUserId: string;
   threadMessages?: NormalizedDiscordContextMessage[];
+  messages?: NormalizedDiscordContextMessage[];
   threadContextFetchError?: Error;
 }
 
@@ -20,6 +22,7 @@ export class MemoryDiscordBotClient implements DiscordBotClient {
   readonly deletedOwnReactions: DiscordReactionInput[] = [];
   readonly messages: DiscordPostInput[] = [];
   readonly threadReads: Array<{ channelId: string; beforeMessageId: string }> = [];
+  readonly messageReads: Array<{ channelId: string; messageId: string }> = [];
   private readonly handlers = new Set<DiscordRawMessageHandler>();
   private readonly guildDeleteHandlers = new Set<DiscordGuildDeleteHandler>();
   private readonly normalizedHandlers = new Set<(event: NormalizedDiscordMessageEvent) => void>();
@@ -53,6 +56,22 @@ export class MemoryDiscordBotClient implements DiscordBotClient {
 
   async sendChannelMessage(input: DiscordPostInput): Promise<void> {
     this.messages.push(input);
+  }
+
+  async sendConversationReply(input: DiscordConversationReplyInput): Promise<void> {
+    this.messages.push(input);
+  }
+
+  async readMessage(input: {
+    channelId: string;
+    messageId: string;
+  }): Promise<NormalizedDiscordContextMessage> {
+    this.messageReads.push(input);
+    const message = this.options.messages?.find(
+      (candidate) => candidate.channelId === input.channelId && candidate.id === input.messageId,
+    );
+    if (message === undefined) throw new Error(`discord message unavailable: ${input.messageId}`);
+    return message;
   }
 
   async readThreadMessages(input: {

--- a/src/triggers/discord/provider.test.ts
+++ b/src/triggers/discord/provider.test.ts
@@ -170,7 +170,7 @@ describe("Discord Phase 1 trigger provider", () => {
             threadId: "207",
             parentChannelId: "200",
             attachments: [attachment],
-            referencedMessage: { id: "298", channelId: "200", guildId: "100" },
+            referencedMessage: { id: "299", channelId: "207", guildId: "100" },
           }),
         ),
         connectionId: "22222222-2222-4222-8222-222222222222",
@@ -179,6 +179,7 @@ describe("Discord Phase 1 trigger provider", () => {
 
     if (!isAcceptedTriggerProviderMatch(match)) throw new Error("expected accepted match");
     assert.deepEqual(bot.threadReads, []);
+    assert.deepEqual(bot.messageReads, []);
     assert.equal(
       await database.findAttachmentBySource(
         "11111111-1111-4111-8111-111111111118",
@@ -191,8 +192,8 @@ describe("Discord Phase 1 trigger provider", () => {
     assert.ok(triggerAttachment);
     assert.equal("url" in triggerAttachment, false);
     assert.deepEqual(match.triggerContext.event.discord.trigger_message.referenced_message, {
-      id: "298",
-      channel_id: "200",
+      id: "299",
+      channel_id: "207",
       guild_id: "100",
     });
     assert.deepEqual(match.triggerContext.event.discord.trigger_thread_context, {
@@ -206,6 +207,7 @@ describe("Discord Phase 1 trigger provider", () => {
       triggerContext: match.triggerContext,
     });
     assert.deepEqual(bot.threadReads, [{ channelId: "207", beforeMessageId: "300" }]);
+    assert.deepEqual(bot.messageReads, []);
     const contextAttachment = await database.findAttachmentBySource(
       "11111111-1111-4111-8111-111111111118",
       "discord",
@@ -214,6 +216,23 @@ describe("Discord Phase 1 trigger provider", () => {
     assert.ok(contextAttachment);
     assert.deepEqual(materialized, {
       discord: {
+        referenced_message: {
+          id: "299",
+          content: "see image",
+          author: { id: "401", username: "maintainer", bot: false },
+          channel: { id: "207" },
+          created_at: "2026-05-18T23:59:00.000Z",
+          attachments: [
+            {
+              id: contextAttachment.id,
+              filename: "design.png",
+              content_type: "image/png",
+              size: 42,
+              url: attachments.urlFor(contextAttachment.id, "execution-discord-materialize"),
+            },
+          ],
+          referenced_message: null,
+        },
         thread: {
           id: "207",
           parent_channel_id: "200",
@@ -261,6 +280,65 @@ describe("Discord Phase 1 trigger provider", () => {
     assert.ok(secondUrl);
     assert.notEqual(firstUrl, secondUrl);
     assert.match(secondUrl, /execution-discord-materialize-2/u);
+  });
+
+  it("hydrates the direct message referenced by a channel trigger only on demand", async () => {
+    const { project, revision, store } = await activeConfiguration();
+    const referencedMessage = {
+      id: "298",
+      channelId: "200",
+      content: "the original question",
+      author: { id: "401", username: "maintainer", bot: false },
+      createdAt: "2026-05-18T23:59:00.000Z",
+      attachments: [],
+      referencedMessage: null,
+    };
+    const bot = new MemoryDiscordBotClient({
+      selfUserId: "900",
+      messages: [referencedMessage],
+    });
+    const provider = createDiscordTriggerProvider({
+      configurationStoreForProject: () => store,
+      bot,
+    });
+    const match = (
+      await provider.match(
+        external(
+          project.id,
+          revision.id,
+          event({ referencedMessage: { id: "298", channelId: "200", guildId: "100" } }),
+        ),
+      )
+    )[0];
+    if (!isAcceptedTriggerProviderMatch(match)) throw new Error("expected accepted match");
+
+    assert.deepEqual(bot.threadReads, []);
+    assert.deepEqual(bot.messageReads, []);
+
+    const materialized = await provider.materializeContext!({
+      executionId: "execution-discord-reference",
+      organizationId: "org_1",
+      projectId: project.id,
+      providerEventReceiptId: "11111111-1111-4111-8111-111111111118",
+      triggerContext: match.triggerContext,
+    });
+
+    assert.deepEqual(bot.threadReads, []);
+    assert.deepEqual(bot.messageReads, [{ channelId: "200", messageId: "298" }]);
+    assert.deepEqual(materialized, {
+      discord: {
+        referenced_message: {
+          id: "298",
+          content: "the original question",
+          author: { id: "401", username: "maintainer", bot: false },
+          channel: { id: "200" },
+          created_at: "2026-05-18T23:59:00.000Z",
+          attachments: [],
+          referenced_message: null,
+        },
+        thread: null,
+      },
+    });
   });
 
   it("does not require attachment capability during Discord ingestion", async () => {

--- a/src/triggers/discord/provider.ts
+++ b/src/triggers/discord/provider.ts
@@ -48,6 +48,7 @@ export interface DiscordMaterializedMessage {
 
 export interface DiscordMaterializedContext {
   discord: {
+    referenced_message: DiscordMaterializedMessage | null;
     thread: {
       id: string;
       parent_channel_id: string | null;
@@ -170,13 +171,13 @@ export function createDiscordTriggerProvider(options: {
     },
     async materializeContext(launch) {
       const event = launch.triggerContext.event.discord;
-      if (event.trigger_message.thread === null) {
-        return { discord: { thread: null } };
-      }
-      const messages = await options.bot.readThreadMessages({
-        channelId: event.trigger_message.thread.id,
-        beforeMessageId: event.trigger_message.id,
-      });
+      const messages =
+        event.trigger_message.thread === null
+          ? []
+          : await options.bot.readThreadMessages({
+              channelId: event.trigger_message.thread.id,
+              beforeMessageId: event.trigger_message.id,
+            });
       const contextMessages = await Promise.all(
         messages.map((message) =>
           materializeDiscordMessage(
@@ -189,12 +190,22 @@ export function createDiscordTriggerProvider(options: {
           ),
         ),
       );
+      const referencedMessage = await materializeReferencedMessage(
+        event.trigger_message.referenced_message,
+        messages,
+        contextMessages,
+        launch,
+        options.bot,
+        options.attachments,
+        event.connection_id,
+      );
       return {
         discord: {
-          thread: {
-            ...event.trigger_message.thread,
-            messages: contextMessages,
-          },
+          referenced_message: referencedMessage,
+          thread:
+            event.trigger_message.thread === null
+              ? null
+              : { ...event.trigger_message.thread, messages: contextMessages },
         },
       };
     },
@@ -234,6 +245,39 @@ export function createDiscordTriggerProvider(options: {
       return reactionState;
     },
   };
+}
+
+async function materializeReferencedMessage(
+  reference: DiscordMergeMessage["referenced_message"],
+  sourceMessages: NormalizedDiscordContextMessage[],
+  materializedMessages: DiscordMaterializedMessage[],
+  launch: {
+    executionId: string;
+    organizationId: string;
+    providerEventReceiptId: string;
+  },
+  bot: DiscordBotClient,
+  attachments: AttachmentCapabilityRegistry | undefined,
+  connectionId: string | null,
+): Promise<DiscordMaterializedMessage | null> {
+  if (reference === null) return null;
+  const existingIndex = sourceMessages.findIndex(
+    (message) => message.id === reference.id && message.channelId === reference.channel_id,
+  );
+  if (existingIndex !== -1) return materializedMessages[existingIndex]!;
+
+  const message = await bot.readMessage({
+    channelId: reference.channel_id,
+    messageId: reference.id,
+  });
+  return materializeDiscordMessage(
+    message,
+    launch.providerEventReceiptId,
+    launch.organizationId,
+    connectionId,
+    launch.executionId,
+    attachments,
+  );
 }
 
 async function deleteReactionForPhase(

--- a/src/triggers/discord/reply.test.ts
+++ b/src/triggers/discord/reply.test.ts
@@ -4,7 +4,7 @@ import { MemoryDiscordBotClient } from "./memory-bot.js";
 import { createDiscordReplyExecutor } from "./reply.js";
 
 describe("Discord reply executor", () => {
-  it("creates a thread on channel messages before posting the reply", async () => {
+  it("sends repeated replies through the conversation reply capability", async () => {
     const bot = new MemoryDiscordBotClient({ selfUserId: "900" });
     const executor = createDiscordReplyExecutor({ bot });
 
@@ -14,6 +14,12 @@ describe("Discord reply executor", () => {
       args: { content: "hello world" },
       outputContext: { channelId: "200", threadId: null, messageId: "300" },
     });
+    await executor({
+      agentExecutionId: "exec-1",
+      toolType: "discord.reply",
+      args: { content: "second reply" },
+      outputContext: { channelId: "200", threadId: null, messageId: "300" },
+    });
 
     assert.deepEqual(bot.messages, [
       {
@@ -21,6 +27,12 @@ describe("Discord reply executor", () => {
         threadId: null,
         messageId: "300",
         content: "hello world",
+      },
+      {
+        channelId: "200",
+        threadId: null,
+        messageId: "300",
+        content: "second reply",
       },
     ]);
   });

--- a/src/triggers/discord/reply.ts
+++ b/src/triggers/discord/reply.ts
@@ -24,7 +24,7 @@ export function createDiscordReplyExecutor(
     const args = DiscordReplyArgsSchema.parse(input.args);
     const context = DiscordReplyOutputContextSchema.parse(input.outputContext);
 
-    await options.bot.sendChannelMessage({
+    await options.bot.sendConversationReply({
       channelId: context.channelId,
       threadId: context.threadId ?? null,
       messageId: context.messageId,

--- a/src/triggers/slack/reply.test.ts
+++ b/src/triggers/slack/reply.test.ts
@@ -4,13 +4,26 @@ import type { SlackBotClient } from "./client.js";
 import { createSlackReplyExecutor } from "./reply.js";
 
 describe("Slack reply output", () => {
-  it("posts plain text into the originating thread", async () => {
+  it("posts repeated replies into the same originating thread", async () => {
     const client = new RecordingSlackClient();
     const execute = createSlackReplyExecutor({ client });
     await execute({
       agentExecutionId: "execution-1",
       toolType: "slack.reply",
       args: { content: "Done" },
+      outputContext: {
+        provider: "slack",
+        organizationId: "org-1",
+        teamId: "T1",
+        channelId: "C1",
+        threadTs: "1700000000.000001",
+        messageTs: "1700000000.000001",
+      },
+    });
+    await execute({
+      agentExecutionId: "execution-1",
+      toolType: "slack.reply",
+      args: { content: "Still working" },
       outputContext: {
         provider: "slack",
         organizationId: "org-1",
@@ -27,6 +40,13 @@ describe("Slack reply output", () => {
         channelId: "C1",
         threadTs: "1700000000.000001",
         content: "Done",
+      },
+      {
+        organizationId: "org-1",
+        teamId: "T1",
+        channelId: "C1",
+        threadTs: "1700000000.000001",
+        content: "Still working",
       },
     ]);
   });

--- a/src/workflows/reactions.test.ts
+++ b/src/workflows/reactions.test.ts
@@ -488,6 +488,10 @@ class RecordingDiscordBot implements DiscordBotClient {
   }
 
   async sendChannelMessage(): Promise<void> {}
+  async sendConversationReply(): Promise<void> {}
+  async readMessage(): Promise<never> {
+    throw new Error("message unavailable");
+  }
   async readThreadMessages(): Promise<never[]> {
     return [];
   }


### PR DESCRIPTION
Discord conversations now keep every Hub reply in one destination thread, whether the trigger starts in a channel, already has a thread, or originates inside one. Explicit ambient context also includes the direct message referenced by a Discord reply without changing the authored prompt.

## Goals

- Resolve or create the Discord reply thread once and reuse it for repeated replies.
- Keep reply destination ownership inside the Discord provider boundary.
- Include the direct referenced Discord message in explicit paseo.context hydration.
- Preserve bounded thread history, attachment authority, and prompt immutability.
- Prove Slack repeated replies continue targeting the same thread.

## Non-goals

- Add generic workflow conversation state.
- Auto-inject ambient context or rewrite paseo.prompt.
- Change Slack production behavior.
- Hydrate recursive reply ancestry.

## Why

Discord channel-trigger output previously asked generic sending to start a thread for every reply. The first reply succeeded, then later replies attempted to start the same thread again and failed delivery. A Discord-owned conversation reply operation makes destination resolution explicit and reuses an attached or newly created thread.

## Verification

- Focused Discord, Slack, workflow context, and reaction tests: 79 passed.
- Full test suite: 711 passed, 15 opt-in tests skipped.
- Typecheck, lint, and format checks pass.

## Risk surface

The change is limited to Discord reply destination resolution and Discord context materialization. Review existing-thread lookup, concurrent first replies, and execution-scoped attachment URLs in referenced messages.