### PR TITLE
Make integration failures diagnosable

### DIFF
--- a/src/billing/index.ts
+++ b/src/billing/index.ts
@@ -340,6 +340,10 @@ export class BillingRuntime {
       );
       return new Response("reconciliation failed", { status: 503 });
     }
+    logger.info(
+      { provider: "stripe", eventId: event.id, eventType: event.type },
+      "billing webhook processed",
+    );
     return Response.json({ received: true });
   }
 

--- a/src/connections/functions.ts
+++ b/src/connections/functions.ts
@@ -2,6 +2,7 @@ import { createServerFn } from "@tanstack/react-start";
 import { getRequest } from "@tanstack/react-start/server";
 import { z } from "zod";
 import { respondError, respondOk, type Result } from "../contract/respond.js";
+import { logger } from "../logger.js";
 import { handleConnections } from "../server/runtime.js";
 
 const githubStatusSchema = z.discriminatedUnion("status", [
@@ -56,7 +57,8 @@ export const connectionStatus = createServerFn({ method: "GET" })
         return respondError({ message: "We couldn't load this organization's connections." });
       }
       return respondOk(connectionStatusSchema.parse(await response.json()));
-    } catch {
+    } catch (error) {
+      logger.error({ err: error, operation: "status" }, "connection dashboard request failed");
       return respondError({ message: "We couldn't load this organization's connections." });
     }
   });
@@ -78,7 +80,11 @@ export const startConnection = createServerFn({ method: "POST" })
         return respondError({ message: `We couldn't start the ${name} connection. Try again.` });
       }
       return respondOk(startSchema.parse(await response.json()));
-    } catch {
+    } catch (error) {
+      logger.error(
+        { err: error, provider: data.provider, operation: "start" },
+        "connection dashboard request failed",
+      );
       return respondError({ message: `We couldn't start the ${name} connection. Try again.` });
     }
   });
@@ -100,7 +106,11 @@ export const disconnectConnection = createServerFn({ method: "POST" })
         return respondError({ message: `We couldn't disconnect ${name}. Try again.` });
       }
       return respondOk({ result: `${data.provider}_disconnected` as const });
-    } catch {
+    } catch (error) {
+      logger.error(
+        { err: error, provider: data.provider, operation: "disconnect" },
+        "connection dashboard request failed",
+      );
       return respondError({ message: `We couldn't disconnect ${name}. Try again.` });
     }
   });

--- a/src/connections/shared.test.ts
+++ b/src/connections/shared.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import { Writable } from "node:stream";
+import { describe, it } from "vitest";
+import { createLogger } from "../logger.js";
+import { connectionCallbackFailure } from "./shared.js";
+
+class CaptureStream extends Writable {
+  readonly chunks: string[] = [];
+
+  override _write(
+    chunk: Buffer | string,
+    _encoding: BufferEncoding,
+    callback: (error?: Error | null) => void,
+  ): void {
+    this.chunks.push(chunk.toString());
+    callback();
+  }
+}
+
+describe("connection callback failures", () => {
+  it("logs safe operator evidence and keeps the public response generic", () => {
+    const stream = new CaptureStream();
+    const token = "ghp_abcdefghijklmnopqrstuvwxyz1234567890";
+
+    const response = connectionCallbackFailure({
+      error: new Error(`github oauth exchange failed: 401 ${token}`),
+      provider: "github",
+      phase: "authorization",
+      applicationBaseUrl: "https://hub.test",
+      returnRoute: "/o/acme/connections",
+      log: createLogger(stream),
+    });
+
+    const output = stream.chunks.join("");
+    assert.match(output, /connection callback unavailable/u);
+    assert.match(output, /github/u);
+    assert.match(output, /authorization/u);
+    assert.match(output, /github oauth exchange failed: 401/u);
+    assert.equal(output.includes(token), false);
+    assert.equal(response.status, 303);
+    assert.equal(
+      response.headers.get("location"),
+      "https://hub.test/o/acme/connections?result=connection_unavailable",
+    );
+  });
+});

--- a/src/connections/shared.ts
+++ b/src/connections/shared.ts
@@ -1,4 +1,5 @@
 import { createHash, randomBytes } from "node:crypto";
+import type { Logger } from "pino";
 import { ProductRequestError } from "../auth/organization-access.js";
 import type { AuthServer } from "../auth/server.js";
 import { ConnectionAccessDeniedError, ConnectionConflictError } from "../db/errors.js";
@@ -8,7 +9,7 @@ import type {
   Database,
   TenantRouteAccess,
 } from "../db/types.js";
-import { logger } from "../logger.js";
+import { logger, redact } from "../logger.js";
 import { resolveRouteTenant } from "../projects/access.js";
 
 export const CONNECTION_ATTEMPT_LIFETIME_MINUTES = 10;
@@ -69,6 +70,27 @@ export function connectionResult(
   const url = new URL(returnRoute, publicBaseUrl);
   url.searchParams.set("result", result);
   return Response.redirect(url, 303);
+}
+
+export function connectionCallbackFailure(input: {
+  error: unknown;
+  provider: "github" | "discord" | "slack";
+  phase: string;
+  applicationBaseUrl: string;
+  returnRoute: string;
+  log?: Pick<Logger, "error">;
+}): Response {
+  const log = input.log ?? logger;
+  log.error(
+    {
+      provider: input.provider,
+      phase: input.phase,
+      errorType: input.error instanceof Error ? input.error.name : "UnknownError",
+      ...(input.error instanceof Error ? { errorMessage: redact(input.error.message) } : {}),
+    },
+    "connection callback unavailable",
+  );
+  return connectionResult(input.applicationBaseUrl, input.returnRoute, "connection_unavailable");
 }
 
 export function connectionActionFailure(

--- a/src/providers/discord/client.ts
+++ b/src/providers/discord/client.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { logger } from "../../logger.js";
 import { DiscordSnowflakeSchema } from "../../discord/snowflake.js";
 
 export interface DiscordGuildIdentity {
@@ -87,7 +88,11 @@ export function createDiscordConnectionClient(input: {
         });
         if (response.ok) return "present";
         return response.status === 404 ? "absent" : "unknown";
-      } catch {
+      } catch (error) {
+        logger.warn(
+          { err: error, provider: "discord", guildId },
+          "Discord guild membership check failed",
+        );
         return "unknown";
       }
     },

--- a/src/providers/discord/index.ts
+++ b/src/providers/discord/index.ts
@@ -7,6 +7,7 @@ import {
   callbackConnectionAccess,
   connectionAccess,
   connectionActionFailure,
+  connectionCallbackFailure,
   connectionResult,
   manageConnectionAccess,
   newConnectionState,
@@ -263,8 +264,14 @@ async function completeAuthorization(
     }
     await bindDiscord(options.database, state, access, guild);
     return connectionResult(options.applicationBaseUrl, attempt.returnRoute, "discord_connected");
-  } catch {
-    return connectionResult(options.applicationBaseUrl, returnRoute, "connection_unavailable");
+  } catch (error) {
+    return connectionCallbackFailure({
+      error,
+      provider: "discord",
+      phase: "authorization",
+      applicationBaseUrl: options.applicationBaseUrl,
+      returnRoute,
+    });
   }
 }
 

--- a/src/providers/github/index.ts
+++ b/src/providers/github/index.ts
@@ -10,6 +10,7 @@ import {
   callbackConnectionAccess,
   connectionAccess,
   connectionActionFailure,
+  connectionCallbackFailure,
   connectionResult,
   manageConnectionAccess,
   newConnectionState,
@@ -370,8 +371,14 @@ async function completeSetup(
       }),
       303,
     );
-  } catch {
-    return connectionResult(options.applicationBaseUrl, returnRoute, "connection_unavailable");
+  } catch (error) {
+    return connectionCallbackFailure({
+      error,
+      provider: "github",
+      phase: "setup",
+      applicationBaseUrl: options.applicationBaseUrl,
+      returnRoute,
+    });
   }
 }
 
@@ -417,8 +424,14 @@ async function completeAuthorization(
     }
     await bindGitHub(options.database, state, access, identity);
     return connectionResult(options.applicationBaseUrl, attempt.returnRoute, "github_connected");
-  } catch {
-    return connectionResult(options.applicationBaseUrl, returnRoute, "connection_unavailable");
+  } catch (error) {
+    return connectionCallbackFailure({
+      error,
+      provider: "github",
+      phase: "authorization",
+      applicationBaseUrl: options.applicationBaseUrl,
+      returnRoute,
+    });
   }
 }
 

--- a/src/providers/slack/index.ts
+++ b/src/providers/slack/index.ts
@@ -4,6 +4,7 @@ import {
   callbackConnectionAccess,
   connectionAccess,
   connectionActionFailure,
+  connectionCallbackFailure,
   connectionResult,
   manageConnectionAccess,
   newConnectionState,
@@ -263,8 +264,14 @@ async function completeAuthorization(
     const installation = await client.exchangeCode(code);
     await bindSlack(options.database, state, access, installation);
     return connectionResult(options.applicationBaseUrl, attempt.returnRoute, "slack_connected");
-  } catch {
-    return connectionResult(options.applicationBaseUrl, returnRoute, "connection_unavailable");
+  } catch (error) {
+    return connectionCallbackFailure({
+      error,
+      provider: "slack",
+      phase: "authorization",
+      applicationBaseUrl: options.applicationBaseUrl,
+      returnRoute,
+    });
   }
 }
 

--- a/src/triggers/audit.test.ts
+++ b/src/triggers/audit.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { Writable } from "node:stream";
+import { describe, it } from "vitest";
+import { z } from "zod";
+import { createLogger } from "../logger.js";
+import { logProviderEventIntake, logProviderEventRouting } from "./audit.js";
+
+class CaptureStream extends Writable {
+  readonly chunks: string[] = [];
+
+  override _write(
+    chunk: Buffer | string,
+    _encoding: BufferEncoding,
+    callback: (error?: Error | null) => void,
+  ): void {
+    this.chunks.push(chunk.toString());
+    callback();
+  }
+}
+
+describe("provider event audit logs", () => {
+  it("records safe intake outcomes without event payloads", () => {
+    const stream = new CaptureStream();
+    logProviderEventIntake({
+      provider: "github",
+      source: "github.issue_comment",
+      deliveryId: "delivery-1",
+      repository: "getpaseo/paseo",
+      acceptance: {
+        status: "dropped",
+        receiptId: "receipt-1",
+        reason: "no_project_route",
+      },
+      log: createLogger(stream),
+    });
+
+    const entry = z.record(z.string(), z.unknown()).parse(JSON.parse(stream.chunks.join("")));
+    assert.equal(entry["msg"], "provider event intake completed");
+    assert.equal(entry["outcome"], "dropped");
+    assert.equal(entry["reason"], "no_project_route");
+    assert.equal(entry["repository"], "getpaseo/paseo");
+    assert.equal("payload" in entry, false);
+  });
+
+  it("records the configured triggers selected for one project route", () => {
+    const stream = new CaptureStream();
+    logProviderEventRouting({
+      source: "slack.mention",
+      deliveryId: "delivery-2",
+      receiptId: "receipt-2",
+      projectId: "project-1",
+      triggerNames: ["classify", "maintain"],
+      acceptedCount: 1,
+      rejectedCount: 1,
+      log: createLogger(stream),
+    });
+
+    const entry = z.record(z.string(), z.unknown()).parse(JSON.parse(stream.chunks.join("")));
+    assert.equal(entry["msg"], "provider event routing completed");
+    assert.equal(entry["outcome"], "matched");
+    assert.deepEqual(entry["triggerNames"], ["classify", "maintain"]);
+    assert.equal(entry["acceptedCount"], 1);
+    assert.equal(entry["rejectedCount"], 1);
+  });
+});

--- a/src/triggers/audit.ts
+++ b/src/triggers/audit.ts
@@ -1,0 +1,61 @@
+import type { Logger } from "pino";
+import type { ProviderEventAcceptance } from "../db/types.js";
+import { logger } from "../logger.js";
+
+type EventAuditLogger = Pick<Logger, "info">;
+
+export function logProviderEventIntake(input: {
+  provider: "github" | "slack" | "discord";
+  source: string;
+  deliveryId: string;
+  acceptance: ProviderEventAcceptance;
+  repository?: string | undefined;
+  resourceId?: string | undefined;
+  log?: EventAuditLogger;
+}): void {
+  const acceptance = input.acceptance;
+  (input.log ?? logger).info(
+    {
+      provider: input.provider,
+      source: input.source,
+      deliveryId: input.deliveryId,
+      receiptId: acceptance.receiptId,
+      outcome: acceptance.status,
+      ...(acceptance.status === "accepted" ? { routeCount: acceptance.events.length } : {}),
+      ...(acceptance.status === "dropped" ? { reason: acceptance.reason } : {}),
+      ...(input.repository === undefined ? {} : { repository: input.repository }),
+      ...(input.resourceId === undefined ? {} : { resourceId: input.resourceId }),
+    },
+    "provider event intake completed",
+  );
+}
+
+export function logProviderEventRouting(input: {
+  source: string;
+  deliveryId: string;
+  receiptId: string;
+  projectId: string;
+  triggerNames: readonly string[];
+  acceptedCount: number;
+  rejectedCount: number;
+  dropReason?: string | undefined;
+  log?: EventAuditLogger;
+}): void {
+  (input.log ?? logger).info(
+    {
+      source: input.source,
+      deliveryId: input.deliveryId,
+      receiptId: input.receiptId,
+      projectId: input.projectId,
+      outcome: input.dropReason === undefined ? "matched" : "dropped",
+      ...(input.dropReason === undefined
+        ? {
+            triggerNames: input.triggerNames,
+            acceptedCount: input.acceptedCount,
+            rejectedCount: input.rejectedCount,
+          }
+        : { reason: input.dropReason }),
+    },
+    "provider event routing completed",
+  );
+}

--- a/src/triggers/discord/bot.ts
+++ b/src/triggers/discord/bot.ts
@@ -81,7 +81,15 @@ export function createDiscordBotClient(options: CreateDiscordBotClientOptions): 
   client.on("messageCreate", (message: Message) => {
     void Promise.all(Array.from(handlers, (handler) => handler(message))).catch(
       (error: unknown) => {
-        logger.error({ err: error }, "discord messageCreate handler failed");
+        logger.error(
+          {
+            err: error,
+            deliveryId: `discord-${message.id}`,
+            guildId: message.guildId,
+            channelId: message.channelId,
+          },
+          "Discord event handoff failed",
+        );
       },
     );
   });

--- a/src/triggers/discord/gateway.ts
+++ b/src/triggers/discord/gateway.ts
@@ -2,6 +2,7 @@ import type { Message } from "discord.js";
 import type { ProviderEventAcceptance } from "../../db/types.js";
 import type { TriggerHandler, TriggerSource } from "../index.js";
 import type { ProviderEventDropReasonCode } from "../drop-reason.js";
+import { logProviderEventIntake } from "../audit.js";
 import type { DiscordBotClient } from "./bot.js";
 import { NormalizedDiscordMessageEventSchema } from "./events.js";
 import type { NormalizedDiscordMessageEvent } from "./events.js";
@@ -120,6 +121,13 @@ async function dispatchMessage(
     receivedAt: new Date(normalizedEvent.createdAt),
     payload: normalizedEvent,
     ...(handlers.size === 0 ? { dropReason: "configuration_unavailable" } : {}),
+  });
+  logProviderEventIntake({
+    provider: "discord",
+    source: "discord.mention",
+    deliveryId: `discord-${normalizedEvent.messageId}`,
+    resourceId: normalizedEvent.guildId,
+    acceptance,
   });
   if (acceptance.status !== "accepted") return;
 

--- a/src/triggers/github/webhook.ts
+++ b/src/triggers/github/webhook.ts
@@ -8,6 +8,7 @@ import { logger } from "../../logger.js";
 import { readBoundedRequestBody } from "../../http/request-body.js";
 import type { TriggerHandler, TriggerSource } from "../index.js";
 import type { ProviderEventDropReasonCode } from "../drop-reason.js";
+import { logProviderEventIntake } from "../audit.js";
 
 const MAX_WEBHOOK_BYTES = 1_048_576;
 const MAX_HEADER_LENGTH = 128;
@@ -65,15 +66,15 @@ export function createWebhookSource(
     try {
       return await handleVerifiedWebhook(verified, options, handlers);
     } catch (error) {
+      logger.error(
+        {
+          err: error,
+          deliveryId: verified.deliveryId,
+          eventType: verified.eventType,
+        },
+        "GitHub webhook handling failed",
+      );
       if (isDatabaseUnavailableError(error)) {
-        logger.error(
-          {
-            err: error,
-            deliveryId: verified.deliveryId,
-            eventType: verified.eventType,
-          },
-          "rejecting webhook because database is unavailable",
-        );
         return Response.json({ error: "database_unavailable" }, { status: 503 });
       }
       throw error;
@@ -98,7 +99,10 @@ async function handleVerifiedWebhook(
 ): Promise<Response> {
   const { body, deliveryId, eventType, signatureHash } = verified;
   const installationId = body.installation?.id;
-  if (typeof installationId !== "number") return new Response("Bad Request", { status: 400 });
+  if (typeof installationId !== "number") {
+    logger.warn({ deliveryId, eventType }, "rejecting webhook without an installation ID");
+    return new Response("Bad Request", { status: 400 });
+  }
 
   if (eventType === "installation" || eventType === "installation_repositories") {
     return handleLifecycle(options, verified, installationId, eventType);
@@ -107,7 +111,7 @@ async function handleVerifiedWebhook(
   const event = normalizeWebhookEvent({ body, deliveryId, eventType });
   if (event === undefined) {
     logger.info({ deliveryId, eventType }, "skipping webhook event without repo or installation");
-    await options.accept({
+    const acceptance = await options.accept({
       installationId,
       deliveryId,
       signatureHash,
@@ -115,6 +119,12 @@ async function handleVerifiedWebhook(
       payload: body,
       receivedAt: new Date(),
       dropReason: "no_trigger_for_source",
+    });
+    logProviderEventIntake({
+      provider: "github",
+      source: `github.${eventType}`,
+      deliveryId,
+      acceptance,
     });
     return new Response("OK", { status: 200 });
   }
@@ -130,6 +140,14 @@ async function handleVerifiedWebhook(
     receivedAt: new Date(event.createdAt),
     ...(handlers.size === 0 ? { dropReason: "configuration_unavailable" } : {}),
   });
+  logProviderEventIntake({
+    provider: "github",
+    source: `github.${eventType}`,
+    deliveryId,
+    repository: event.repo,
+    resourceId: String(event.repositoryId),
+    acceptance,
+  });
   if (eventType === "push" && options.synchronizePush !== undefined) {
     await options.synchronizePush({
       installationId: event.installationId,
@@ -141,7 +159,7 @@ async function handleVerifiedWebhook(
 
   if (acceptance.status !== "accepted") return new Response("OK", { status: 200 });
 
-  return dispatchWebhook(handlers, acceptance.events, verified);
+  return dispatchWebhook(handlers, acceptance.events);
 }
 
 async function verifyWebhookRequest(
@@ -187,12 +205,17 @@ async function verifyWebhookRequest(
   try {
     rawJson = JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(captured));
   } catch {
+    logger.warn(
+      { eventType, deliveryId },
+      "rejecting webhook request because payload is invalid JSON",
+    );
     return Response.json({ error: "request body must be valid JSON" }, { status: 400 });
   }
 
   const parsedBody = WebhookPayloadSchema.safeParse(rawJson);
 
   if (!parsedBody.success) {
+    logger.warn({ eventType, deliveryId }, "rejecting webhook request because payload is invalid");
     return Response.json(
       { error: "invalid webhook payload", issues: parsedBody.error.format() },
       { status: 400 },
@@ -217,47 +240,27 @@ async function handleLifecycle(
     payload: webhook.body,
     receivedAt: new Date(),
   });
+  logger.info(
+    {
+      provider: "github",
+      source: `github.${webhook.eventType}`,
+      deliveryId: webhook.deliveryId,
+      installationId,
+    },
+    "provider lifecycle event applied",
+  );
   return new Response("OK", { status: 200 });
 }
 
 async function dispatchWebhook(
   handlers: Set<TriggerHandler>,
   triggers: readonly Parameters<TriggerHandler>[0][],
-  webhook: VerifiedWebhook,
 ): Promise<Response> {
-  const { deliveryId, eventType } = webhook;
-  logger.info(
-    {
-      deliveryId,
-      eventType,
-      repo: readRepo(triggers[0]?.payload),
-    },
-    "received webhook event",
+  await Promise.all(
+    triggers.flatMap((trigger) => Array.from(handlers, (handler) => handler(trigger))),
   );
 
-  try {
-    await Promise.all(
-      triggers.flatMap((trigger) => Array.from(handlers, (handler) => handler(trigger))),
-    );
-  } catch (error) {
-    if (isDatabaseUnavailableError(error)) {
-      logger.error(
-        { err: error, deliveryId, eventType },
-        "rejecting webhook because database is unavailable",
-      );
-      return Response.json({ error: "database_unavailable" }, { status: 503 });
-    }
-
-    throw error;
-  }
-
   return new Response("OK", { status: 200 });
-}
-
-function readRepo(payload: unknown): string | undefined {
-  return typeof payload === "object" && payload !== null && "repo" in payload
-    ? String(payload.repo)
-    : undefined;
 }
 
 export function verifySignature(

--- a/src/triggers/manual/source.ts
+++ b/src/triggers/manual/source.ts
@@ -53,6 +53,15 @@ export async function dispatchManualTrigger(
     resourceId: trigger.resourceId ?? null,
   });
   if (persisted.status === "duplicate") {
+    logger.info(
+      {
+        source: trigger.source,
+        deliveryId: trigger.deliveryId,
+        receiptId: persisted.providerEventReceiptId,
+        outcome: "duplicate",
+      },
+      "manual event intake completed",
+    );
     return { providerEventReceiptId: persisted.providerEventReceiptId };
   }
   if (state.handler === undefined) {
@@ -60,8 +69,27 @@ export async function dispatchManualTrigger(
       persisted.event.providerEventReceiptId,
       "configuration_unavailable",
     );
+    logger.info(
+      {
+        source: trigger.source,
+        deliveryId: trigger.deliveryId,
+        receiptId: persisted.event.providerEventReceiptId,
+        outcome: "dropped",
+        reason: "configuration_unavailable",
+      },
+      "manual event intake completed",
+    );
     return { providerEventReceiptId: persisted.event.providerEventReceiptId };
   }
+  logger.info(
+    {
+      source: trigger.source,
+      deliveryId: trigger.deliveryId,
+      receiptId: persisted.event.providerEventReceiptId,
+      outcome: "accepted",
+    },
+    "manual event intake completed",
+  );
   return state.handler(persisted.event);
 }
 
@@ -70,13 +98,18 @@ async function handleManualRequest(request: Request, source: TriggerSource): Pro
 
   try {
     body = await request.json();
-  } catch {
+  } catch (error) {
+    logger.warn(
+      { errorType: error instanceof Error ? error.name : "UnknownError" },
+      "rejecting manual trigger because payload is invalid JSON",
+    );
     return Response.json({ error: "request body must be valid JSON" }, { status: 400 });
   }
 
   const parsed = parseManualTriggerPayload(body);
 
   if (typeof parsed === "string") {
+    logger.warn({ reason: parsed }, "rejecting manual trigger because payload is invalid");
     return Response.json({ error: parsed }, { status: 400 });
   }
 

--- a/src/triggers/slack/client.ts
+++ b/src/triggers/slack/client.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { logger } from "../../logger.js";
 
 const SlackApiResponseSchema = z
   .object({ ok: z.boolean(), error: z.string().optional() })
@@ -189,6 +190,16 @@ export function createSlackBotClient(options: {
         if (!result.ok) throw new Error(`Slack API ${result.error ?? "unknown_error"}`);
       } catch (error) {
         if (selected.length === 0) throw error;
+        logger.warn(
+          {
+            err: error,
+            teamId: input.teamId,
+            channelId: input.channelId,
+            threadTs: input.threadTs,
+            pagesRead,
+          },
+          "Slack thread history hydration incomplete",
+        );
         complete = false;
         break;
       }

--- a/src/triggers/slack/webhook.ts
+++ b/src/triggers/slack/webhook.ts
@@ -5,6 +5,7 @@ import { readBoundedRequestBody } from "../../http/request-body.js";
 import { logger } from "../../logger.js";
 import type { TriggerHandler, TriggerSource } from "../index.js";
 import type { ProviderEventDropReasonCode } from "../drop-reason.js";
+import { logProviderEventIntake } from "../audit.js";
 import {
   normalizeSlackEvent,
   SlackEventCallbackSchema,
@@ -64,12 +65,14 @@ async function verifySlackRequest(
   const signature = request.headers.get("x-slack-signature");
   const timestamp = request.headers.get("x-slack-request-timestamp");
   if (signature === null || timestamp === null) {
+    logger.warn("rejecting Slack event because signature headers are missing");
     return new Response("Unauthorized", { status: 401 });
   }
 
   const body = await readBoundedRequestBody(request, MAX_WEBHOOK_BYTES);
   if (body instanceof Response) return body;
   if (!verifySlackSignature(options.signingSecret, timestamp, body, signature, options.now?.())) {
+    logger.warn("rejecting Slack event because signature verification failed");
     return new Response("Unauthorized", { status: 401 });
   }
 
@@ -77,6 +80,7 @@ async function verifySlackRequest(
   try {
     payload = JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(body));
   } catch {
+    logger.warn("rejecting Slack event because payload is invalid JSON");
     return Response.json({ error: "request body must be valid JSON" }, { status: 400 });
   }
 
@@ -89,23 +93,34 @@ async function handleVerifiedSlackRequest(
   options: SlackWebhookSourceOptions,
 ): Promise<Response> {
   const envelopeType = SlackEnvelopeTypeSchema.safeParse(verified.payload);
-  if (!envelopeType.success) return new Response("Bad Request", { status: 400 });
+  if (!envelopeType.success) {
+    logger.warn("rejecting Slack event because its envelope is invalid");
+    return new Response("Bad Request", { status: 400 });
+  }
 
   if (envelopeType.data.type === "url_verification") {
     const challenge = SlackUrlVerificationSchema.safeParse(verified.payload);
     if (!challenge.success || !matchesConfiguredApp(challenge.data.api_app_id, options.appId)) {
+      logger.warn("rejecting Slack URL verification because its app or payload is invalid");
       return new Response("Bad Request", { status: 400 });
     }
     return Response.json({ challenge: challenge.data.challenge });
   }
 
-  if (envelopeType.data.type !== "event_callback") return new Response("OK", { status: 200 });
+  if (envelopeType.data.type !== "event_callback") {
+    logger.info({ envelopeType: envelopeType.data.type }, "ignoring unsupported Slack envelope");
+    return new Response("OK", { status: 200 });
+  }
   const callback = SlackEventCallbackSchema.safeParse(verified.payload);
   if (!callback.success || callback.data.api_app_id !== options.appId) {
+    logger.warn("rejecting Slack event because its app or callback payload is invalid");
     return new Response("Bad Request", { status: 400 });
   }
   const normalizedEvent = normalizeSlackEvent(callback.data);
-  if (normalizedEvent === undefined) return new Response("OK", { status: 200 });
+  if (normalizedEvent === undefined) {
+    logger.info({ eventId: callback.data.event_id }, "ignoring unsupported Slack event");
+    return new Response("OK", { status: 200 });
+  }
 
   const deliveryId = `slack-${normalizedEvent.id}`;
   try {
@@ -117,6 +132,13 @@ async function handleVerifiedSlackRequest(
       payload: normalizedEvent,
       receivedAt: new Date(normalizedEvent.eventTime * 1_000),
       ...(handlers.size === 0 ? { dropReason: "configuration_unavailable" } : {}),
+    });
+    logProviderEventIntake({
+      provider: "slack",
+      source: "slack.mention",
+      deliveryId,
+      resourceId: normalizedEvent.teamId,
+      acceptance,
     });
     const events = acceptance.status === "accepted" ? acceptance.events : [];
     await Promise.all(

--- a/src/workflows/engine.ts
+++ b/src/workflows/engine.ts
@@ -31,6 +31,7 @@ import type {
   AcceptedTriggerProviderMatch,
 } from "../triggers/index.js";
 import type { ProviderEventDropReasonCode } from "../triggers/drop-reason.js";
+import { logProviderEventRouting } from "../triggers/audit.js";
 import { asTriggerContextValue, isAcceptedTriggerProviderMatch } from "../triggers/index.js";
 import {
   ExpressionEvaluationError,
@@ -128,6 +129,16 @@ export class DurableWorkflowEngine {
         trigger.providerEventReceiptId,
         dropReason,
       );
+      logProviderEventRouting({
+        source: trigger.source,
+        deliveryId: trigger.deliveryId,
+        receiptId: trigger.providerEventReceiptId,
+        projectId: trigger.projectId,
+        triggerNames: [],
+        acceptedCount: 0,
+        rejectedCount: 0,
+        dropReason,
+      });
       return { providerEventReceiptId: trigger.providerEventReceiptId };
     }
     const createdAt = this.now();
@@ -187,6 +198,15 @@ export class DurableWorkflowEngine {
         if (created.created) await this.deliverWorkflowRunAccepted(created.run);
       }),
     );
+    logProviderEventRouting({
+      source: trigger.source,
+      deliveryId: trigger.deliveryId,
+      receiptId: trigger.providerEventReceiptId,
+      projectId: trigger.projectId,
+      triggerNames: matches.map((match) => match.triggerName),
+      acceptedCount: matches.filter(isAcceptedTriggerProviderMatch).length,
+      rejectedCount: matches.filter((match) => match.invocation.status === "rejected").length,
+    });
     return { providerEventReceiptId: trigger.providerEventReceiptId };
   }
 
@@ -233,6 +253,10 @@ export class DurableWorkflowEngine {
     } catch (error) {
       const reason =
         error instanceof Error ? error.message : "workflow_condition_evaluation_failed";
+      this.logger.error(
+        { err: error, triggerRunId: run.id, stepId: step.id },
+        "workflow condition evaluation failed",
+      );
       const failed = await database.failWorkflowRun(run.id, "failed", reason, step.id);
       if (failed?.transitioned === true) await this.notifyWorkflowRunTerminal(failed.run);
       return;
@@ -244,6 +268,10 @@ export class DurableWorkflowEngine {
       }
     } catch (error) {
       const reason = error instanceof Error ? error.message : "workflow_value_evaluation_failed";
+      this.logger.error(
+        { err: error, triggerRunId: run.id, stepId: step.id },
+        "workflow value evaluation failed",
+      );
       const failed = await database.failWorkflowRun(run.id, "failed", reason, step.id);
       if (failed?.transitioned === true) await this.notifyWorkflowRunTerminal(failed.run);
       return;
@@ -495,6 +523,10 @@ export class DurableWorkflowEngine {
       );
     } catch (error) {
       if (!(error instanceof ExpressionEvaluationError)) throw error;
+      this.logger.error(
+        { err: error, triggerRunId: run.id, stepId: step.id },
+        "workflow launch expression evaluation failed",
+      );
       const failed = await database.failWorkflowRun(run.id, "failed", error.message, step.id);
       if (failed?.transitioned === true) await this.notifyWorkflowRunTerminal(failed.run);
       return undefined;
@@ -530,6 +562,10 @@ export class DurableWorkflowEngine {
       );
     } catch (error) {
       const reason = error instanceof Error ? error.message : "trigger_context_unavailable";
+      this.logger.error(
+        { err: error, triggerRunId: run.id, stepId: step.id, executionId },
+        "trigger context materialization failed",
+      );
       const failed = await this.options.database!.failWorkflowRun(
         run.id,
         "failed",
@@ -591,6 +627,10 @@ export class DurableWorkflowEngine {
     } catch (error) {
       const reason =
         error instanceof Error ? error.message : "required output capability unavailable";
+      this.logger.error(
+        { err: error, triggerRunId: run.id, stepId: step.id },
+        "workflow launch intent validation failed",
+      );
       const failed = await database.failWorkflowRun(run.id, "failed", reason, step.id);
       if (failed?.transitioned === true) await this.notifyWorkflowRunTerminal(failed.run);
       return true;
@@ -611,6 +651,10 @@ export class DurableWorkflowEngine {
       );
     } catch (error) {
       const reason = error instanceof Error ? error.message : "workflow_value_evaluation_failed";
+      this.logger.error(
+        { err: error, triggerRunId: run.id },
+        "final workflow value evaluation failed",
+      );
       const failed = await database.failWorkflowRun(run.id, "failed", reason);
       if (failed?.transitioned === true) await this.notifyWorkflowRunTerminal(failed.run);
       return;


### PR DESCRIPTION
Hub now records structured, correlated server logs across connection callbacks and provider event intake and routing. Self-hosters can see why an integration failed or an event did not launch a workflow without exposing event payloads or credentials.

## Goals

- Log safe GitHub, Slack, and Discord connection callback and setup failures.
- Correlate provider event intake and routing with delivery, receipt, project, and trigger identifiers.
- Record accepted, duplicate, rejected, and dropped outcomes at their owning boundaries.
- Surface downstream workflow evaluation, context hydration, and launch failures.
- Keep payloads, prompts, message bodies, attachments, tokens, and credentials out of these logs.

## Non-goals

- Redesign the dashboard or add a persisted audit schema.
- Add a telemetry or log-export backend.
- Change connection, trigger, routing, or workflow behavior.

## Why

Connection failures previously collapsed into generic redirects, and provider events could be accepted or dropped without enough correlated server-side evidence to explain what happened.

## Verification

- Full source suite before relocation: 698 passed, 15 skipped.
- Rebased focused suite: 67 passed.
- Typecheck, lint, formatting, and diff checks pass on current main.
