### PR TITLE
Add a driver-neutral database runtime seam

### DIFF
--- a/e2e/app.ts
+++ b/e2e/app.ts
@@ -9,7 +9,7 @@ import { PostgreSqlContainer, type StartedPostgreSqlContainer } from "@testconta
 import { Client } from "pg";
 import { z } from "zod";
 import { PaseoHub, type BuiltApplication, type BuiltApplicationOptions } from "./helpers/hub.js";
-import { createDatabase } from "../src/db/pg.js";
+import { createDatabase } from "../src/db/test-utils/runtime.js";
 import { SourcePaseo } from "./helpers/source-paseo.js";
 import type { BrowserDiscordEvent } from "../src/e2e/harness/browser-providers.js";
 import type { BrowserProviderScenario } from "../src/e2e/harness/browser-providers.js";

--- a/e2e/helpers/hub.ts
+++ b/e2e/helpers/hub.ts
@@ -21,7 +21,7 @@ import type { BrowserDiscordEvent } from "../../src/e2e/harness/browser-provider
 import type { BrowserProviderScenario } from "../../src/e2e/harness/browser-providers.js";
 import type { FixtureBillingProduct } from "../../src/e2e/harness/browser-billing.js";
 import { fixtureSubscriptionId } from "../../src/e2e/harness/browser-billing.js";
-import { createDatabase } from "../../src/db/pg.js";
+import { createDatabase } from "../../src/db/test-utils/runtime.js";
 import { ProjectConfigurationStore } from "../../src/configuration/store.js";
 import { configurationBundleFixture } from "../../src/test-utils/configuration-bundle.js";
 import { slugify } from "../../src/slug.js";

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@codemirror/language": "^6.12.4",
         "@codemirror/state": "^6.7.1",
         "@codemirror/view": "^6.43.8",
+        "@electric-sql/pglite": "^0.5.4",
         "@lezer/highlight": "^1.2.3",
         "@modelcontextprotocol/sdk": "^1.30.0",
         "@scalar/api-reference-react": "^0.9.37",
@@ -1046,6 +1047,12 @@
       "resolved": "https://registry.npmjs.org/@drizzle-team/brocli/-/brocli-0.10.2.tgz",
       "integrity": "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==",
       "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@electric-sql/pglite": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.5.4.tgz",
+      "integrity": "sha512-yYZUyyXrHU7tPlCjwZQJ6hIG9DscdCCn7Uk0mYKwC1FeHX286AbcmFveMiRBEak8e9iPupjsoVImN3yJZVed2g==",
       "license": "Apache-2.0"
     },
     "node_modules/@esbuild-kit/core-utils": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@codemirror/language": "^6.12.4",
     "@codemirror/state": "^6.7.1",
     "@codemirror/view": "^6.43.8",
+    "@electric-sql/pglite": "^0.5.4",
     "@lezer/highlight": "^1.2.3",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "@scalar/api-reference-react": "^0.9.37",

--- a/src/auth/api-keys.integration.test.ts
+++ b/src/auth/api-keys.integration.test.ts
@@ -2,8 +2,12 @@ import assert from "node:assert/strict";
 import { randomUUID } from "node:crypto";
 import { afterAll, beforeAll, describe, it } from "vitest";
 import { PostgreSqlContainer, type StartedPostgreSqlContainer } from "@testcontainers/postgresql";
-import { Client } from "pg";
-import { createDatabase } from "../db/pg.js";
+import { createPostgresQueryRuntime } from "../db/test-utils/runtime.js";
+import {
+  createDatabase,
+  testDatabaseLocks,
+  testDatabaseRuntime,
+} from "../db/test-utils/runtime.js";
 import type { Database } from "../db/types.js";
 import { createAuthServer, type AuthServer } from "./server.js";
 import { composeEntitlements, type ComposedEntitlements } from "./entitlements.js";
@@ -25,8 +29,8 @@ describe("organization API-key boundary", () => {
     postgres = await new PostgreSqlContainer("postgres:17-alpine").start();
     databaseUrl = postgres.getConnectionUri();
     authDatabase = await createDatabase(databaseUrl);
-    const client = new Client({ connectionString: databaseUrl });
-    await client.connect();
+    const client = await createPostgresQueryRuntime(databaseUrl);
+
     await client.query(`
       insert into organization (id, name, slug) values
         ('organization-a', 'Organization A', 'organization-a'),
@@ -38,10 +42,11 @@ describe("organization API-key boundary", () => {
         ('member-a', 'organization-a', 'user-a', 'owner'),
         ('member-b', 'organization-b', 'user-b', 'owner');
     `);
-    await client.end();
-    authEntitlements = composeEntitlements(authDatabase, databaseUrl);
+    await client.close();
+    authEntitlements = composeEntitlements(authDatabase, testDatabaseRuntime(authDatabase));
     auth = createAuthServer({
-      databaseUrl,
+      database: testDatabaseRuntime(authDatabase),
+      locks: testDatabaseLocks(authDatabase),
       entitlements: authEntitlements.service,
       secret: "test".repeat(8),
       baseURL: "http://localhost:3000",
@@ -266,8 +271,8 @@ describe("organization API-key boundary", () => {
 
   it("serializes enrollment issuance with API-key revocation", async () => {
     const database = await createDatabase(databaseUrl);
-    const client = new Client({ connectionString: databaseUrl });
-    await client.connect();
+    const client = await createPostgresQueryRuntime(databaseUrl);
+
     try {
       const revokedFirst = await auth.apiKeys!.create(
         "organization-a",
@@ -275,21 +280,22 @@ describe("organization API-key boundary", () => {
         `revoked-first-${randomUUID()}`,
         ["daemons:enroll"],
       );
-      await client.query("begin");
-      await client.query(`select id from organization_api_keys where id = $1 for update`, [
-        revokedFirst.summary.id,
-      ]);
-      const revokeFirst = auth.apiKeys!.revoke("organization-a", revokedFirst.summary.id);
-      await new Promise<void>((resolve) => setImmediate(resolve));
-      const rejectedIssue = database.issueEnrollmentToken({
-        id: randomUUID(),
-        verifier: `race-rejected-${randomUUID()}`,
-        organizationId: "organization-a",
-        issuedByApiKeyId: revokedFirst.summary.id,
-        expiresAt: new Date(Date.now() + 60_000),
-        consumedAt: null,
+      const { revokeFirst, rejectedIssue } = await client.transaction(async (transaction) => {
+        await transaction.query(`select id from organization_api_keys where id = $1 for update`, [
+          revokedFirst.summary.id,
+        ]);
+        const revokeOperation = auth.apiKeys!.revoke("organization-a", revokedFirst.summary.id);
+        await new Promise<void>((resolve) => setImmediate(resolve));
+        const issueOperation = database.issueEnrollmentToken({
+          id: randomUUID(),
+          verifier: `race-rejected-${randomUUID()}`,
+          organizationId: "organization-a",
+          issuedByApiKeyId: revokedFirst.summary.id,
+          expiresAt: new Date(Date.now() + 60_000),
+          consumedAt: null,
+        });
+        return { revokeFirst: revokeOperation, rejectedIssue: issueOperation };
       });
-      await client.query("commit");
       assert.equal(await revokeFirst, true);
       assert.equal(await rejectedIssue, false);
 
@@ -300,21 +306,22 @@ describe("organization API-key boundary", () => {
         ["daemons:enroll"],
       );
       const issuedTokenId = randomUUID();
-      await client.query("begin");
-      await client.query(`select id from organization_api_keys where id = $1 for update`, [
-        issuedFirst.summary.id,
-      ]);
-      const acceptedIssue = database.issueEnrollmentToken({
-        id: issuedTokenId,
-        verifier: `race-accepted-${randomUUID()}`,
-        organizationId: "organization-a",
-        issuedByApiKeyId: issuedFirst.summary.id,
-        expiresAt: new Date(Date.now() + 60_000),
-        consumedAt: null,
+      const { acceptedIssue, revokeAfterIssue } = await client.transaction(async (transaction) => {
+        await transaction.query(`select id from organization_api_keys where id = $1 for update`, [
+          issuedFirst.summary.id,
+        ]);
+        const issueOperation = database.issueEnrollmentToken({
+          id: issuedTokenId,
+          verifier: `race-accepted-${randomUUID()}`,
+          organizationId: "organization-a",
+          issuedByApiKeyId: issuedFirst.summary.id,
+          expiresAt: new Date(Date.now() + 60_000),
+          consumedAt: null,
+        });
+        await new Promise<void>((resolve) => setImmediate(resolve));
+        const revokeOperation = auth.apiKeys!.revoke("organization-a", issuedFirst.summary.id);
+        return { acceptedIssue: issueOperation, revokeAfterIssue: revokeOperation };
       });
-      await new Promise<void>((resolve) => setImmediate(resolve));
-      const revokeAfterIssue = auth.apiKeys!.revoke("organization-a", issuedFirst.summary.id);
-      await client.query("commit");
       assert.equal(await acceptedIssue, true);
       assert.equal(await revokeAfterIssue, true);
       const token = await client.query<{ expires_at: Date }>(
@@ -324,7 +331,7 @@ describe("organization API-key boundary", () => {
       assert.equal(token.rowCount, 1);
       assert.ok(token.rows[0]!.expires_at <= new Date());
     } finally {
-      await client.end();
+      await client.close();
       await database.close();
     }
   });
@@ -344,8 +351,8 @@ describe("organization API-key boundary", () => {
       ?.match(/^(?:[^;]+);/u)?.[0]
       ?.slice(0, -1);
     assert.ok(cookie);
-    const client = new Client({ connectionString: databaseUrl });
-    await client.connect();
+    const client = await createPostgresQueryRuntime(databaseUrl);
+
     const user = await client.query<{ id: string }>(`select id from "user" where email = $1`, [
       email,
     ]);
@@ -353,7 +360,7 @@ describe("organization API-key boundary", () => {
       `insert into member (id, organization_id, user_id, role) values ($1, 'organization-a', $2, 'member')`,
       [randomUUID(), user.rows[0]!.id],
     );
-    await client.end();
+    await client.close();
     const select = await auth.handle(
       new Request("http://localhost:3000/api/auth/paseo/select-organization", {
         method: "POST",
@@ -390,8 +397,8 @@ describe("organization API-key boundary", () => {
       ?.match(/^(?:[^;]+);/u)?.[0]
       ?.slice(0, -1);
     assert.ok(cookie);
-    const client = new Client({ connectionString: databaseUrl });
-    await client.connect();
+    const client = await createPostgresQueryRuntime(databaseUrl);
+
     const user = await client.query<{ id: string }>(`select id from "user" where email = $1`, [
       email,
     ]);
@@ -400,7 +407,7 @@ describe("organization API-key boundary", () => {
        values ($1, 'organization-a', $2, 'owner')`,
       [randomUUID(), user.rows[0]!.id],
     );
-    await client.end();
+    await client.close();
     const select = await auth.handle(
       new Request("http://localhost:3000/api/auth/paseo/select-organization", {
         method: "POST",

--- a/src/auth/api-keys.ts
+++ b/src/auth/api-keys.ts
@@ -1,5 +1,11 @@
 import { createHash, randomBytes, randomUUID, timingSafeEqual } from "node:crypto";
-import type { Pool, PoolClient, QueryResultRow } from "pg";
+import type {
+  DatabaseRuntime,
+  QueryHandle,
+  QueryRow,
+  TransactionHandle,
+} from "../db/runtime/index.js";
+import type { Locks } from "../db/runtime/locks/index.js";
 import { z } from "zod";
 import { apiKeyScopesSchema, type ApiKeyScope } from "./api-key-contract.js";
 import { withApiKeySerialization } from "../db/api-key-serialization.js";
@@ -36,7 +42,7 @@ export type OperationAuthorizationResult =
   | { status: "forbidden" }
   | { status: "authorized"; access: OperationAuthorization };
 
-interface ApiKeyRow extends QueryResultRow {
+interface ApiKeyRow extends QueryRow {
   id: string;
   organization_id: string;
   name: string;
@@ -49,14 +55,17 @@ interface ApiKeyRow extends QueryResultRow {
 }
 
 export class OrganizationApiKeys {
-  constructor(private readonly pool: Pool) {}
+  constructor(
+    private readonly pool: DatabaseRuntime,
+    private readonly locks: Locks,
+  ) {}
 
   async create(
     organizationId: string,
     createdByUserId: string,
     name: string,
     scopes: readonly ApiKeyScope[],
-    client: Pool | PoolClient = this.pool,
+    client: QueryHandle = this.pool,
   ): Promise<CreatedApiKey> {
     const keyName = apiKeyNameSchema.parse(name);
     const keyScopes = apiKeyScopesSchema.parse([...new Set(scopes)]);
@@ -98,24 +107,15 @@ export class OrganizationApiKeys {
   async revoke(
     organizationId: string,
     id: string,
-    transactionClient?: PoolClient,
+    transactionClient?: TransactionHandle,
   ): Promise<boolean> {
     return withApiKeySerialization(id, async () => {
       if (transactionClient !== undefined) {
-        return revokeWithClient(transactionClient, organizationId, id);
+        return revokeWithClient(this.locks, transactionClient, organizationId, id);
       }
-      const client = await this.pool.connect();
-      try {
-        await client.query("begin");
-        const revoked = await revokeWithClient(client, organizationId, id);
-        await client.query("commit");
-        return revoked;
-      } catch (error) {
-        await client.query("rollback").catch(() => undefined);
-        throw error;
-      } finally {
-        client.release();
-      }
+      return this.pool.transaction((client) =>
+        revokeWithClient(this.locks, client, organizationId, id),
+      );
     });
   }
 
@@ -160,11 +160,12 @@ export class OrganizationApiKeys {
 }
 
 async function revokeWithClient(
-  client: PoolClient,
+  locks: Locks,
+  client: TransactionHandle,
   organizationId: string,
   id: string,
 ): Promise<boolean> {
-  await client.query(`select pg_advisory_xact_lock(hashtext($1))`, [id]);
+  await locks.withTxLock(client, id);
   const result = await client.query(
     `update organization_api_keys
      set revoked_at = coalesce(revoked_at, now())

--- a/src/auth/bootstrap.integration.test.ts
+++ b/src/auth/bootstrap.integration.test.ts
@@ -1,9 +1,14 @@
 import assert from "node:assert/strict";
 import { afterAll, beforeAll, describe, it } from "vitest";
 import { PostgreSqlContainer, type StartedPostgreSqlContainer } from "@testcontainers/postgresql";
-import { Client } from "pg";
+import { createPostgresQueryRuntime } from "../db/test-utils/runtime.js";
 import { z } from "zod";
-import { createDatabase, createPostgresPool } from "../db/pg.js";
+import {
+  createDatabase,
+  createPostgresPool,
+  testDatabaseLocks,
+  testDatabaseRuntime,
+} from "../db/test-utils/runtime.js";
 import { bootstrapInstance, InstanceBootstrapError } from "./bootstrap.js";
 import { createAuthServer, type AuthServer } from "./server.js";
 import { composeEntitlements } from "./entitlements.js";
@@ -35,7 +40,7 @@ describe("instance bootstrap and first-login boundary", () => {
   it("creates one owner with a forced password change and is restart-idempotent", async () => {
     const pool = await migratedPool(databaseUrl);
     await bootstrapInstance(pool, policy);
-    await pool.end();
+    await pool.close();
 
     const first = await queryBootstrapState(databaseUrl);
     assert.equal(first.organizationCount, 1);
@@ -46,15 +51,15 @@ describe("instance bootstrap and first-login boundary", () => {
     assert.equal(first.mustChangePassword, true);
     assert.equal(first.completionOrganizationId, first.organizationId);
 
-    const client = new Client({ connectionString: databaseUrl });
-    await client.connect();
+    const client = await createPostgresQueryRuntime(databaseUrl);
+
     await client.query(`update "user" set must_change_password = false where email = $1`, [
       policy.bootstrap!.ownerEmail,
     ]);
-    await client.end();
+    await client.close();
     const restarted = await migratedPool(databaseUrl);
     await bootstrapInstance(restarted, policy);
-    await restarted.end();
+    await restarted.close();
     const afterRestart = await queryBootstrapState(databaseUrl);
     assert.equal(afterRestart.mustChangePassword, false);
     assert.deepEqual({ ...afterRestart, mustChangePassword: true }, first);
@@ -63,27 +68,27 @@ describe("instance bootstrap and first-login boundary", () => {
       ...policy,
       bootstrap: { ...policy.bootstrap!, ownerPassword: undefined },
     });
-    await completedWithoutPassword.end();
+    await completedWithoutPassword.close();
     assert.equal((await queryBootstrapState(databaseUrl)).mustChangePassword, false);
   }, 120_000);
 
   it("does not write identity data when the configured owner conflicts", async () => {
     const isolated = await isolatedDatabaseUrl(databaseUrl, "bootstrap_conflict");
     const database = await createDatabase(isolated);
-    const client = new Client({ connectionString: isolated });
-    await client.connect();
+    const client = await createPostgresQueryRuntime(isolated);
+
     await client.query(
       `insert into "user" (id, name, email, email_verified) values ('existing', 'Existing', $1, true)`,
       [policy.bootstrap!.ownerEmail],
     );
-    await client.end();
-    const pool = createPostgresPool(isolated);
+    await client.close();
+    const pool = await createPostgresPool(isolated);
     await assert.rejects(
       bootstrapInstance(pool, policy),
       (error: unknown) =>
         error instanceof InstanceBootstrapError && error.message.includes("already belongs"),
     );
-    await pool.end();
+    await pool.close();
     await database.close();
     const verification = await queryBootstrapState(isolated);
     assert.equal(verification.organizationCount, 0);
@@ -103,7 +108,7 @@ describe("instance bootstrap and first-login boundary", () => {
         error instanceof InstanceBootstrapError &&
         error.message.includes("PASEO_BOOTSTRAP_OWNER_PASSWORD"),
     );
-    await pool.end();
+    await pool.close();
     const result = await queryBootstrapState(isolated);
     assert.equal(result.organizationCount, 0);
     assert.equal(result.ownerCount, 0);
@@ -113,10 +118,10 @@ describe("instance bootstrap and first-login boundary", () => {
   it("serializes concurrent production starts into one bootstrap result", async () => {
     const isolated = await isolatedDatabaseUrl(databaseUrl, "bootstrap_race");
     const first = await migratedPool(isolated);
-    const second = createPostgresPool(isolated);
+    const second = await createPostgresPool(isolated);
     await Promise.all([bootstrapInstance(first, policy), bootstrapInstance(second, policy)]);
-    await first.end();
-    await second.end();
+    await first.close();
+    await second.close();
     const result = await queryBootstrapState(isolated);
     assert.equal(result.organizationCount, 1);
     assert.equal(result.ownerCount, 1);
@@ -130,11 +135,12 @@ describe("instance bootstrap and first-login boundary", () => {
     const isolated = await isolatedDatabaseUrl(databaseUrl, "bootstrap_gate");
     const pool = await migratedPool(isolated);
     await bootstrapInstance(pool, policy);
-    await pool.end();
+    await pool.close();
     const database = await createDatabase(isolated);
-    const entitlements = composeEntitlements(database, isolated);
+    const entitlements = composeEntitlements(database, testDatabaseRuntime(database));
     const auth = createAuthServer({
-      databaseUrl: isolated,
+      database: testDatabaseRuntime(database),
+      locks: testDatabaseLocks(database),
       entitlements: entitlements.service,
       secret: "bootstrap-gate-secret-at-least-32-characters",
       baseURL: "http://localhost:3000",
@@ -203,18 +209,18 @@ async function migratedPool(url: string) {
 async function isolatedDatabaseUrl(baseUrl: string, name: string): Promise<string> {
   const base = new URL(baseUrl);
   base.pathname = "/postgres";
-  const admin = new Client({ connectionString: base.toString() });
-  await admin.connect();
+  const admin = await createPostgresQueryRuntime(base.toString());
+
   const databaseName = `${name}_${Date.now()}`;
   await admin.query(`create database "${databaseName}"`);
-  await admin.end();
+  await admin.close();
   base.pathname = `/${databaseName}`;
   return base.toString();
 }
 
 async function queryBootstrapState(url: string) {
-  const client = new Client({ connectionString: url });
-  await client.connect();
+  const client = await createPostgresQueryRuntime(url);
+
   const result = await client.query<{
     organization_count: number;
     owner_count: number;
@@ -237,7 +243,7 @@ async function queryBootstrapState(url: string) {
       (select id from organization limit 1) as organization_id,
       (select count(*)::integer from instance_bootstrap) as bootstrap_rows
   `);
-  await client.end();
+  await client.close();
   const row = result.rows[0]!;
   return {
     organizationCount: row.organization_count,

--- a/src/auth/bootstrap.ts
+++ b/src/auth/bootstrap.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { hashPassword } from "better-auth/crypto";
-import type { Pool, PoolClient, QueryResultRow } from "pg";
+import type { DatabaseRuntime, QueryHandle, QueryRow } from "../db/runtime/index.js";
 import {
   provisionOrganization,
   UNLIMITED_PROVISIONING,
@@ -11,13 +11,13 @@ import type { BootstrapSettings, InstanceAuthPolicy } from "./instance-policy.js
 
 const BOOTSTRAP_ROW_ID = "default";
 
-interface BootstrapRow extends QueryResultRow {
+interface BootstrapRow extends QueryRow {
   organization_id: string | null;
   owner_user_id: string | null;
   completed_at: Date | null;
 }
 
-interface ExistingOrganization extends QueryResultRow {
+interface ExistingOrganization extends QueryRow {
   id: string;
   name: string;
   slug: string;
@@ -38,7 +38,7 @@ export class InstanceBootstrapError extends Error {
  * a later startup might mistake for a completed bootstrap.
  */
 export async function bootstrapInstance(
-  pool: Pool,
+  pool: DatabaseRuntime,
   policy: InstanceAuthPolicy,
   provisioningEntitlements: ProvisioningEntitlementResolver = () =>
     Promise.resolve(UNLIMITED_PROVISIONING),
@@ -49,54 +49,47 @@ export async function bootstrapInstance(
   // Resolve outside the transaction — the same value the create-organization path uses, so the
   // bootstrap owner's organization is stamped by the instance's provisioning policy too.
   const entitlement = await provisioningEntitlements();
-  const client = await pool.connect();
   try {
-    await client.query("begin");
-    await client.query(
-      `insert into instance_bootstrap (id) values ($1)
+    await pool.transaction(async (client) => {
+      await client.query(
+        `insert into instance_bootstrap (id) values ($1)
        on conflict (id) do nothing`,
-      [BOOTSTRAP_ROW_ID],
-    );
-    const existing = await client.query<BootstrapRow>(
-      `select organization_id, owner_user_id, completed_at
+        [BOOTSTRAP_ROW_ID],
+      );
+      const existing = await client.query<BootstrapRow>(
+        `select organization_id, owner_user_id, completed_at
        from instance_bootstrap
        where id = $1
        for update`,
-      [BOOTSTRAP_ROW_ID],
-    );
-    const row = existing.rows[0];
-    if (row === undefined) throw new InstanceBootstrapError("bootstrap state disappeared");
-    if (row.completed_at !== null) {
-      await client.query("commit");
-      return;
-    }
-    if (row.owner_user_id !== null) {
-      throw new InstanceBootstrapError(
-        "bootstrap state has an owner without completion; repair the instance_bootstrap row before restarting",
+        [BOOTSTRAP_ROW_ID],
       );
-    }
+      const row = existing.rows[0];
+      if (row === undefined) throw new InstanceBootstrapError("bootstrap state disappeared");
+      if (row.completed_at !== null) return;
+      if (row.owner_user_id !== null) {
+        throw new InstanceBootstrapError(
+          "bootstrap state has an owner without completion; repair the instance_bootstrap row before restarting",
+        );
+      }
 
-    const created = await createBootstrapData(client, settings, row.organization_id, entitlement);
-    await client.query(
-      `update instance_bootstrap
+      const created = await createBootstrapData(client, settings, row.organization_id, entitlement);
+      await client.query(
+        `update instance_bootstrap
        set organization_id = $2, owner_user_id = $3, completed_at = now()
        where id = $1`,
-      [BOOTSTRAP_ROW_ID, created.organizationId, created.ownerUserId],
-    );
-    await client.query("commit");
+        [BOOTSTRAP_ROW_ID, created.organizationId, created.ownerUserId],
+      );
+    });
   } catch (error) {
-    await client.query("rollback").catch(() => undefined);
     if (error instanceof InstanceBootstrapError) throw error;
     throw new InstanceBootstrapError(
       `bootstrap failed: ${error instanceof Error ? error.message : "unknown database error"}`,
     );
-  } finally {
-    client.release();
   }
 }
 
 async function createBootstrapData(
-  client: PoolClient,
+  client: QueryHandle,
   settings: BootstrapSettings,
   existingOrganizationId: string | null,
   entitlement: ProvisioningEntitlement,
@@ -229,7 +222,7 @@ async function createBootstrapData(
   };
 }
 
-async function latestOrganizationId(client: PoolClient, ownerUserId: string): Promise<string> {
+async function latestOrganizationId(client: QueryHandle, ownerUserId: string): Promise<string> {
   const result = await client.query<{ id: string }>(
     `select organization_id as id from member where user_id = $1 and role = 'owner'`,
     [ownerUserId],

--- a/src/auth/cli-credentials.ts
+++ b/src/auth/cli-credentials.ts
@@ -1,12 +1,12 @@
 import { createHash, timingSafeEqual } from "node:crypto";
-import type { Pool, PoolClient, QueryResultRow } from "pg";
+import type { DatabaseRuntime, QueryHandle, QueryRow } from "../db/runtime/index.js";
 import { API_KEY_SCOPES, type ApiKeyScope } from "./api-key-contract.js";
 import type { OperationAuthorizationResult } from "./api-keys.js";
 
 export const CLI_CREDENTIAL_PREFIX = "paseo_cli_";
 const CLI_CREDENTIAL_PREFIX_LENGTH = 12;
 
-interface CliCredentialRow extends QueryResultRow {
+interface CliCredentialRow extends QueryRow {
   id: string;
   organization_id: string;
   prefix: string;
@@ -15,7 +15,7 @@ interface CliCredentialRow extends QueryResultRow {
 }
 
 export class OrganizationCliCredentials {
-  constructor(private readonly pool: Pool) {}
+  constructor(private readonly pool: DatabaseRuntime) {}
 
   async authorize(
     request: Request,
@@ -74,7 +74,7 @@ export class OrganizationCliCredentials {
   async revoke(
     organizationId: string,
     id: string,
-    client: Pool | PoolClient = this.pool,
+    client: QueryHandle = this.pool,
   ): Promise<boolean> {
     const result = await client.query(
       `update organization_cli_credentials set revoked_at = coalesce(revoked_at, now())
@@ -93,7 +93,7 @@ export interface CliCredentialSummary {
   revokedAt: Date | null;
 }
 
-interface CliCredentialSummaryRow extends QueryResultRow {
+interface CliCredentialSummaryRow extends QueryRow {
   id: string;
   prefix: string;
   created_at: Date;

--- a/src/auth/entitlements.ts
+++ b/src/auth/entitlements.ts
@@ -1,4 +1,4 @@
-import { createPostgresPool } from "../db/pg.js";
+import type { DatabaseRuntime } from "../db/runtime/index.js";
 import type { Database } from "../db/types.js";
 import { EntitlementsService } from "../entitlements/service.js";
 import { countOrganizationSeatUsage } from "./organization-access.js";
@@ -6,7 +6,7 @@ import { countOrganizationSeatUsage } from "./organization-access.js";
 export interface ComposedEntitlements {
   service: EntitlementsService;
   /** The organization's live seat count (members + pending invitations). Shared with billing's
-   * post-paid seat reporter so both read the same pool-backed count. */
+   * post-paid seat reporter so both read the same runtime-backed count. */
   seatUsage: (organizationId: string) => Promise<number>;
   close(): Promise<void>;
 }
@@ -17,15 +17,15 @@ export interface ComposedEntitlements {
  * instances that run without auth, so entitlements can never be owned by the optional auth
  * server. Auth, the dashboard, and the workflow engine are all injected this one instance.
  *
- * The `seats` counter reads better-auth `member`/`invitation` tables, so it needs a pool rather
- * than the `Database` interface (the in-memory database does not model them). This owns that
- * pool and closes it. The count runs on its own pooled connection; the invite flow's advisory
- * lock is what serializes concurrent invites, so a cross-connection count still sees a
- * consistent seat total.
+ * The `seats` counter reads better-auth `member`/`invitation` tables, so it needs the database
+ * runtime rather than the `Database` interface (the in-memory database does not model them).
+ * The composition root owns that runtime; this service only borrows it.
  */
-export function composeEntitlements(database: Database, databaseUrl: string): ComposedEntitlements {
-  const pool = createPostgresPool(databaseUrl);
-  const seatUsage = (organizationId: string) => countOrganizationSeatUsage(pool, organizationId);
+export function composeEntitlements(
+  database: Database,
+  runtime: DatabaseRuntime,
+): ComposedEntitlements {
+  const seatUsage = (organizationId: string) => countOrganizationSeatUsage(runtime, organizationId);
   const service = new EntitlementsService(database, { seats: seatUsage });
-  return { service, seatUsage, close: () => pool.end() };
+  return { service, seatUsage, close: () => Promise.resolve() };
 }

--- a/src/auth/organization-access.ts
+++ b/src/auth/organization-access.ts
@@ -1,5 +1,11 @@
 import { randomUUID } from "node:crypto";
-import type { Pool, PoolClient, QueryResultRow } from "pg";
+import type {
+  DatabaseRuntime,
+  QueryHandle,
+  QueryRow,
+  TransactionHandle,
+} from "../db/runtime/index.js";
+import type { Locks } from "../db/runtime/locks/index.js";
 import { z } from "zod";
 import { logger } from "../logger.js";
 import { OrganizationApiKeys } from "./api-keys.js";
@@ -78,7 +84,8 @@ export interface AccountSessionReader {
 }
 
 interface OrganizationAccessOptions {
-  pool: Pool;
+  pool: DatabaseRuntime;
+  locks: Locks;
   sessions: AccountSessionReader;
   baseURL: string;
   policy: InstanceAuthPolicy;
@@ -94,7 +101,7 @@ interface OrganizationAccessOptions {
   onMembershipChanged?: (organizationId: string) => Promise<void>;
 }
 
-interface MembershipRow extends QueryResultRow {
+interface MembershipRow extends QueryRow {
   member_id: string;
   organization_id: string;
   organization_name: string;
@@ -102,7 +109,7 @@ interface MembershipRow extends QueryResultRow {
   role: string;
 }
 
-interface MemberRow extends QueryResultRow {
+interface MemberRow extends QueryRow {
   id: string;
   user_id: string;
   name: string;
@@ -110,7 +117,7 @@ interface MemberRow extends QueryResultRow {
   role: string;
 }
 
-interface InvitationRow extends QueryResultRow {
+interface InvitationRow extends QueryRow {
   id: string;
   organization_id: string;
   organization_name: string;
@@ -120,7 +127,7 @@ interface InvitationRow extends QueryResultRow {
   expires_at: Date;
 }
 
-interface TargetMemberRow extends QueryResultRow {
+interface TargetMemberRow extends QueryRow {
   id: string;
   user_id: string;
   role: string;
@@ -282,7 +289,7 @@ export class OrganizationAccess {
     // Resolve the provisioning entitlement before opening the transaction — on a hosted instance
     // this reads the Free plan from the catalog mirror, which must not run inside the org insert.
     const entitlement = await this.options.provisioningEntitlements();
-    const organization = await transaction(this.options.pool, async (client) => {
+    const organization = await this.options.pool.transaction(async (client) => {
       const created = await provisionOrganization(
         client,
         {
@@ -304,7 +311,7 @@ export class OrganizationAccess {
   private async selectOrganization(request: Request): Promise<Response> {
     const session = await this.requireSession(request);
     const input = await parseBody(request, organizationIdBody);
-    await transaction(this.options.pool, async (client) => {
+    await this.options.pool.transaction(async (client) => {
       const membership = await client.query(
         `select 1 from member
          where user_id = $1 and organization_id = $2 and role in ('owner', 'admin', 'member')`,
@@ -357,8 +364,12 @@ export class OrganizationAccess {
     if (scopes.length !== input.scopes.length) {
       throw new ProductRequestError(400, "invalid_api_key_scopes");
     }
-    const created = await transaction(this.options.pool, async (client) => {
-      await lockOrganizationMembershipTransitions(client, access.organization.id);
+    const created = await this.options.pool.transaction(async (client) => {
+      await lockOrganizationMembershipTransitions(
+        this.options.locks,
+        client,
+        access.organization.id,
+      );
       const actorRole = await currentActorRole(client, access);
       if (!capabilitiesFor(actorRole).manageResources) {
         throw new ProductRequestError(403, "forbidden");
@@ -392,8 +403,12 @@ export class OrganizationAccess {
     const session = await this.requireSession(request);
     const input = await parseBody(request, apiKeyIdBody);
     const access = await this.requireActiveAccess(session);
-    await transaction(this.options.pool, async (client) => {
-      await lockOrganizationMembershipTransitions(client, access.organization.id);
+    await this.options.pool.transaction(async (client) => {
+      await lockOrganizationMembershipTransitions(
+        this.options.locks,
+        client,
+        access.organization.id,
+      );
       const actorRole = await currentActorRole(client, access);
       if (!capabilitiesFor(actorRole).manageResources) {
         throw new ProductRequestError(403, "forbidden");
@@ -409,8 +424,12 @@ export class OrganizationAccess {
     const session = await this.requireSession(request);
     const input = await parseBody(request, apiKeyIdBody);
     const access = await this.requireActiveAccess(session);
-    await transaction(this.options.pool, async (client) => {
-      await lockOrganizationMembershipTransitions(client, access.organization.id);
+    await this.options.pool.transaction(async (client) => {
+      await lockOrganizationMembershipTransitions(
+        this.options.locks,
+        client,
+        access.organization.id,
+      );
       const role = await currentActorRole(client, access);
       if (!capabilitiesFor(role).manageResources) {
         throw new ProductRequestError(403, "forbidden");
@@ -427,8 +446,12 @@ export class OrganizationAccess {
     const input = await parseBody(request, createInvitationBody);
     const access = await this.requireActiveAccess(session);
     const email = normalizeEmail(input.email);
-    const invitation = await transaction(this.options.pool, async (client) => {
-      await lockOrganizationMembershipTransitions(client, access.organization.id);
+    const invitation = await this.options.pool.transaction(async (client) => {
+      await lockOrganizationMembershipTransitions(
+        this.options.locks,
+        client,
+        access.organization.id,
+      );
       await lockOrganizationMembers(client, access.organization.id);
       const actorRole = await currentActorRole(client, access);
       if (!capabilitiesFor(actorRole).manageMembers) {
@@ -505,11 +528,13 @@ export class OrganizationAccess {
     const session = await this.requireSession(request);
     const input = await parseBody(request, invitationIdBody);
     const access = await this.requireActiveAccess(session);
-    await transaction(this.options.pool, async (client) => {
-      await client.query(`select pg_advisory_xact_lock(hashtextextended($1, 0))`, [
-        invitationLockName(input.invitationId),
-      ]);
-      await lockOrganizationMembershipTransitions(client, access.organization.id);
+    await this.options.pool.transaction(async (client) => {
+      await this.options.locks.withTxLock(client, invitationLockName(input.invitationId));
+      await lockOrganizationMembershipTransitions(
+        this.options.locks,
+        client,
+        access.organization.id,
+      );
       await lockOrganizationMembers(client, access.organization.id);
       const actorRole = await currentActorRole(client, access);
       if (!capabilitiesFor(actorRole).manageMembers) {
@@ -530,7 +555,7 @@ export class OrganizationAccess {
   private async acceptInvitation(request: Request): Promise<Response> {
     const session = await this.requireSession(request);
     const input = await parseBody(request, invitationIdBody);
-    const organizationId = await transaction(this.options.pool, async (client) => {
+    const organizationId = await this.options.pool.transaction(async (client) => {
       const target = await client.query<{ organization_id: string }>(
         `select organization_id from invitation where id = $1`,
         [input.invitationId],
@@ -539,10 +564,8 @@ export class OrganizationAccess {
       if (targetOrganizationId === undefined) {
         throw new ProductRequestError(404, "invitation_unavailable");
       }
-      await client.query(`select pg_advisory_xact_lock(hashtextextended($1, 0))`, [
-        invitationLockName(input.invitationId),
-      ]);
-      await lockOrganizationMembershipTransitions(client, targetOrganizationId);
+      await this.options.locks.withTxLock(client, invitationLockName(input.invitationId));
+      await lockOrganizationMembershipTransitions(this.options.locks, client, targetOrganizationId);
       const invitationResult = await client.query<InvitationRow>(
         `select invitation.id, invitation.organization_id, organization.name as organization_name,
                 "user".name as inviter_name, invitation.email, invitation.role,
@@ -584,8 +607,12 @@ export class OrganizationAccess {
     const session = await this.requireSession(request);
     const input = await parseBody(request, changeRoleBody);
     const access = await this.requireActiveAccess(session);
-    await transaction(this.options.pool, async (client) => {
-      await lockOrganizationMembershipTransitions(client, access.organization.id);
+    await this.options.pool.transaction(async (client) => {
+      await lockOrganizationMembershipTransitions(
+        this.options.locks,
+        client,
+        access.organization.id,
+      );
       await lockOrganizationMembers(client, access.organization.id);
       const actorRole = await currentActorRole(client, access);
       const target = await targetMember(client, access.organization.id, input.memberId);
@@ -606,8 +633,12 @@ export class OrganizationAccess {
     const session = await this.requireSession(request);
     const input = await parseBody(request, removeMemberBody);
     const access = await this.requireActiveAccess(session);
-    await transaction(this.options.pool, async (client) => {
-      await lockOrganizationMembershipTransitions(client, access.organization.id);
+    await this.options.pool.transaction(async (client) => {
+      await lockOrganizationMembershipTransitions(
+        this.options.locks,
+        client,
+        access.organization.id,
+      );
       await lockOrganizationMembers(client, access.organization.id);
       const actorRole = await currentActorRole(client, access);
       const target = await targetMember(client, access.organization.id, input.memberId);
@@ -662,7 +693,7 @@ export class OrganizationAccess {
   }
 
   private async activeAccess(
-    client: Pool | PoolClient,
+    client: QueryHandle,
     session: AccountSession,
   ): Promise<OrganizationAccessValue | undefined> {
     if (session.activeOrganizationId === null) return undefined;
@@ -675,7 +706,7 @@ export class OrganizationAccess {
   }
 
   private async memberships(
-    client: Pool | PoolClient,
+    client: QueryHandle,
     userId: string,
     organizationId?: string,
   ): Promise<MembershipRow[]> {
@@ -760,7 +791,7 @@ export class OrganizationAccess {
   }
 
   private async availableInvitation(
-    client: Pool | PoolClient,
+    client: QueryHandle,
     invitationId: string,
     accountEmail: string,
   ): Promise<InvitationRow | undefined> {
@@ -779,7 +810,7 @@ export class OrganizationAccess {
   }
 
   private async signedOutInvitation(
-    client: Pool | PoolClient,
+    client: QueryHandle,
     invitationId: string,
   ): Promise<InvitationRow | undefined> {
     const result = await client.query<InvitationRow>(
@@ -881,7 +912,7 @@ async function parseBody<TSchema extends z.ZodType>(
 }
 
 async function activateSession(
-  client: PoolClient,
+  client: QueryHandle,
   session: AccountSession,
   organizationId: string,
 ): Promise<void> {
@@ -894,7 +925,7 @@ async function activateSession(
 }
 
 async function targetMember(
-  client: PoolClient,
+  client: QueryHandle,
   organizationId: string,
   memberId: string,
 ): Promise<TargetMemberRow | undefined> {
@@ -906,7 +937,7 @@ async function targetMember(
 }
 
 async function currentActorRole(
-  client: PoolClient,
+  client: QueryHandle,
   access: OrganizationAccessValue,
 ): Promise<OrganizationRole> {
   const result = await client.query<{ role: string }>(
@@ -925,7 +956,7 @@ async function currentActorRole(
  * This is the seats counter wired into `EntitlementsService` at composition.
  */
 export async function countOrganizationSeatUsage(
-  pool: Pool,
+  pool: QueryHandle,
   organizationId: string,
 ): Promise<number> {
   const result = await pool.query<{ count: string }>(
@@ -938,23 +969,22 @@ export async function countOrganizationSeatUsage(
   return Number(result.rows[0]?.count ?? 0);
 }
 
-async function lockOrganizationMembers(client: PoolClient, organizationId: string): Promise<void> {
+async function lockOrganizationMembers(client: QueryHandle, organizationId: string): Promise<void> {
   await client.query(`select id from member where organization_id = $1 for update`, [
     organizationId,
   ]);
 }
 
 async function lockOrganizationMembershipTransitions(
-  client: PoolClient,
+  locks: Locks,
+  client: TransactionHandle,
   organizationId: string,
 ): Promise<void> {
-  await client.query(`select pg_advisory_xact_lock(hashtextextended($1, 0))`, [
-    `paseo-organization-membership:${organizationId}`,
-  ]);
+  await locks.withTxLock(client, `paseo-organization-membership:${organizationId}`);
 }
 
 async function protectLastOwner(
-  client: PoolClient,
+  client: QueryHandle,
   organizationId: string,
   current: OrganizationRole,
   next: OrganizationRole | undefined,
@@ -966,24 +996,6 @@ async function protectLastOwner(
     [organizationId],
   );
   if (owners.rows[0]?.count === 1) throw new ProductRequestError(409, "last_owner_required");
-}
-
-async function transaction<T>(
-  pool: Pool,
-  operation: (client: PoolClient) => Promise<T>,
-): Promise<T> {
-  const client = await pool.connect();
-  try {
-    await client.query("begin");
-    const value = await operation(client);
-    await client.query("commit");
-    return value;
-  } catch (error) {
-    await client.query("rollback");
-    throw error;
-  } finally {
-    client.release();
-  }
 }
 
 function normalizeEmail(email: string): string {

--- a/src/auth/registration-admission.integration.test.ts
+++ b/src/auth/registration-admission.integration.test.ts
@@ -2,8 +2,12 @@ import assert from "node:assert/strict";
 import { randomUUID } from "node:crypto";
 import { afterAll, beforeAll, describe, it } from "vitest";
 import { PostgreSqlContainer, type StartedPostgreSqlContainer } from "@testcontainers/postgresql";
-import { Client } from "pg";
-import { createDatabase } from "../db/pg.js";
+import { createPostgresQueryRuntime } from "../db/test-utils/runtime.js";
+import {
+  createDatabase,
+  testDatabaseLocks,
+  testDatabaseRuntime,
+} from "../db/test-utils/runtime.js";
 import { createAuthServer, type AuthServer } from "./server.js";
 import { composeEntitlements } from "./entitlements.js";
 
@@ -104,9 +108,10 @@ describe("registration policy boundary", () => {
   async function startAuth(registrationMode: "open" | "invite_only" | "disabled") {
     const url = await isolatedDatabaseUrl(postgres.getConnectionUri(), registrationMode);
     const database = await createDatabase(url);
-    const entitlements = composeEntitlements(database, url);
+    const entitlements = composeEntitlements(database, testDatabaseRuntime(database));
     const auth = createAuthServer({
-      databaseUrl: url,
+      database: testDatabaseRuntime(database),
+      locks: testDatabaseLocks(database),
       entitlements: entitlements.service,
       secret: "registration-policy-secret-at-least-32-characters",
       baseURL: "http://localhost:3000",
@@ -161,8 +166,8 @@ async function seedInvitation(
   status: "pending" | "canceled",
   expired = false,
 ): Promise<string> {
-  const client = new Client({ connectionString: url });
-  await client.connect();
+  const client = await createPostgresQueryRuntime(url);
+
   const id = randomUUID();
   const organizationId = `org-${id}`;
   const userId = `user-${id}`;
@@ -189,28 +194,28 @@ async function seedInvitation(
       userId,
     ],
   );
-  await client.end();
+  await client.close();
   return id;
 }
 
 async function userCount(url: string): Promise<number> {
-  const client = new Client({ connectionString: url });
-  await client.connect();
+  const client = await createPostgresQueryRuntime(url);
+
   const result = await client.query<{ count: number }>(
     `select count(*)::integer as count from "user"`,
   );
-  await client.end();
+  await client.close();
   return result.rows[0]!.count;
 }
 
 async function isolatedDatabaseUrl(baseUrl: string, name: string): Promise<string> {
   const base = new URL(baseUrl);
   base.pathname = "/postgres";
-  const admin = new Client({ connectionString: base.toString() });
-  await admin.connect();
+  const admin = await createPostgresQueryRuntime(base.toString());
+
   const databaseName = `${name}_${randomUUID().slice(0, 8)}`;
   await admin.query(`create database "${databaseName}"`);
-  await admin.end();
+  await admin.close();
   base.pathname = `/${databaseName}`;
   return base.toString();
 }

--- a/src/auth/registration-admission.ts
+++ b/src/auth/registration-admission.ts
@@ -1,4 +1,5 @@
-import type { Pool, PoolClient } from "pg";
+import type { DatabaseRuntime, TransactionHandle } from "../db/runtime/index.js";
+import type { Locks } from "../db/runtime/locks/index.js";
 import { z } from "zod";
 import type { InstanceAuthPolicy } from "./instance-policy.js";
 import { normalizeEmail } from "./instance-policy.js";
@@ -12,7 +13,8 @@ export function invitationLockName(invitationId: string): string {
 
 export class RegistrationAdmission {
   constructor(
-    private readonly pool: Pool,
+    private readonly pool: DatabaseRuntime,
+    private readonly locks: Locks,
     private readonly policy: InstanceAuthPolicy,
   ) {}
 
@@ -55,40 +57,27 @@ export class RegistrationAdmission {
   ): Promise<T> {
     if (this.policy.registrationMode === "open") return action();
     if (invitationId === undefined) throw new RegistrationAdmissionError();
-    const client = await this.pool.connect();
     const lockKey = invitationLockName(invitationId);
-    try {
-      await client.query(`select pg_advisory_lock(hashtextextended($1, 0))`, [lockKey]);
-      if (!(await this.isAdmittedWithClient(client, email, invitationId))) {
+    return this.locks.withLock(lockKey, async () => {
+      if (!(await this.isAdmitted(email, invitationId))) {
         throw new RegistrationAdmissionError();
       }
-      const existingUser = await client.query(
+      const existingUser = await this.pool.query(
         `select 1 from "user" where lower(email) = $1 limit 1`,
         [normalizeEmail(email)],
       );
       if (existingUser.rowCount !== 0) throw new RegistrationAdmissionError();
       return await action();
-    } finally {
-      await client
-        .query(`select pg_advisory_unlock(hashtextextended($1, 0))`, [lockKey])
-        .catch(() => undefined);
-      client.release();
-    }
+    });
   }
 
-  async lockInvitation(client: PoolClient, invitationId: string): Promise<void> {
-    await client.query(`select pg_advisory_xact_lock(hashtextextended($1, 0))`, [
-      invitationLockName(invitationId),
-    ]);
+  async lockInvitation(client: TransactionHandle, invitationId: string): Promise<void> {
+    await this.locks.withTxLock(client, invitationLockName(invitationId));
   }
 
-  private async isAdmittedWithClient(
-    client: PoolClient,
-    email: string,
-    invitationId: string,
-  ): Promise<boolean> {
+  private async isAdmitted(email: string, invitationId: string): Promise<boolean> {
     if (this.policy.registrationMode === "disabled") return false;
-    const result = await client.query(
+    const result = await this.pool.query(
       `select 1 from invitation
        where id = $1 and status = 'pending' and expires_at > now()
          and lower(email) = $2`,

--- a/src/auth/server.integration.test.ts
+++ b/src/auth/server.integration.test.ts
@@ -2,9 +2,14 @@ import assert from "node:assert/strict";
 import { randomUUID } from "node:crypto";
 import { afterAll, afterEach, beforeAll, describe, it } from "vitest";
 import { PostgreSqlContainer, type StartedPostgreSqlContainer } from "@testcontainers/postgresql";
-import { Client } from "pg";
+import { createPostgresQueryRuntime } from "../db/test-utils/runtime.js";
+import type { DatabaseRuntime } from "../db/runtime/index.js";
 import { z } from "zod";
-import { createDatabase } from "../db/pg.js";
+import {
+  createDatabase,
+  testDatabaseLocks,
+  testDatabaseRuntime,
+} from "../db/test-utils/runtime.js";
 import type { Database } from "../db/types.js";
 import { OrganizationResources } from "../organizations/resources.js";
 import {
@@ -350,13 +355,14 @@ class PaseoAccounts {
   static async start(postgres: StartedPostgreSqlContainer): Promise<PaseoAccounts> {
     const url = isolatedDatabaseUrl(postgres);
     const database = await createDatabase(url);
-    const entitlements = composeEntitlements(database, url);
+    const entitlements = composeEntitlements(database, testDatabaseRuntime(database));
     return new PaseoAccounts(
       url,
       database,
       entitlements,
       createAuthServer({
-        databaseUrl: url,
+        database: testDatabaseRuntime(database),
+        locks: testDatabaseLocks(database),
         entitlements: entitlements.service,
         secret: "phase-one-auth-secret-at-least-32-characters",
         baseURL: "http://localhost:3000",
@@ -512,32 +518,30 @@ class PaseoAccounts {
   }
 
   async revokeDuringInvitation(actor: AccountBrowser, organizationId: string): Promise<number> {
-    const blocker = new Client({ connectionString: this.url });
-    await blocker.connect();
+    const blocker = await createPostgresQueryRuntime(this.url);
+
     try {
-      await blocker.query("begin");
-      await blocker.query(
-        `select member.id from member
+      let request!: Promise<number>;
+      await blocker.transaction(async (transaction) => {
+        await transaction.query(
+          `select member.id from member
          join "user" on "user".id = member.user_id
          where member.organization_id = $1 and lower("user".email) = $2
          for update of member`,
-        [organizationId, actor.email],
-      );
-      const request = actor.createInvitation("blocked@example.com", "member");
-      await waitForBlockedTransaction(blocker);
-      await blocker.query(
-        `delete from member using "user"
+          [organizationId, actor.email],
+        );
+        request = actor.createInvitation("blocked@example.com", "member");
+        await waitForBlockedTransaction(blocker);
+        await transaction.query(
+          `delete from member using "user"
          where member.user_id = "user".id and member.organization_id = $1
            and lower("user".email) = $2`,
-        [organizationId, actor.email],
-      );
-      await blocker.query("commit");
+          [organizationId, actor.email],
+        );
+      });
       return await request;
-    } catch (error) {
-      await blocker.query("rollback");
-      throw error;
     } finally {
-      await blocker.end();
+      await blocker.close();
     }
   }
 
@@ -614,12 +618,12 @@ class PaseoAccounts {
     text: string,
     values: unknown[] = [],
   ): Promise<TRow[]> {
-    const client = new Client({ connectionString: this.url });
-    await client.connect();
+    const client = await createPostgresQueryRuntime(this.url);
+
     try {
       return (await client.query<TRow>(text, values)).rows;
     } finally {
-      await client.end();
+      await client.close();
     }
   }
 }
@@ -889,7 +893,7 @@ function missingResources(): ResourceIds {
   };
 }
 
-async function waitForBlockedTransaction(client: Client): Promise<void> {
+async function waitForBlockedTransaction(client: DatabaseRuntime): Promise<void> {
   for (let attempt = 0; attempt < 100; attempt += 1) {
     const result = await client.query<{ blocked: boolean }>(
       `select exists (

--- a/src/auth/server.ts
+++ b/src/auth/server.ts
@@ -1,10 +1,10 @@
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { tanstackStartCookies } from "better-auth/tanstack-start";
-import { drizzle } from "drizzle-orm/node-postgres";
-import { createPostgresPool } from "../db/pg.js";
 import { z } from "zod";
 import * as schema from "../db/schema.js";
+import type { DatabaseRuntime } from "../db/runtime/index.js";
+import type { Locks } from "../db/runtime/locks/index.js";
 import { OrganizationApiKeys } from "./api-keys.js";
 import { OrganizationCliCredentials } from "./cli-credentials.js";
 import { PublicCredentialAuthenticator } from "./public-credentials.js";
@@ -61,7 +61,8 @@ export interface AuthServer {
 }
 
 interface AuthServerOptions {
-  databaseUrl: string;
+  database: DatabaseRuntime;
+  locks: Locks;
   /** Owned by the composition root, injected here — auth consumes entitlements, never owns them. */
   entitlements: EntitlementsService;
   secret: string;
@@ -104,15 +105,14 @@ const RAW_PRODUCT_PATHS = new Set([
 ]);
 
 export function createAuthServer(options: AuthServerOptions): AuthServer {
-  const pool = createPostgresPool(options.databaseUrl);
-  const database = drizzle(pool, { schema });
+  const database = options.database.drizzle();
   const policy = options.policy ?? defaultInstanceAuthPolicy();
   const provisioningEntitlements =
     options.provisioningEntitlements ?? (() => Promise.resolve(UNLIMITED_PROVISIONING));
-  const apiKeys = new OrganizationApiKeys(pool);
-  const cliCredentials = new OrganizationCliCredentials(pool);
+  const apiKeys = new OrganizationApiKeys(options.database, options.locks);
+  const cliCredentials = new OrganizationCliCredentials(options.database);
   const publicCredentials = new PublicCredentialAuthenticator(apiKeys, cliCredentials);
-  const registration = new RegistrationAdmission(pool, policy);
+  const registration = new RegistrationAdmission(options.database, options.locks, policy);
   const authSchema = {
     user: schema.users,
     session: schema.sessions,
@@ -174,7 +174,8 @@ export function createAuthServer(options: AuthServerOptions): AuthServer {
     },
   };
   const access = new OrganizationAccess({
-    pool,
+    pool: options.database,
+    locks: options.locks,
     sessions,
     baseURL: options.baseURL,
     policy,
@@ -246,7 +247,7 @@ export function createAuthServer(options: AuthServerOptions): AuthServer {
         body: { ...data, revokeOtherSessions: true },
         headers,
       });
-      await pool.query(
+      await options.database.query(
         `update "user" set must_change_password = false, updated_at = now() where id = $1`,
         [session.userId],
       );
@@ -257,11 +258,11 @@ export function createAuthServer(options: AuthServerOptions): AuthServer {
     resolveOrganizationAccess: (request) => access.resolve(request),
     resolveAccount: (request) => access.account(request),
     rejectCookieMutation: (request) => rejectCrossOriginCookieMutation(request, browserOrigin),
-    initialize: () => bootstrapInstance(pool, policy, provisioningEntitlements),
+    initialize: () => bootstrapInstance(options.database, policy, provisioningEntitlements),
     apiKeys,
     cliCredentials,
     publicCredentials,
-    close: () => pool.end(),
+    close: () => Promise.resolve(),
   };
 
   async function changePassword(request: Request): Promise<Response> {
@@ -282,7 +283,7 @@ export function createAuthServer(options: AuthServerOptions): AuthServer {
           )
         : await auth.handler(request);
     if (response.ok && session !== undefined) {
-      await pool.query(`update "user" set must_change_password = false where id = $1`, [
+      await options.database.query(`update "user" set must_change_password = false where id = $1`, [
         session.userId,
       ]);
     }

--- a/src/cli-authorizations/cli-authorizations.integration.test.ts
+++ b/src/cli-authorizations/cli-authorizations.integration.test.ts
@@ -1,9 +1,10 @@
 import assert from "node:assert/strict";
 import { afterAll, beforeAll, describe, it } from "vitest";
 import { PostgreSqlContainer, type StartedPostgreSqlContainer } from "@testcontainers/postgresql";
-import { Client, type QueryResultRow } from "pg";
+import type { QueryRow } from "../db/runtime/index.js";
+import { createPostgresQueryRuntime } from "../db/test-utils/runtime.js";
 import { z } from "zod";
-import { createDatabase, createPostgresPool } from "../db/pg.js";
+import { createDatabase, createPostgresPool } from "../db/test-utils/runtime.js";
 import type { Database } from "../db/types.js";
 import { OrganizationCliCredentials } from "../auth/cli-credentials.js";
 import { CliAuthorizations } from "./index.js";
@@ -69,7 +70,7 @@ describe("CLI authorization PostgreSQL state machine", () => {
     );
     assert.equal(stored[0]?.count, 1);
     assert.notEqual(stored[0]?.verifier, credential);
-    const pool = createPostgresPool(databaseUrl);
+    const pool = await createPostgresPool(databaseUrl);
     const cliCredentials = new OrganizationCliCredentials(pool);
     const authorized = await cliCredentials.authorize(
       new Request("https://hub.test/api/v1/projects", {
@@ -96,7 +97,7 @@ describe("CLI authorization PostgreSQL state machine", () => {
       ).status,
       "unauthorized",
     );
-    await pool.end();
+    await pool.close();
     assert.equal(
       (await authorizations.poll(post("/poll", { deviceCode: started.deviceCode }))).status,
       200,
@@ -136,22 +137,22 @@ describe("CLI authorization PostgreSQL state machine", () => {
   });
 
   async function sql(statement: string): Promise<void> {
-    const client = new Client({ connectionString: databaseUrl });
-    await client.connect();
+    const client = await createPostgresQueryRuntime(databaseUrl);
+
     try {
       await client.query(statement);
     } finally {
-      await client.end();
+      await client.close();
     }
   }
 
-  async function rows<T extends QueryResultRow>(statement: string): Promise<T[]> {
-    const client = new Client({ connectionString: databaseUrl });
-    await client.connect();
+  async function rows<T extends QueryRow>(statement: string): Promise<T[]> {
+    const client = await createPostgresQueryRuntime(databaseUrl);
+
     try {
       return (await client.query<T>(statement)).rows;
     } finally {
-      await client.end();
+      await client.close();
     }
   }
 });

--- a/src/connections/connections.integration.test.ts
+++ b/src/connections/connections.integration.test.ts
@@ -2,8 +2,9 @@ import assert from "node:assert/strict";
 import { createHash, createHmac, randomUUID } from "node:crypto";
 import { PostgreSqlContainer, type StartedPostgreSqlContainer } from "@testcontainers/postgresql";
 import { afterEach, beforeEach, describe, it } from "vitest";
-import { Client, type Pool } from "pg";
-import { createDatabase, createPostgresPool } from "../db/pg.js";
+import type { DatabaseRuntime, QueryHandle } from "../db/runtime/index.js";
+import { createPostgresQueryRuntime } from "../db/test-utils/runtime.js";
+import { createDatabase, createPostgresPool } from "../db/test-utils/runtime.js";
 import type { Database } from "../db/types.js";
 import type { AuthServer } from "../auth/server.js";
 import type { OrganizationAccessValue } from "../auth/organization-access.js";
@@ -28,7 +29,7 @@ interface ProviderFixture {
 
 describe("provider connection facades PostgreSQL authority", () => {
   let postgres: StartedPostgreSqlContainer;
-  let pool: Pool;
+  let pool: DatabaseRuntime;
   let database: Database;
   let auth: ConnectionAuth;
   let github: TestGitHub;
@@ -38,7 +39,7 @@ describe("provider connection facades PostgreSQL authority", () => {
   beforeEach(async () => {
     postgres = await new PostgreSqlContainer("postgres:17-alpine").start();
     database = await createDatabase(postgres.getConnectionUri());
-    pool = createPostgresPool(postgres.getConnectionUri());
+    pool = await createPostgresPool(postgres.getConnectionUri());
     await seedAccount(pool, "acme", "owner");
     auth = new ConnectionAuth(accessFor("acme", "owner"));
     github = new TestGitHub();
@@ -52,7 +53,7 @@ describe("provider connection facades PostgreSQL authority", () => {
   }, 120_000);
 
   afterEach(async () => {
-    await pool?.end();
+    await pool?.close();
     await database?.close();
     await postgres?.stop();
   }, 120_000);
@@ -619,7 +620,7 @@ function connectionsWithAuth(database: Database, auth: AuthServer): ProviderFixt
   });
 }
 
-async function seedAccount(pool: Pool, organizationId: string, role: string): Promise<void> {
+async function seedAccount(pool: QueryHandle, organizationId: string, role: string): Promise<void> {
   const userId = `user-${organizationId}`;
   await pool.query(`insert into organization (id, name, slug) values ($1,$1,$1)`, [organizationId]);
   await pool.query(`insert into "user" (id, name, email) values ($1,$2,$3)`, [
@@ -721,7 +722,7 @@ async function connectDiscord(connections: ProviderFixture): Promise<void> {
 
 async function rejectGitHubCallbackAfter(
   database: Database,
-  pool: Pool,
+  pool: QueryHandle,
   organizationId: string,
   mutateAuthority: () => Promise<void>,
 ): Promise<string | null> {
@@ -749,41 +750,39 @@ async function rejectCallbackAfterExpiryWhileLocked(
   lockedRow: { text: string; values: unknown[] },
   callback: () => Promise<Response>,
 ): Promise<string | null> {
-  const holder = new Client({ connectionString });
-  await holder.connect();
+  const holder = await createPostgresQueryRuntime(connectionString);
+
   try {
-    const scheduled = await holder.query<{ expires_at: Date }>(
-      scheduleExpiry.text,
-      scheduleExpiry.values,
-    );
-    const expiresAt = scheduled.rows[0]?.expires_at;
-    assert.notEqual(expiresAt, undefined);
-    await holder.query("begin");
-    await holder.query(lockedRow.text, lockedRow.values);
-    const response = callback();
-    await expectBlockedOnLockedAuthority(holder);
-    await holder.query(
-      `select pg_sleep(
+    let response!: Promise<Response>;
+    await holder.transaction(async (transaction) => {
+      const scheduled = await transaction.query<{ expires_at: Date }>(
+        scheduleExpiry.text,
+        scheduleExpiry.values,
+      );
+      const expiresAt = scheduled.rows[0]?.expires_at;
+      assert.notEqual(expiresAt, undefined);
+      await transaction.query(lockedRow.text, lockedRow.values);
+      response = callback();
+      await expectBlockedOnLockedAuthority(holder);
+      await transaction.query(
+        `select pg_sleep(
          greatest(extract(epoch from ($1::timestamptz - clock_timestamp())), 0) + 0.01
        )`,
-      [expiresAt],
-    );
-    const expired = await holder.query<{ expired: boolean }>(
-      `select $1::timestamptz <= clock_timestamp() as expired`,
-      [expiresAt],
-    );
-    assert.equal(expired.rows[0]?.expired, true);
-    await holder.query("commit");
+        [expiresAt],
+      );
+      const expired = await transaction.query<{ expired: boolean }>(
+        `select $1::timestamptz <= clock_timestamp() as expired`,
+        [expiresAt],
+      );
+      assert.equal(expired.rows[0]?.expired, true);
+    });
     return result(await response);
-  } catch (error) {
-    await holder.query("rollback").catch(() => undefined);
-    throw error;
   } finally {
-    await holder.end();
+    await holder.close();
   }
 }
 
-async function attemptAuthority(pool: Pool, attemptId: string) {
+async function attemptAuthority(pool: QueryHandle, attemptId: string) {
   const authority = await pool.query<{
     phase: string;
     consumed: boolean;
@@ -798,7 +797,7 @@ async function attemptAuthority(pool: Pool, attemptId: string) {
   return authority.rows[0];
 }
 
-async function expectBlockedOnLockedAuthority(client: Client): Promise<void> {
+async function expectBlockedOnLockedAuthority(client: DatabaseRuntime): Promise<void> {
   for (let attempt = 0; attempt < 100; attempt += 1) {
     const waiting = await client.query<{ count: number }>(
       `select count(*)::integer as count
@@ -813,7 +812,7 @@ async function expectBlockedOnLockedAuthority(client: Client): Promise<void> {
   assert.fail("connection callback did not block on the locked authority row");
 }
 
-async function attemptIdForState(pool: Pool, state: string): Promise<string> {
+async function attemptIdForState(pool: QueryHandle, state: string): Promise<string> {
   const attempt = await pool.query<{ id: string }>(
     `select id from organization_connection_attempts where state_verifier = $1`,
     [createHashForTest(state)],

--- a/src/daemons/test-utils/hub-harness.ts
+++ b/src/daemons/test-utils/hub-harness.ts
@@ -6,7 +6,7 @@ import { createServer } from "node:net";
 import type { Duplex } from "node:stream";
 import { PostgreSqlContainer, type StartedPostgreSqlContainer } from "@testcontainers/postgresql";
 import { createStartHandler, defaultStreamHandler } from "@tanstack/react-start/server";
-import { Client } from "pg";
+import { createPostgresQueryRuntime } from "../../db/test-utils/runtime.js";
 import { dump } from "js-yaml";
 import { WebSocket, type RawData } from "ws";
 import { z } from "zod";
@@ -24,7 +24,7 @@ import {
   deriveAgentExecutionCompletionToken,
   hashAgentExecutionCompletionToken,
 } from "../../agent-executions/completion-token.js";
-import { createDatabase } from "../../db/pg.js";
+import { createDatabase } from "../../db/test-utils/runtime.js";
 import type { ApiKeyScope } from "../../auth/api-key-contract.js";
 import type { OperationAuthenticator } from "../../auth/operation-auth.js";
 import type {
@@ -251,8 +251,8 @@ export class HubHarness {
   async seedSlackWorkspace(teamId: string, slug = "paseo"): Promise<string> {
     if (this.postgres === undefined) throw new Error("Postgres is unavailable");
     const id = "00000000-0000-4000-8000-0000000000c1";
-    const client = new Client({ connectionString: this.postgres.getConnectionUri() });
-    await client.connect();
+    const client = await createPostgresQueryRuntime(this.postgres.getConnectionUri());
+
     await client.query(
       `insert into slack_connections
          (id, organization_id, team_id, slug, team_name, bot_user_id, bot_access_token, scopes)
@@ -260,15 +260,15 @@ export class HubHarness {
        on conflict (team_id) do nothing`,
       [id, HUB_ORGANIZATION_ID, teamId, slug, JSON.stringify(["app_mentions:read", "chat:write"])],
     );
-    await client.end();
+    await client.close();
     return id;
   }
 
   async seedCurrentProjectResources(): Promise<string> {
     const slackId = await this.seedSlackWorkspace("paseo");
     if (this.postgres === undefined) throw new Error("Postgres is unavailable");
-    const client = new Client({ connectionString: this.postgres.getConnectionUri() });
-    await client.connect();
+    const client = await createPostgresQueryRuntime(this.postgres.getConnectionUri());
+
     const githubId = "00000000-0000-4000-8000-0000000000c2";
     await client.query(
       `insert into discord_connections
@@ -293,7 +293,7 @@ export class HubHarness {
        on conflict (connection_id, repository_id) do nothing`,
       [HUB_ORGANIZATION_ID, githubId],
     );
-    await client.end();
+    await client.close();
     return slackId;
   }
 
@@ -1475,10 +1475,8 @@ export class HubHarness {
   private async startResources(): Promise<void> {
     this.postgres = await new PostgreSqlContainer("postgres:17-alpine").start();
     this.database = await createDatabase(this.postgres.getConnectionUri());
-    const client = new Client({
-      connectionString: this.postgres.getConnectionUri(),
-    });
-    await client.connect();
+    const client = await createPostgresQueryRuntime(this.postgres.getConnectionUri());
+
     await client.query(
       `insert into organization (id, name, slug) values ('org_1', 'Hub harness', 'hub-harness')`,
     );
@@ -1509,7 +1507,7 @@ export class HubHarness {
        values ($1, $2, 'Default', $3, $4)`,
       [HUB_PROJECT_ID, HUB_ORGANIZATION_ID, HUB_PROJECT_SLUG, HUB_USER_ID],
     );
-    await client.end();
+    await client.close();
     const store = new ProjectConfigurationStore(this.database, HUB_PROJECT_ID);
     await this.database.issueEnrollmentToken({
       id: "00000000-0000-4000-8000-0000000000ee",

--- a/src/db/agent-executions.integration.test.ts
+++ b/src/db/agent-executions.integration.test.ts
@@ -1,9 +1,9 @@
 import assert from "node:assert/strict";
 import { randomUUID } from "node:crypto";
 import { PostgreSqlContainer, type StartedPostgreSqlContainer } from "@testcontainers/postgresql";
-import { Client } from "pg";
+import { createPostgresQueryRuntime } from "./test-utils/runtime.js";
 import { afterAll, beforeAll, describe, it } from "vitest";
-import { createDatabase } from "./pg.js";
+import { createDatabase } from "./test-utils/runtime.js";
 import {
   compileHubConfig,
   compiledConfigurationHash,
@@ -602,8 +602,8 @@ describe("agent execution PostgreSQL repository", () => {
       );
       assert.equal(recoveredExecution?.id, execution.id);
       assert.equal(successfulHandoffs, 1);
-      const client = new Client({ connectionString: fixture.databaseUrl });
-      await client.connect();
+      const client = await createPostgresQueryRuntime(fixture.databaseUrl);
+
       try {
         const count = await client.query<{ count: string }>(
           `select count(*)::text as count
@@ -614,7 +614,7 @@ describe("agent execution PostgreSQL repository", () => {
         );
         assert.equal(count.rows[0]?.count, "1");
       } finally {
-        await client.end();
+        await client.close();
       }
     } finally {
       await fixture.database.close();
@@ -1079,10 +1079,9 @@ describe("agent execution PostgreSQL repository", () => {
 
   it("replays accepted and rejected runs by receipt, project, and trigger identity", async () => {
     const fixture = await executionFixture(postgres);
-    const client = new Client({ connectionString: fixture.databaseUrl });
+    const client = await createPostgresQueryRuntime(fixture.databaseUrl);
     const projectTwoId = "00000000-0000-0000-0000-000000000002";
     try {
-      await client.connect();
       await client.query(
         `insert into projects (id, organization_id, name, slug)
          values ($1, 'org-1', 'Second', 'second')`,
@@ -1199,7 +1198,7 @@ describe("agent execution PostgreSQL repository", () => {
       assert.equal(rejectedFirstReplay.created, false);
       assert.equal(rejectedSecondReplay.created, false);
     } finally {
-      await client.end();
+      await client.close();
       await fixture.database.close();
     }
   });
@@ -1566,8 +1565,8 @@ async function executionFixture(
   const url = new URL(postgres.getConnectionUri());
   url.pathname = `/execution_finality_${randomUUID().replaceAll("-", "")}`;
   const database = await createDatabase(url.toString());
-  const client = new Client({ connectionString: url.toString() });
-  await client.connect();
+  const client = await createPostgresQueryRuntime(url.toString());
+
   await client.query(
     "insert into organization (id, name, slug) values ('org-1', 'Finality', 'finality')",
   );
@@ -1575,7 +1574,7 @@ async function executionFixture(
     `insert into projects (id, organization_id, name, slug)
      values ('00000000-0000-4000-8000-000000000001', 'org-1', 'Default', 'default')`,
   );
-  await client.end();
+  await client.close();
 
   const revisionConfiguration = allWorkflowConfigurations();
   const config = await database.insertProjectConfigurationRevision({

--- a/src/db/connections.ts
+++ b/src/db/connections.ts
@@ -1,5 +1,6 @@
 import { and, eq, inArray, isNull, sql } from "drizzle-orm";
-import type { NodePgDatabase } from "drizzle-orm/node-postgres";
+import type { Locks } from "./runtime/locks/index.js";
+import type { DatabaseRuntime, DrizzleHandle, TransactionHandle } from "./runtime/index.js";
 import { slugify } from "../slug.js";
 import { ConnectionAccessDeniedError, ConnectionConflictError } from "./errors.js";
 import * as schema from "./schema.js";
@@ -20,15 +21,23 @@ import type {
   StartConnectionAttemptInput,
 } from "./types.js";
 
-type HubDatabase = NodePgDatabase<typeof schema>;
-type HubTransaction = Parameters<Parameters<HubDatabase["transaction"]>[0]>[0];
+type HubDatabase = DrizzleHandle;
+type HubTransaction = HubDatabase;
 type AttemptRow = typeof schema.organizationConnectionAttempts.$inferSelect;
 
 export class ConnectionRepository {
-  constructor(private readonly database: HubDatabase) {}
+  private readonly database: HubDatabase;
+
+  constructor(
+    private readonly runtime: DatabaseRuntime,
+    private readonly locks: Locks,
+  ) {
+    this.database = runtime.drizzle();
+  }
 
   async startAttempt(input: StartConnectionAttemptInput): Promise<void> {
-    await this.database.transaction(async (transaction) => {
+    await this.runtime.transaction(async (runtimeTransaction) => {
+      const transaction = runtimeTransaction.drizzle();
       await lockStartAuthority(transaction, input.access);
       await transaction.delete(schema.organizationConnectionAttempts).where(orExpiredOrConsumed());
       await transaction.insert(schema.organizationConnectionAttempts).values({
@@ -45,7 +54,8 @@ export class ConnectionRepository {
   }
 
   async readAttempt(input: ReadConnectionAttemptInput): Promise<ConnectionAttemptRecord> {
-    return this.database.transaction(async (transaction) => {
+    return this.runtime.transaction(async (runtimeTransaction) => {
+      const transaction = runtimeTransaction.drizzle();
       await lockAccountSession(transaction, input.access);
       const attempt = await lockAttempt(transaction, input);
       await lockStoredAuthority(transaction, attempt);
@@ -54,7 +64,8 @@ export class ConnectionRepository {
   }
 
   async consumeAttempt(input: ReadConnectionAttemptInput): Promise<void> {
-    await this.database.transaction(async (transaction) => {
+    await this.runtime.transaction(async (runtimeTransaction) => {
+      const transaction = runtimeTransaction.drizzle();
       await lockAccountSession(transaction, input.access);
       const attempt = await lockAttempt(transaction, input);
       await lockStoredAuthority(transaction, attempt);
@@ -63,7 +74,8 @@ export class ConnectionRepository {
   }
 
   async advanceGitHubAttempt(input: AdvanceGitHubConnectionAttemptInput): Promise<void> {
-    await this.database.transaction(async (transaction) => {
+    await this.runtime.transaction(async (runtimeTransaction) => {
+      const transaction = runtimeTransaction.drizzle();
       await lockAccountSession(transaction, input.access);
       const attempt = await lockAttempt(transaction, input);
       await lockStoredAuthority(transaction, attempt);
@@ -80,9 +92,10 @@ export class ConnectionRepository {
   }
 
   async bindGitHub(input: BindGitHubConnectionInput): Promise<void> {
-    await this.database.transaction(async (transaction) => {
+    await this.runtime.transaction(async (runtimeTransaction) => {
+      const transaction = runtimeTransaction.drizzle();
       await lockAccountSession(transaction, input.access);
-      await lockExternal(transaction, "github", String(input.installationId));
+      await lockExternal(this.locks, runtimeTransaction, "github", String(input.installationId));
       const attempt = await lockAttempt(transaction, input);
       await lockStoredAuthority(transaction, attempt);
       const [existing] = await transaction
@@ -154,9 +167,10 @@ export class ConnectionRepository {
   }
 
   async bindSlack(input: BindSlackConnectionInput): Promise<void> {
-    await this.database.transaction(async (transaction) => {
+    await this.runtime.transaction(async (runtimeTransaction) => {
+      const transaction = runtimeTransaction.drizzle();
       await lockAccountSession(transaction, input.access);
-      await lockExternal(transaction, "slack", input.teamId);
+      await lockExternal(this.locks, runtimeTransaction, "slack", input.teamId);
       const attempt = await lockAttempt(transaction, input);
       await lockStoredAuthority(transaction, attempt);
       const [existing] = await transaction
@@ -209,9 +223,10 @@ export class ConnectionRepository {
     externalId: string,
     insert: (transaction: HubTransaction, attempt: AttemptRow) => Promise<void>,
   ): Promise<void> {
-    await this.database.transaction(async (transaction) => {
+    await this.runtime.transaction(async (runtimeTransaction) => {
+      const transaction = runtimeTransaction.drizzle();
       await lockAccountSession(transaction, input.access);
-      await lockExternal(transaction, provider, externalId);
+      await lockExternal(this.locks, runtimeTransaction, provider, externalId);
       const attempt = await lockAttempt(transaction, input);
       await lockStoredAuthority(transaction, attempt);
       const conflict =
@@ -262,7 +277,8 @@ export class ConnectionRepository {
     connectionId: string,
     access: ConnectionStartAuthority,
   ) {
-    return this.database.transaction(async (transaction) => {
+    return this.runtime.transaction(async (runtimeTransaction) => {
+      const transaction = runtimeTransaction.drizzle();
       await lockStartAuthority(transaction, access);
       if (provider === "github") {
         const [connection] = await transaction
@@ -514,12 +530,14 @@ async function expiredAtDatabaseClock(
 }
 
 async function lockExternal(
-  transaction: HubTransaction,
+  locks: Locks,
+  transaction: TransactionHandle,
   provider: ConnectionProvider,
   externalId: string,
 ): Promise<void> {
-  await transaction.execute(
-    sql`select pg_advisory_xact_lock(hashtextextended(${JSON.stringify(["paseo-connection", provider, "external", externalId])}, 0))`,
+  await locks.withTxLock(
+    transaction,
+    JSON.stringify(["paseo-connection", provider, "external", externalId]),
   );
 }
 

--- a/src/db/migrate.ts
+++ b/src/db/migrate.ts
@@ -1,8 +1,12 @@
 import "dotenv/config";
-import { createDatabase } from "./pg.js";
+import { postgresDatabaseRuntime } from "./runtime/index.js";
 
 const databaseUrl =
   process.env["DATABASE_URL"] ?? "postgres://postgres:postgres@localhost:5432/paseo_hub";
-const database = await createDatabase(databaseUrl);
+const { runtime } = await postgresDatabaseRuntime(databaseUrl);
 
-await database.close();
+try {
+  await runtime.migrate();
+} finally {
+  await runtime.close();
+}

--- a/src/db/migrations.integration.test.ts
+++ b/src/db/migrations.integration.test.ts
@@ -4,10 +4,11 @@ import { readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, it } from "vitest";
 import { PostgreSqlContainer, type StartedPostgreSqlContainer } from "@testcontainers/postgresql";
-import { Client, type QueryResultRow } from "pg";
+import type { DatabaseRuntime, QueryHandle, QueryRow } from "./runtime/index.js";
+import { createPostgresQueryRuntime } from "./test-utils/runtime.js";
 import { z } from "zod";
 import { dump } from "js-yaml";
-import { createDatabase, createPostgresPool } from "./pg.js";
+import { createDatabase, createPostgresPool } from "./test-utils/runtime.js";
 import { createHubApplication } from "../app.js";
 import { ProjectConfigurationStore, revisionBundleFiles } from "../configuration/store.js";
 import { configurationBundleFixture } from "../test-utils/configuration-bundle.js";
@@ -369,9 +370,9 @@ describe("database migration application", () => {
         ownerPassword: "temporary-migrated-owner-password",
       },
     };
-    const pool = createPostgresPool(fixture.url);
+    const pool = await createPostgresPool(fixture.url);
     await bootstrapInstance(pool, policy);
-    await pool.end();
+    await pool.close();
 
     assert.deepEqual(await durableSnapshot(fixture.url), before);
     const completion = await poolQuery<{
@@ -405,8 +406,8 @@ describe("database migration application", () => {
       prefix: "retired_project_evidence",
       through: "0010_classy_strong_guy",
     });
-    const client = new Client({ connectionString: url });
-    await client.connect();
+    const client = await createPostgresQueryRuntime(url);
+
     const activeId = randomUUID();
     const historicalId = randomUUID();
     const machineId = randomUUID();
@@ -435,7 +436,7 @@ describe("database migration application", () => {
        values ($1, 'organization-bootstrap', '{}', 'terminated', $2)`,
       [machineId, activeId],
     );
-    await client.end();
+    await client.close();
 
     const database = await createDatabase(url);
     await database.close();
@@ -1107,19 +1108,19 @@ async function rejectedPhaseOneFixtures(
 async function rejectedPhaseOneFixture(
   postgres: StartedPostgreSqlContainer,
   name: string,
-  seed: (client: Client) => Promise<void>,
+  seed: (client: DatabaseRuntime) => Promise<void>,
 ): Promise<string> {
   const url = await createHistoricalBaseline({
     postgres,
     prefix: name,
     through: "0000_phase_0_spine",
   });
-  const client = new Client({ connectionString: url });
-  await client.connect();
+  const client = await createPostgresQueryRuntime(url);
+
   try {
     await seed(client);
   } finally {
-    await client.end();
+    await client.close();
   }
   try {
     const migrated = await createDatabase(url);
@@ -1130,7 +1131,7 @@ async function rejectedPhaseOneFixture(
   }
 }
 
-async function seedMigrationIdentity(client: Client): Promise<void> {
+async function seedMigrationIdentity(client: DatabaseRuntime): Promise<void> {
   await client.query(`
     insert into organization (id, name, slug)
       values ('organization-fixture', 'Fixture', 'fixture');
@@ -1272,7 +1273,7 @@ async function createLegacyDatabase(
      values ('legacy-operator', $1)`,
     [organizationId],
   );
-  await client.end();
+  await client.close();
   return { url, organizationId, legacyToken };
 }
 
@@ -1284,20 +1285,20 @@ async function createPendingEnrollmentDatabase(postgres: StartedPostgreSqlContai
      values ($1, $2, now() + interval '1 day')`,
     [randomUUID(), createHash("sha256").update(token).digest("base64url")],
   );
-  await client.end();
+  await client.close();
   return { url, token };
 }
 
 async function createLegacySchema(postgres: StartedPostgreSqlContainer, prefix: string) {
   const url = databaseUrl(postgres, prefix);
   const databaseName = new URL(url).pathname.slice(1);
-  const admin = new Client({ connectionString: postgres.getConnectionUri() });
-  await admin.connect();
-  await admin.query(`create database "${databaseName}"`);
-  await admin.end();
+  const admin = await createPostgresQueryRuntime(postgres.getConnectionUri());
 
-  const client = new Client({ connectionString: url });
-  await client.connect();
+  await admin.query(`create database "${databaseName}"`);
+  await admin.close();
+
+  const client = await createPostgresQueryRuntime(url);
+
   await client.query(`
     create table paseo_hub_migrations (
       filename text primary key,
@@ -1323,7 +1324,7 @@ interface HistoricalBaselineOptions {
 
 async function createHistoricalBaseline(options: HistoricalBaselineOptions): Promise<string> {
   const baseline = await createLegacySchema(options.postgres, options.prefix);
-  await baseline.client.end();
+  await baseline.client.close();
   await applyHistoricalMigrations(baseline.url, options.through);
   return baseline.url;
 }
@@ -1332,7 +1333,7 @@ async function applyHistoricalMigrations(url: string, through: string): Promise<
   const journal = migrationJournalSchema.parse(
     JSON.parse(await readFile(join(DRIZZLE_MIGRATIONS, "meta/_journal.json"), "utf8")),
   );
-  const migrations = [];
+  const migrations: typeof journal.entries = [];
   for (const entry of journal.entries) {
     migrations.push(entry);
     if (entry.tag === through) break;
@@ -1341,8 +1342,8 @@ async function applyHistoricalMigrations(url: string, through: string): Promise<
     throw new Error(`historical migration is absent from the journal: ${through}`);
   }
 
-  const client = new Client({ connectionString: url });
-  await client.connect();
+  const client = await createPostgresQueryRuntime(url);
+
   try {
     await client.query("create schema if not exists drizzle");
     await client.query(`
@@ -1352,36 +1353,31 @@ async function applyHistoricalMigrations(url: string, through: string): Promise<
         created_at bigint
       )
     `);
-    await client.query("begin");
-    try {
+    await client.transaction(async (transaction) => {
       for (const entry of migrations) {
         const migration = await readFile(join(DRIZZLE_MIGRATIONS, `${entry.tag}.sql`), "utf8");
-        await applyMigration(client, migration);
+        await applyMigration(transaction, migration);
         const hash = createHash("sha256").update(migration).digest("hex");
-        await client.query(
+        await transaction.query(
           `insert into drizzle.__drizzle_migrations (hash, created_at) values ($1, $2)`,
           [hash, entry.when],
         );
       }
-      await client.query("commit");
-    } catch (error) {
-      await client.query("rollback");
-      throw error;
-    }
+    });
   } finally {
-    await client.end();
+    await client.close();
   }
 }
 
-async function applyMigration(client: Client, migration: string): Promise<void> {
+async function applyMigration(client: QueryHandle, migration: string): Promise<void> {
   for (const statement of migration.split("--> statement-breakpoint")) {
     if (statement.trim().length > 0) await client.query(statement);
   }
 }
 
 async function durableSnapshot(url: string) {
-  const client = new Client({ connectionString: url });
-  await client.connect();
+  const client = await createPostgresQueryRuntime(url);
+
   try {
     const relation = await client.query<{ legacy: boolean }>(
       `select to_regclass('public.hub_configs') is not null as legacy`,
@@ -1406,11 +1402,11 @@ async function durableSnapshot(url: string) {
     if (row === undefined) throw new Error("durable snapshot returned no row");
     return row;
   } finally {
-    await client.end();
+    await client.close();
   }
 }
 
-interface DurableSnapshot extends QueryResultRow {
+interface DurableSnapshot extends QueryRow {
   machines: number;
   configs: number;
   daemons: number;
@@ -1424,8 +1420,8 @@ interface DurableSnapshot extends QueryResultRow {
 }
 
 async function historicalShape(url: string) {
-  const client = new Client({ connectionString: url });
-  await client.connect();
+  const client = await createPostgresQueryRuntime(url);
+
   try {
     const shape = await client.query<{
       auth_tables: number;
@@ -1485,7 +1481,7 @@ async function historicalShape(url: string) {
       unownedEnrollmentTokens: row.unowned_enrollment_tokens,
     };
   } finally {
-    await client.end();
+    await client.close();
   }
 }
 
@@ -1509,8 +1505,8 @@ class LegacyUpgrade {
   ) {
     const apiKey = "paseo_pk_migration_test";
     const apiKeyId = "00000000-0000-4000-8000-0000000000bb";
-    const client = new Client({ connectionString: url });
-    await client.connect();
+    const client = await createPostgresQueryRuntime(url);
+
     try {
       await client.query(
         `insert into organization_api_keys
@@ -1519,7 +1515,7 @@ class LegacyUpgrade {
         [apiKeyId, organizationId, ["configuration:install", "runs:dispatch", "daemons:enroll"]],
       );
     } finally {
-      await client.end();
+      await client.close();
     }
     const operationAuth: OperationAuthenticator = {
       async authorize(request: Request, _scope: ApiKeyScope) {
@@ -1637,8 +1633,8 @@ class LegacyUpgrade {
 }
 
 async function seedHistoricalIdentity(url: string): Promise<void> {
-  const client = new Client({ connectionString: url });
-  await client.connect();
+  const client = await createPostgresQueryRuntime(url);
+
   try {
     await client.query(`
       insert into "user" (id, name, email)
@@ -1659,13 +1655,13 @@ async function seedHistoricalIdentity(url: string): Promise<void> {
                 'member', 'pending', now() + interval '1 day', 'user-phase-zero');
     `);
   } finally {
-    await client.end();
+    await client.close();
   }
 }
 
 async function exactIdentitySnapshot(url: string) {
-  const client = new Client({ connectionString: url });
-  await client.connect();
+  const client = await createPostgresQueryRuntime(url);
+
   try {
     const result = await client.query<{
       account_id: string;
@@ -1714,7 +1710,7 @@ async function exactIdentitySnapshot(url: string) {
       userId: row.user_id,
     };
   } finally {
-    await client.end();
+    await client.close();
   }
 }
 
@@ -1724,16 +1720,16 @@ function databaseUrl(postgres: StartedPostgreSqlContainer, prefix: string): stri
   return url.toString();
 }
 
-async function poolQuery<Row extends QueryResultRow = QueryResultRow>(
+async function poolQuery<Row extends QueryRow = QueryRow>(
   url: string,
   text: string,
   values: unknown[] = [],
 ) {
-  const client = new Client({ connectionString: url });
-  await client.connect();
+  const client = await createPostgresQueryRuntime(url);
+
   try {
     return await client.query<Row>(text, values);
   } finally {
-    await client.end();
+    await client.close();
   }
 }

--- a/src/db/pg.ts
+++ b/src/db/pg.ts
@@ -1,24 +1,17 @@
-import { basename, join } from "node:path";
 import { randomUUID } from "node:crypto";
-import { drizzle } from "drizzle-orm/node-postgres";
-import { migrate } from "drizzle-orm/node-postgres/migrator";
-import { Pool } from "pg";
-import type { PoolClient, PoolConfig, QueryResultRow } from "pg";
 import type { LaunchMachineIntent } from "../dispatcher/launch-machine-intent.js";
 import type { JsonValue } from "../config/compiler.js";
 import { parseInvocationInputs, parseInvocationRejection } from "../triggers/invocation.js";
 import type { ProviderEventDropReasonCode } from "../triggers/drop-reason.js";
-import { logger } from "../logger.js";
 import {
   clearOverrideKey,
   entitlementOverridesSchema,
   mergeOverrides,
 } from "../entitlements/catalog.js";
-import { DatabaseUnavailableError, toDatabaseError } from "./errors.js";
+import { toDatabaseError } from "./errors.js";
 import { withApiKeySerialization } from "./api-key-serialization.js";
 import { ConnectionRepository } from "./connections.js";
 import { ProviderEventAcceptanceRepository } from "./trigger-acceptance.js";
-import * as schema from "./schema.js";
 import {
   toAgentExecutionRecord,
   toAttachmentRecord,
@@ -29,6 +22,8 @@ import {
   toProviderEventReceiptRecord,
 } from "./mappers.js";
 import type { AgentExecutionStatus, MachineSource, MachineStatus } from "./schema.js";
+import type { DatabaseRuntime, QueryHandle, QueryRow } from "./runtime/index.js";
+import type { Locks } from "./runtime/locks/index.js";
 import type {
   AgentExecutionOutputAttempt,
   AgentExecutionRecord,
@@ -109,9 +104,6 @@ import type {
   ReconcileOrganizationSubscriptionInput,
 } from "./types.js";
 
-const QUERY_DEADLINE_MS = 3_000;
-const MIGRATIONS_FOLDER = join(process.cwd(), "drizzle");
-const DEFAULT_POSTGRES_DATABASE = "postgres";
 const OUTPUT_ATTEMPT_LEASE_MS = 5 * 60_000;
 
 function transitionWithTerminalRun(
@@ -123,25 +115,20 @@ function transitionWithTerminalRun(
     : { ...transition, terminalRun: run };
 }
 
-export async function createDatabase(url: string): Promise<Database> {
-  await ensureDatabaseExists(url);
-  const pool = createPostgresPool(url);
-  try {
-    await runMigrations(pool);
-    return new PgDatabase(pool);
-  } catch (error) {
-    await pool.end();
-    throw toDatabaseError(error);
-  }
+export function createDatabase(runtime: DatabaseRuntime, locks: Locks): Database {
+  return new PgDatabase(runtime, locks);
 }
 
 class PgDatabase implements Database {
   private readonly connections;
   private readonly triggerAcceptance;
 
-  constructor(private readonly pool: Pool) {
-    const database = drizzle(pool, { schema });
-    this.connections = new ConnectionRepository(database);
+  constructor(
+    private readonly pool: DatabaseRuntime,
+    private readonly locks: Locks,
+  ) {
+    const database = this.pool.drizzle();
+    this.connections = new ConnectionRepository(this.pool, locks);
     this.triggerAcceptance = new ProviderEventAcceptanceRepository(database, this.connections);
   }
 
@@ -474,82 +461,77 @@ class PgDatabase implements Database {
   async createAcceptedTriggerRun(
     input: CreateAcceptedTriggerRunInput,
   ): Promise<{ run: AcceptedTriggerRunRecord; created: boolean }> {
-    const client = await this.pool.connect();
     try {
-      await client.query("begin");
-      const inserted = await client.query<TriggerRunRow>(
-        `insert into trigger_runs
+      return await this.pool.transaction(async (client) => {
+        const inserted = await client.query<TriggerRunRow>(
+          `insert into trigger_runs
            (id, organization_id, project_id, configuration_revision_id, provider_event_receipt_id,
            configured_trigger_name, outcome, status,
             raw_prompt, prompt, inputs, values, trigger_context, output_context, deadline_at, deadline_kind, rejection, created_at)
          values (coalesce($1, gen_random_uuid()), $2, $3, $4, $5, $6, 'accepted', 'running', $7, $8, $9, '{}'::jsonb, $10, $11, $12, null, null, $13)
          on conflict (provider_event_receipt_id, project_id, configured_trigger_name) do nothing
          returning *`,
-        [
-          input.id ?? null,
-          input.organizationId,
-          input.projectId,
-          input.configurationRevisionId,
-          input.providerEventReceiptId,
-          input.configuredTriggerName,
-          input.rawPrompt,
-          input.prompt,
-          input.inputs,
-          input.triggerContext,
-          input.outputContext,
-          input.deadlineAt,
-          input.createdAt ?? new Date(),
-        ],
-      );
-      let run = inserted.rows[0];
-      const created = run !== undefined;
-      if (run === undefined) {
-        const existing = await client.query<TriggerRunRow>(
-          `select * from trigger_runs
+          [
+            input.id ?? null,
+            input.organizationId,
+            input.projectId,
+            input.configurationRevisionId,
+            input.providerEventReceiptId,
+            input.configuredTriggerName,
+            input.rawPrompt,
+            input.prompt,
+            input.inputs,
+            input.triggerContext,
+            input.outputContext,
+            input.deadlineAt,
+            input.createdAt ?? new Date(),
+          ],
+        );
+        let run = inserted.rows[0];
+        const created = run !== undefined;
+        if (run === undefined) {
+          const existing = await client.query<TriggerRunRow>(
+            `select * from trigger_runs
            where provider_event_receipt_id = $1 and project_id = $2 and configured_trigger_name = $3
            for update`,
-          [input.providerEventReceiptId, input.projectId, input.configuredTriggerName],
-        );
-        run = existing.rows[0];
-      }
-      if (run === undefined) throw new Error("trigger run insert returned no row");
-      if (run.outcome !== "accepted") throw new Error("trigger branch outcome conflict");
-      for (const [ordinal, stepId] of input.stepIds.entries()) {
-        await client.query(
-          `insert into workflow_step_runs
+            [input.providerEventReceiptId, input.projectId, input.configuredTriggerName],
+          );
+          run = existing.rows[0];
+        }
+        if (run === undefined) throw new Error("trigger run insert returned no row");
+        if (run.outcome !== "accepted") throw new Error("trigger branch outcome conflict");
+        for (const [ordinal, stepId] of input.stepIds.entries()) {
+          await client.query(
+            `insert into workflow_step_runs
              (trigger_run_id, step_id, ordinal, status, deadline_kind, deadline_at, idle_deadline_at)
            values ($1, $2, $3, 'pending', null, null, null)
            on conflict (trigger_run_id, ordinal) do nothing`,
-          [run.id, stepId, ordinal],
-        );
-      }
-      await client.query(
-        `insert into workflow_wakeups (trigger_run_id, available_at, lease_expires_at)
+            [run.id, stepId, ordinal],
+          );
+        }
+        await client.query(
+          `insert into workflow_wakeups (trigger_run_id, available_at, lease_expires_at)
          values ($1, $2, null)
          on conflict (trigger_run_id) do nothing`,
-        [run.id, input.createdAt ?? new Date()],
-      );
-      await client.query("commit");
-      const record = toTriggerRunRecord(run);
-      if (record.outcome !== "accepted") throw new Error("trigger branch outcome conflict");
-      return { run: record, created };
+          [run.id, input.createdAt ?? new Date()],
+        );
+        const record = toTriggerRunRecord(run);
+        if (record.outcome !== "accepted") throw new Error("trigger branch outcome conflict");
+        return { run: record, created };
+      });
     } catch (error) {
-      await client.query("rollback").catch(() => undefined);
       throw toDatabaseError(error);
-    } finally {
-      client.release();
     }
   }
 
   async createRejectedTriggerRun(
     input: CreateRejectedTriggerRunInput,
   ): Promise<{ run: RejectedTriggerRunRecord; created: boolean }> {
-    const client = await this.pool.connect();
     try {
-      await client.query("begin");
-      const createdAt = input.createdAt ?? new Date();
-      const inserted = await client.query<TriggerRunRow>(
-        `insert into trigger_runs
+      return await this.pool.transaction(async (client) => {
+        const createdAt = input.createdAt ?? new Date();
+        const inserted = await client.query<TriggerRunRow>(
+          `insert into trigger_runs
            (id, organization_id, project_id, configuration_revision_id, provider_event_receipt_id,
            configured_trigger_name, outcome, status,
             raw_prompt, prompt, inputs, values, trigger_context, output_context, deadline_at, rejection, created_at, completed_at)
@@ -557,44 +539,41 @@ class PgDatabase implements Database {
                  $7, $8, $9, '{}'::jsonb, $10, $11, null, $13, $12, $12)
          on conflict (provider_event_receipt_id, project_id, configured_trigger_name) do nothing
          returning *`,
-        [
-          input.id ?? null,
-          input.organizationId,
-          input.projectId,
-          input.configurationRevisionId,
-          input.providerEventReceiptId,
-          input.configuredTriggerName,
-          input.rawPrompt,
-          input.prompt,
-          input.inputs,
-          input.triggerContext,
-          input.outputContext,
-          createdAt,
-          input.rejection,
-        ],
-      );
-      let run = inserted.rows[0];
-      const created = run !== undefined;
-      if (run === undefined) {
-        const existing = await client.query<TriggerRunRow>(
-          `select * from trigger_runs
+          [
+            input.id ?? null,
+            input.organizationId,
+            input.projectId,
+            input.configurationRevisionId,
+            input.providerEventReceiptId,
+            input.configuredTriggerName,
+            input.rawPrompt,
+            input.prompt,
+            input.inputs,
+            input.triggerContext,
+            input.outputContext,
+            createdAt,
+            input.rejection,
+          ],
+        );
+        let run = inserted.rows[0];
+        const created = run !== undefined;
+        if (run === undefined) {
+          const existing = await client.query<TriggerRunRow>(
+            `select * from trigger_runs
            where provider_event_receipt_id = $1 and project_id = $2 and configured_trigger_name = $3
            for update`,
-          [input.providerEventReceiptId, input.projectId, input.configuredTriggerName],
-        );
-        run = existing.rows[0];
-      }
-      if (run === undefined) throw new Error("trigger run insert returned no row");
-      if (run.outcome !== "rejected") throw new Error("trigger branch outcome conflict");
-      await client.query("commit");
-      const record = toTriggerRunRecord(run);
-      if (record.outcome !== "rejected") throw new Error("trigger branch outcome conflict");
-      return { run: record, created };
+            [input.providerEventReceiptId, input.projectId, input.configuredTriggerName],
+          );
+          run = existing.rows[0];
+        }
+        if (run === undefined) throw new Error("trigger run insert returned no row");
+        if (run.outcome !== "rejected") throw new Error("trigger branch outcome conflict");
+        const record = toTriggerRunRecord(run);
+        if (record.outcome !== "rejected") throw new Error("trigger branch outcome conflict");
+        return { run: record, created };
+      });
     } catch (error) {
-      await client.query("rollback").catch(() => undefined);
       throw toDatabaseError(error);
-    } finally {
-      client.release();
     }
   }
 
@@ -665,33 +644,28 @@ class PgDatabase implements Database {
   }
 
   async claimWorkflowWakeup(now: Date, leaseMs: number) {
-    const client = await this.pool.connect();
     try {
-      await client.query("begin");
-      const selected = await client.query<WorkflowWakeupRow>(
-        `select * from workflow_wakeups
+      return await this.pool.transaction(async (client) => {
+        const selected = await client.query<WorkflowWakeupRow>(
+          `select * from workflow_wakeups
          where available_at <= $1
            and (lease_expires_at is null or lease_expires_at <= $1)
          order by available_at, trigger_run_id
          for update skip locked limit 1`,
-        [now],
-      );
-      const wakeup = selected.rows[0];
-      if (wakeup === undefined) {
-        await client.query("commit");
-        return undefined;
-      }
-      const updated = await client.query<WorkflowWakeupRow>(
-        `update workflow_wakeups set lease_expires_at = $2 where trigger_run_id = $1 returning *`,
-        [wakeup.trigger_run_id, new Date(now.getTime() + leaseMs)],
-      );
-      await client.query("commit");
-      return toWorkflowWakeupRecord(updated.rows[0]!, wakeup.lease_expires_at !== null);
+          [now],
+        );
+        const wakeup = selected.rows[0];
+        if (wakeup === undefined) {
+          return undefined;
+        }
+        const updated = await client.query<WorkflowWakeupRow>(
+          `update workflow_wakeups set lease_expires_at = $2 where trigger_run_id = $1 returning *`,
+          [wakeup.trigger_run_id, new Date(now.getTime() + leaseMs)],
+        );
+        return toWorkflowWakeupRecord(updated.rows[0]!, wakeup.lease_expires_at !== null);
+      });
     } catch (error) {
-      await client.query("rollback").catch(() => undefined);
       throw toDatabaseError(error);
-    } finally {
-      client.release();
     }
   }
 
@@ -714,137 +688,129 @@ class PgDatabase implements Database {
   }
 
   async createWorkflowStepExecution(input: WorkflowStepExecutionInput) {
-    const client = await this.pool.connect();
     try {
-      await client.query("begin");
-      const startedAt = input.execution.startedAt;
-      const runRows = await client.query<TriggerRunRow>(
-        `select * from trigger_runs where id = $1 for update`,
-        [input.triggerRunId],
-      );
-      const run = runRows.rows[0];
-      if (run === undefined) throw new Error("workflow trigger run not found");
-      if (run.outcome !== "accepted" || run.status !== "running") {
-        await client.query("commit");
-        const stepRows = await client.query<WorkflowStepRunRow>(
-          `select * from workflow_step_runs where trigger_run_id = $1 and step_id = $2 and ordinal = $3`,
-          [input.triggerRunId, input.stepId, input.ordinal],
+      return await this.pool.transaction(async (client) => {
+        const startedAt = input.execution.startedAt;
+        const runRows = await client.query<TriggerRunRow>(
+          `select * from trigger_runs where id = $1 for update`,
+          [input.triggerRunId],
         );
-        const step = stepRows.rows[0];
-        if (step === undefined) throw new Error("workflow step run not found");
-        return { stepRun: toWorkflowStepRunRecord(step), execution: undefined, created: false };
-      }
-      if (run.deadline_at === null || run.deadline_at.getTime() <= startedAt.getTime()) {
-        await timeoutWorkflowRunOnClient(client, run, startedAt);
-        const stepRows = await client.query<WorkflowStepRunRow>(
-          `select * from workflow_step_runs where trigger_run_id = $1 and step_id = $2 and ordinal = $3`,
-          [input.triggerRunId, input.stepId, input.ordinal],
-        );
-        const step = stepRows.rows[0];
-        await client.query("commit");
-        if (step === undefined) throw new Error("workflow step run not found");
-        return { stepRun: toWorkflowStepRunRecord(step), execution: undefined, created: false };
-      }
-      const deadlineAt = new Date(
-        Math.min(input.execution.deadlineAt.getTime(), run.deadline_at.getTime()),
-      );
-      const idleDeadlineAt = new Date(
-        Math.min(
-          input.execution.idleDeadlineAt.getTime(),
-          deadlineAt.getTime(),
-          run.deadline_at.getTime(),
-        ),
-      );
-      const selected = await client.query<WorkflowStepRunRow>(
-        `select * from workflow_step_runs where trigger_run_id = $1 and step_id = $2 and ordinal = $3 for update`,
-        [input.triggerRunId, input.stepId, input.ordinal],
-      );
-      let step = selected.rows[0];
-      if (step === undefined) throw new Error("workflow step run not found");
-      if (step.agent_execution_id !== null) {
-        const existing = await client.query<AgentExecutionRow>(
-          `select * from agent_executions where id = $1`,
-          [step.agent_execution_id],
-        );
-        await client.query("commit");
-        return {
-          stepRun: toWorkflowStepRunRecord(step),
-          execution:
-            existing.rows[0] === undefined ? undefined : toAgentExecutionRecord(existing.rows[0]),
-          created: false,
-        };
-      }
-      const execution = await insertAgentExecutionOnClient(client, {
-        ...input.execution,
-        id: input.executionId,
-        deadlineAt,
-        idleDeadlineAt,
-        workflowStepRunId: step.id,
-      });
-      // Reserve one meter unit in the same transaction that creates the execution. If the
-      // reservation is denied the whole transaction rolls back, so no execution is created and
-      // nothing is dispatched — metering is atomic with the work it permits.
-      if (input.reservation !== undefined) {
-        const reserved = await reserveOrganizationUsageOnClient(client, {
-          organizationId: input.execution.organizationId,
-          meter: input.reservation.meter,
-          periodStart: input.reservation.periodStart,
-          amount: 1,
-          limit: input.reservation.limit,
-        });
-        if (reserved === undefined) {
-          if (input.reservation.limit === null) {
-            throw new Error("unreachable: an unlimited meter reservation cannot be denied");
-          }
-          const usage = await client.query<OrganizationUsageRow>(
-            `select used from organization_usage
-             where organization_id = $1 and meter = $2 and period_start = $3`,
-            [
-              input.execution.organizationId,
-              input.reservation.meter,
-              input.reservation.periodStart,
-            ],
+        const run = runRows.rows[0];
+        if (run === undefined) throw new Error("workflow trigger run not found");
+        if (run.outcome !== "accepted" || run.status !== "running") {
+          const stepRows = await client.query<WorkflowStepRunRow>(
+            `select * from workflow_step_runs where trigger_run_id = $1 and step_id = $2 and ordinal = $3`,
+            [input.triggerRunId, input.stepId, input.ordinal],
           );
-          await client.query("rollback");
+          const step = stepRows.rows[0];
+          if (step === undefined) throw new Error("workflow step run not found");
+          return { stepRun: toWorkflowStepRunRecord(step), execution: undefined, created: false };
+        }
+        if (run.deadline_at === null || run.deadline_at.getTime() <= startedAt.getTime()) {
+          await timeoutWorkflowRunOnClient(client, run, startedAt);
+          const stepRows = await client.query<WorkflowStepRunRow>(
+            `select * from workflow_step_runs where trigger_run_id = $1 and step_id = $2 and ordinal = $3`,
+            [input.triggerRunId, input.stepId, input.ordinal],
+          );
+          const step = stepRows.rows[0];
+          if (step === undefined) throw new Error("workflow step run not found");
+          return { stepRun: toWorkflowStepRunRecord(step), execution: undefined, created: false };
+        }
+        const deadlineAt = new Date(
+          Math.min(input.execution.deadlineAt.getTime(), run.deadline_at.getTime()),
+        );
+        const idleDeadlineAt = new Date(
+          Math.min(
+            input.execution.idleDeadlineAt.getTime(),
+            deadlineAt.getTime(),
+            run.deadline_at.getTime(),
+          ),
+        );
+        const selected = await client.query<WorkflowStepRunRow>(
+          `select * from workflow_step_runs where trigger_run_id = $1 and step_id = $2 and ordinal = $3 for update`,
+          [input.triggerRunId, input.stepId, input.ordinal],
+        );
+        let step = selected.rows[0];
+        if (step === undefined) throw new Error("workflow step run not found");
+        if (step.agent_execution_id !== null) {
+          const existing = await client.query<AgentExecutionRow>(
+            `select * from agent_executions where id = $1`,
+            [step.agent_execution_id],
+          );
           return {
             stepRun: toWorkflowStepRunRecord(step),
-            execution: undefined,
+            execution:
+              existing.rows[0] === undefined ? undefined : toAgentExecutionRecord(existing.rows[0]),
             created: false,
-            reservationDenied: {
-              meter: input.reservation.meter,
-              limit: input.reservation.limit,
-              current: Number(usage.rows[0]?.used ?? 0),
-            },
           };
         }
-      }
-      const updated = await client.query<WorkflowStepRunRow>(
-        `update workflow_step_runs
+        const execution = await insertAgentExecutionOnClient(client, {
+          ...input.execution,
+          id: input.executionId,
+          deadlineAt,
+          idleDeadlineAt,
+          workflowStepRunId: step.id,
+        });
+        // Reserve one meter unit in the same transaction that creates the execution. If the
+        // reservation is denied the whole transaction rolls back, so no execution is created and
+        // nothing is dispatched — metering is atomic with the work it permits.
+        if (input.reservation !== undefined) {
+          const reserved = await reserveOrganizationUsageOnClient(client, {
+            organizationId: input.execution.organizationId,
+            meter: input.reservation.meter,
+            periodStart: input.reservation.periodStart,
+            amount: 1,
+            limit: input.reservation.limit,
+          });
+          if (reserved === undefined) {
+            if (input.reservation.limit === null) {
+              throw new Error("unreachable: an unlimited meter reservation cannot be denied");
+            }
+            const usage = await client.query<OrganizationUsageRow>(
+              `select used from organization_usage
+             where organization_id = $1 and meter = $2 and period_start = $3`,
+              [
+                input.execution.organizationId,
+                input.reservation.meter,
+                input.reservation.periodStart,
+              ],
+            );
+            return client.rollback({
+              stepRun: toWorkflowStepRunRecord(step),
+              execution: undefined,
+              created: false,
+              reservationDenied: {
+                meter: input.reservation.meter,
+                limit: input.reservation.limit,
+                current: Number(usage.rows[0]?.used ?? 0),
+              },
+            });
+          }
+        }
+        const updated = await client.query<WorkflowStepRunRow>(
+          `update workflow_step_runs
          set status = 'running', agent_execution_id = $2, started_at = coalesce(started_at, $3),
              deadline_at = $4, idle_deadline_at = $5, dispatch_intent = coalesce($6, dispatch_intent)
          where id = $1 and agent_execution_id is null
          returning *`,
-        [
-          step.id,
-          execution.id,
-          execution.started_at,
-          execution.deadline_at,
-          execution.idle_deadline_at,
-          input.execution.launchIntent ?? null,
-        ],
-      );
-      step = updated.rows[0] ?? step;
-      await client.query("commit");
-      return {
-        stepRun: toWorkflowStepRunRecord(step),
-        execution: toAgentExecutionRecord(execution),
-        created: true,
-      };
+          [
+            step.id,
+            execution.id,
+            execution.started_at,
+            execution.deadline_at,
+            execution.idle_deadline_at,
+            input.execution.launchIntent ?? null,
+          ],
+        );
+        step = updated.rows[0] ?? step;
+        return {
+          stepRun: toWorkflowStepRunRecord(step),
+          execution: toAgentExecutionRecord(execution),
+          created: true,
+        };
+      });
     } catch (error) {
-      await client.query("rollback").catch(() => undefined);
       throw toDatabaseError(error);
-    } finally {
-      client.release();
     }
   }
 
@@ -853,44 +819,40 @@ class PgDatabase implements Database {
     executionId: string,
     dispatchIntent?: LaunchMachineIntent,
   ) {
-    const client = await this.pool.connect();
     try {
-      await client.query("begin");
-      const selected = await client.query<WorkflowStepRunRow>(
-        `select * from workflow_step_runs where id = $1 for update`,
-        [stepRunId],
-      );
-      const step = selected.rows[0];
-      if (step === undefined) throw new Error(`workflow step run not found: ${stepRunId}`);
-      if (step.agent_execution_id !== null && step.agent_execution_id !== executionId) {
-        throw new Error(`workflow step run already linked: ${stepRunId}`);
-      }
-      if (step.agent_execution_id === executionId) {
-        await client.query("commit");
-        return toWorkflowStepRunRecord(step);
-      }
-      const execution = await client.query<AgentExecutionRow>(
-        `select * from agent_executions where id = $1`,
-        [executionId],
-      );
-      const executionRow = execution.rows[0];
-      if (executionRow === undefined) throw new Error(`agent execution not found: ${executionId}`);
-      const updated = await client.query<WorkflowStepRunRow>(
-        `update workflow_step_runs
+      return await this.pool.transaction(async (client) => {
+        const selected = await client.query<WorkflowStepRunRow>(
+          `select * from workflow_step_runs where id = $1 for update`,
+          [stepRunId],
+        );
+        const step = selected.rows[0];
+        if (step === undefined) throw new Error(`workflow step run not found: ${stepRunId}`);
+        if (step.agent_execution_id !== null && step.agent_execution_id !== executionId) {
+          throw new Error(`workflow step run already linked: ${stepRunId}`);
+        }
+        if (step.agent_execution_id === executionId) {
+          return toWorkflowStepRunRecord(step);
+        }
+        const execution = await client.query<AgentExecutionRow>(
+          `select * from agent_executions where id = $1`,
+          [executionId],
+        );
+        const executionRow = execution.rows[0];
+        if (executionRow === undefined)
+          throw new Error(`agent execution not found: ${executionId}`);
+        const updated = await client.query<WorkflowStepRunRow>(
+          `update workflow_step_runs
          set status = case when status = 'pending' then 'running' else status end,
              agent_execution_id = $2, started_at = coalesce(started_at, $3),
              dispatch_intent = coalesce($4, dispatch_intent)
          where id = $1 and agent_execution_id is null
          returning *`,
-        [stepRunId, executionId, executionRow.started_at, dispatchIntent ?? null],
-      );
-      await client.query("commit");
-      return toWorkflowStepRunRecord(updated.rows[0] ?? step);
+          [stepRunId, executionId, executionRow.started_at, dispatchIntent ?? null],
+        );
+        return toWorkflowStepRunRecord(updated.rows[0] ?? step);
+      });
     } catch (error) {
-      await client.query("rollback").catch(() => undefined);
       throw toDatabaseError(error);
-    } finally {
-      client.release();
     }
   }
 
@@ -920,166 +882,153 @@ class PgDatabase implements Database {
   }
 
   async completeWorkflowAgentExecution(input: WorkflowAgentCompletionInput) {
-    const client = await this.pool.connect();
     try {
-      await client.query("begin");
-      const initialExecution = await client.query<AgentExecutionRow>(
-        `select * from agent_executions where id = $1`,
-        [input.executionId],
-      );
-      const initial = initialExecution.rows[0];
-      if (initial === undefined) throw new Error(`agent execution not found: ${input.executionId}`);
-      if (initial.workflow_step_run_id === null) {
-        await client.query("commit");
-        return this.transitionAgentExecution(input.executionId, input.executionStatus, {
-          result: input.result,
-          ...(input.completedByAgent === undefined
-            ? {}
-            : { completedByAgent: input.completedByAgent }),
-          ...(input.deadlineCondition === undefined
-            ? {}
-            : { deadlineCondition: input.deadlineCondition }),
-          ...(input.hubAction === undefined ? {} : { hubAction: input.hubAction }),
-        });
-      }
-
-      const stepLookup = await client.query<WorkflowStepRunRow>(
-        `select * from workflow_step_runs where id = $1`,
-        [initial.workflow_step_run_id],
-      );
-      const stepCandidate = stepLookup.rows[0];
-      if (stepCandidate === undefined) throw new Error("workflow step run not found");
-      const runRows = await client.query<TriggerRunRow>(
-        `select * from trigger_runs where id = $1 for update`,
-        [stepCandidate.trigger_run_id],
-      );
-      const run = runRows.rows[0];
-      if (run === undefined) throw new Error("workflow trigger run not found");
-      const stepRows = await client.query<WorkflowStepRunRow>(
-        `select * from workflow_step_runs where id = $1 for update`,
-        [initial.workflow_step_run_id],
-      );
-      const step = stepRows.rows[0];
-      if (step === undefined) throw new Error("workflow step run not found");
-
-      const executionRows = await client.query<AgentExecutionRow>(
-        `select * from agent_executions where id = $1 for update`,
-        [input.executionId],
-      );
-      const execution = executionRows.rows[0];
-      if (execution === undefined)
-        throw new Error(`agent execution not found: ${input.executionId}`);
-      const observedAt = input.observedAt ?? new Date();
-      if (execution.status === "spawning" || execution.status === "running") {
-        const deadlineKind = workflowDeadlineKind(execution, step, run, observedAt);
-        if (deadlineKind === "whole_run") {
-          const recovery = await timeoutWorkflowRunOnClient(client, run, observedAt);
-          const terminalRun = await findTriggerRunOnClient(client, run.id);
-          const updatedExecution = await findAgentExecutionOnClient(client, input.executionId);
-          await client.query("commit");
-          return transitionWithTerminalRun(
-            {
-              execution: updatedExecution ?? toAgentExecutionRecord(execution),
-              transitioned: recovery.executionIds.includes(input.executionId),
-              deadlineKind,
-            },
-            terminalRun,
-          );
+      return await this.pool.transaction(async (client) => {
+        const initialExecution = await client.query<AgentExecutionRow>(
+          `select * from agent_executions where id = $1`,
+          [input.executionId],
+        );
+        const initial = initialExecution.rows[0];
+        if (initial === undefined)
+          throw new Error(`agent execution not found: ${input.executionId}`);
+        if (initial.workflow_step_run_id === null) {
+          return this.transitionAgentExecution(input.executionId, input.executionStatus, {
+            result: input.result,
+            ...(input.completedByAgent === undefined
+              ? {}
+              : { completedByAgent: input.completedByAgent }),
+            ...(input.deadlineCondition === undefined
+              ? {}
+              : { deadlineCondition: input.deadlineCondition }),
+            ...(input.hubAction === undefined ? {} : { hubAction: input.hubAction }),
+          });
         }
-        if (deadlineKind !== undefined) {
-          const updated = await timeoutWorkflowStepOnClient(
-            client,
-            execution,
-            step,
-            run,
-            deadlineKind,
-            observedAt,
-          );
-          const terminalRun = await findTriggerRunOnClient(client, run.id);
-          await client.query("commit");
-          return transitionWithTerminalRun(
-            {
-              execution: toAgentExecutionRecord(updated),
-              transitioned: true,
+
+        const stepLookup = await client.query<WorkflowStepRunRow>(
+          `select * from workflow_step_runs where id = $1`,
+          [initial.workflow_step_run_id],
+        );
+        const stepCandidate = stepLookup.rows[0];
+        if (stepCandidate === undefined) throw new Error("workflow step run not found");
+        const runRows = await client.query<TriggerRunRow>(
+          `select * from trigger_runs where id = $1 for update`,
+          [stepCandidate.trigger_run_id],
+        );
+        const run = runRows.rows[0];
+        if (run === undefined) throw new Error("workflow trigger run not found");
+        const stepRows = await client.query<WorkflowStepRunRow>(
+          `select * from workflow_step_runs where id = $1 for update`,
+          [initial.workflow_step_run_id],
+        );
+        const step = stepRows.rows[0];
+        if (step === undefined) throw new Error("workflow step run not found");
+
+        const executionRows = await client.query<AgentExecutionRow>(
+          `select * from agent_executions where id = $1 for update`,
+          [input.executionId],
+        );
+        const execution = executionRows.rows[0];
+        if (execution === undefined)
+          throw new Error(`agent execution not found: ${input.executionId}`);
+        const observedAt = input.observedAt ?? new Date();
+        if (execution.status === "spawning" || execution.status === "running") {
+          const deadlineKind = workflowDeadlineKind(execution, step, run, observedAt);
+          if (deadlineKind === "whole_run") {
+            const recovery = await timeoutWorkflowRunOnClient(client, run, observedAt);
+            const terminalRun = await findTriggerRunOnClient(client, run.id);
+            const updatedExecution = await findAgentExecutionOnClient(client, input.executionId);
+            return transitionWithTerminalRun(
+              {
+                execution: updatedExecution ?? toAgentExecutionRecord(execution),
+                transitioned: recovery.executionIds.includes(input.executionId),
+                deadlineKind,
+              },
+              terminalRun,
+            );
+          }
+          if (deadlineKind !== undefined) {
+            const updated = await timeoutWorkflowStepOnClient(
+              client,
+              execution,
+              step,
+              run,
               deadlineKind,
-            },
-            terminalRun,
-          );
+              observedAt,
+            );
+            const terminalRun = await findTriggerRunOnClient(client, run.id);
+            return transitionWithTerminalRun(
+              {
+                execution: toAgentExecutionRecord(updated),
+                transitioned: true,
+                deadlineKind,
+              },
+              terminalRun,
+            );
+          }
         }
-      }
 
-      const liveTransition = await transitionWorkflowAgentExecution(client, execution, input);
-      if (liveTransition === undefined) {
-        await client.query("commit");
-        return { execution: toAgentExecutionRecord(execution), transitioned: false };
-      }
+        const liveTransition = await transitionWorkflowAgentExecution(client, execution, input);
+        if (liveTransition === undefined) {
+          return { execution: toAgentExecutionRecord(execution), transitioned: false };
+        }
 
-      await finishWorkflowStepAndRun(client, step, run, input);
-      const terminalRun = await findTriggerRunOnClient(client, run.id);
+        await finishWorkflowStepAndRun(client, step, run, input);
+        const terminalRun = await findTriggerRunOnClient(client, run.id);
 
-      await client.query("commit");
-      return transitionWithTerminalRun(
-        {
-          execution: toAgentExecutionRecord(liveTransition.execution),
-          transitioned: liveTransition.transitioned,
-          ...(input.deadlineKind === undefined ? {} : { deadlineKind: input.deadlineKind }),
-        },
-        terminalRun,
-      );
+        return transitionWithTerminalRun(
+          {
+            execution: toAgentExecutionRecord(liveTransition.execution),
+            transitioned: liveTransition.transitioned,
+            ...(input.deadlineKind === undefined ? {} : { deadlineKind: input.deadlineKind }),
+          },
+          terminalRun,
+        );
+      });
     } catch (error) {
-      await client.query("rollback").catch(() => undefined);
       throw toDatabaseError(error);
-    } finally {
-      client.release();
     }
   }
 
   async markWorkflowStepSkipped(triggerRunId: string, stepId: string, reason: string) {
-    const client = await this.pool.connect();
     try {
-      await client.query("begin");
-      const stepRows = await client.query<WorkflowStepRunRow>(
-        `select * from workflow_step_runs where trigger_run_id = $1 and step_id = $2 for update`,
-        [triggerRunId, stepId],
-      );
-      const step = stepRows.rows[0];
-      const runRows = await client.query<TriggerRunRow>(
-        `select * from trigger_runs where id = $1 for update`,
-        [triggerRunId],
-      );
-      const run = runRows.rows[0];
-      if (step === undefined || run === undefined) {
-        await client.query("commit");
-        return undefined;
-      }
-      if (step.status !== "pending") {
-        await client.query("commit");
-        return { stepRun: toWorkflowStepRunRecord(step), run: toTriggerRunRecord(run) };
-      }
-      const completedAt = new Date();
-      const updatedRows = await client.query<WorkflowStepRunRow>(
-        `update workflow_step_runs
+      return await this.pool.transaction(async (client) => {
+        const stepRows = await client.query<WorkflowStepRunRow>(
+          `select * from workflow_step_runs where trigger_run_id = $1 and step_id = $2 for update`,
+          [triggerRunId, stepId],
+        );
+        const step = stepRows.rows[0];
+        const runRows = await client.query<TriggerRunRow>(
+          `select * from trigger_runs where id = $1 for update`,
+          [triggerRunId],
+        );
+        const run = runRows.rows[0];
+        if (step === undefined || run === undefined) {
+          return undefined;
+        }
+        if (step.status !== "pending") {
+          return { stepRun: toWorkflowStepRunRecord(step), run: toTriggerRunRecord(run) };
+        }
+        const completedAt = new Date();
+        const updatedRows = await client.query<WorkflowStepRunRow>(
+          `update workflow_step_runs
          set status = 'skipped', failure_reason = $2, completed_at = $3
          where id = $1 and status = 'pending' returning *`,
-        [step.id, reason, completedAt],
-      );
-      await client.query(
-        `insert into workflow_wakeups (trigger_run_id, available_at, lease_expires_at)
+          [step.id, reason, completedAt],
+        );
+        await client.query(
+          `insert into workflow_wakeups (trigger_run_id, available_at, lease_expires_at)
          values ($1, $2, null)
          on conflict (trigger_run_id) do update
          set available_at = least(workflow_wakeups.available_at, excluded.available_at), lease_expires_at = null`,
-        [triggerRunId, completedAt],
-      );
-      await client.query("commit");
-      return {
-        stepRun: toWorkflowStepRunRecord(updatedRows.rows[0] ?? step),
-        run: toTriggerRunRecord(run),
-      };
+          [triggerRunId, completedAt],
+        );
+        return {
+          stepRun: toWorkflowStepRunRecord(updatedRows.rows[0] ?? step),
+          run: toTriggerRunRecord(run),
+        };
+      });
     } catch (error) {
-      await client.query("rollback").catch(() => undefined);
       throw toDatabaseError(error);
-    } finally {
-      client.release();
     }
   }
 
@@ -1107,62 +1056,58 @@ class PgDatabase implements Database {
     failureReason: string,
     stepId?: string,
   ) {
-    const client = await this.pool.connect();
     try {
-      await client.query("begin");
-      const runRows = await client.query<TriggerRunRow>(
-        `select * from trigger_runs where id = $1 for update`,
-        [triggerRunId],
-      );
-      const run = runRows.rows[0];
-      const stepRows = await client.query<WorkflowStepRunRow>(
-        `select * from workflow_step_runs
+      return await this.pool.transaction(async (client) => {
+        const runRows = await client.query<TriggerRunRow>(
+          `select * from trigger_runs where id = $1 for update`,
+          [triggerRunId],
+        );
+        const run = runRows.rows[0];
+        const stepRows = await client.query<WorkflowStepRunRow>(
+          `select * from workflow_step_runs
          where trigger_run_id = $1 and ($2::text is null or step_id = $2)
          order by ordinal limit 1 for update`,
-        [triggerRunId, stepId ?? null],
-      );
-      const step = stepRows.rows[0];
-      if (run === undefined || step === undefined) {
-        await client.query("commit");
-        return undefined;
-      }
-      if (run.status !== "running") {
-        await client.query("commit");
-        return {
-          stepRun: toWorkflowStepRunRecord(step),
-          run: toTriggerRunRecord(run),
-          transitioned: false,
-        };
-      }
-      const completedAt = new Date();
-      const updatedStep = await client.query<WorkflowStepRunRow>(
-        `update workflow_step_runs
+          [triggerRunId, stepId ?? null],
+        );
+        const step = stepRows.rows[0];
+        if (run === undefined || step === undefined) {
+          return undefined;
+        }
+        if (run.status !== "running") {
+          return {
+            stepRun: toWorkflowStepRunRecord(step),
+            run: toTriggerRunRecord(run),
+            transitioned: false,
+          };
+        }
+        const completedAt = new Date();
+        const updatedStep = await client.query<WorkflowStepRunRow>(
+          `update workflow_step_runs
          set status = case when status in ('pending', 'running') then $2 else status end,
              failure_reason = case when status in ('pending', 'running') then $3 else failure_reason end,
              completed_at = case when status in ('pending', 'running') then $4 else completed_at end
          where id = $1 returning *`,
-        [step.id, status, failureReason, completedAt],
-      );
-      const updatedRun = await client.query<TriggerRunRow>(
-        `update trigger_runs
+          [step.id, status, failureReason, completedAt],
+        );
+        const updatedRun = await client.query<TriggerRunRow>(
+          `update trigger_runs
          set status = $2, failure_reason = $3, completed_at = $4,
              terminal_notification_pending_at = coalesce(terminal_notification_pending_at, $4),
              terminal_notification_lease_expires_at = null
          where id = $1 returning *`,
-        [triggerRunId, status, failureReason, completedAt],
-      );
-      await client.query(`delete from workflow_wakeups where trigger_run_id = $1`, [triggerRunId]);
-      await client.query("commit");
-      return {
-        stepRun: toWorkflowStepRunRecord(updatedStep.rows[0] ?? step),
-        run: toTriggerRunRecord(updatedRun.rows[0]!),
-        transitioned: true,
-      };
+          [triggerRunId, status, failureReason, completedAt],
+        );
+        await client.query(`delete from workflow_wakeups where trigger_run_id = $1`, [
+          triggerRunId,
+        ]);
+        return {
+          stepRun: toWorkflowStepRunRecord(updatedStep.rows[0] ?? step),
+          run: toTriggerRunRecord(updatedRun.rows[0]!),
+          transitioned: true,
+        };
+      });
     } catch (error) {
-      await client.query("rollback").catch(() => undefined);
       throw toDatabaseError(error);
-    } finally {
-      client.release();
     }
   }
 
@@ -1188,11 +1133,10 @@ class PgDatabase implements Database {
   }
 
   async claimPendingWorkflowRunTerminalNotification(now: Date, leaseMs: number) {
-    const client = await this.pool.connect();
     try {
-      await client.query("begin");
-      const selected = await client.query<TriggerRunRow>(
-        `select * from trigger_runs
+      return await this.pool.transaction(async (client) => {
+        const selected = await client.query<TriggerRunRow>(
+          `select * from trigger_runs
          where outcome = 'accepted'
            and status <> 'running'
            and terminal_notification_pending_at is not null
@@ -1203,27 +1147,23 @@ class PgDatabase implements Database {
            )
          order by terminal_notification_pending_at, id
          for update skip locked limit 1`,
-        [now],
-      );
-      const run = selected.rows[0];
-      if (run === undefined) {
-        await client.query("commit");
-        return undefined;
-      }
-      const updated = await client.query<TriggerRunRow>(
-        `update trigger_runs
+          [now],
+        );
+        const run = selected.rows[0];
+        if (run === undefined) {
+          return undefined;
+        }
+        const updated = await client.query<TriggerRunRow>(
+          `update trigger_runs
          set terminal_notification_lease_expires_at = $2
          where id = $1
          returning *`,
-        [run.id, new Date(now.getTime() + leaseMs)],
-      );
-      await client.query("commit");
-      return toTriggerRunRecord(updated.rows[0]!);
+          [run.id, new Date(now.getTime() + leaseMs)],
+        );
+        return toTriggerRunRecord(updated.rows[0]!);
+      });
     } catch (error) {
-      await client.query("rollback").catch(() => undefined);
       throw toDatabaseError(error);
-    } finally {
-      client.release();
     }
   }
 
@@ -1262,109 +1202,101 @@ class PgDatabase implements Database {
   }
 
   async recoverWorkflowDeadlines(now: Date): Promise<readonly WorkflowDeadlineRecovery[]> {
-    const client = await this.pool.connect();
     try {
-      await client.query("begin");
-      const recoveries: WorkflowDeadlineRecovery[] = [];
-      const overdueRuns = await client.query<TriggerRunRow>(
-        `select * from trigger_runs
+      return await this.pool.transaction(async (client) => {
+        const recoveries: WorkflowDeadlineRecovery[] = [];
+        const overdueRuns = await client.query<TriggerRunRow>(
+          `select * from trigger_runs
          where outcome = 'accepted' and status = 'running' and deadline_at <= $1
          order by deadline_at, id
          for update skip locked`,
-        [now],
-      );
-      for (const run of overdueRuns.rows) {
-        recoveries.push(await timeoutWorkflowRunOnClient(client, run, now));
-      }
+          [now],
+        );
+        for (const run of overdueRuns.rows) {
+          recoveries.push(await timeoutWorkflowRunOnClient(client, run, now));
+        }
 
-      const activeRuns = await client.query<TriggerRunRow>(
-        `select * from trigger_runs
+        const activeRuns = await client.query<TriggerRunRow>(
+          `select * from trigger_runs
          where outcome = 'accepted' and status = 'running' and deadline_at > $1
          order by deadline_at, id
          for update skip locked`,
-        [now],
-      );
-      for (const run of activeRuns.rows) {
-        const steps = await client.query<WorkflowStepRunRow>(
-          `select * from workflow_step_runs
+          [now],
+        );
+        for (const run of activeRuns.rows) {
+          const steps = await client.query<WorkflowStepRunRow>(
+            `select * from workflow_step_runs
            where trigger_run_id = $1 and status = 'running'
            order by ordinal
            for update`,
-          [run.id],
-        );
-        for (const step of steps.rows) {
-          const executionRows =
-            step.agent_execution_id === null
-              ? { rows: [] as AgentExecutionRow[] }
-              : await client.query<AgentExecutionRow>(
-                  `select * from agent_executions where id = $1 for update`,
-                  [step.agent_execution_id],
-                );
-          const execution = executionRows.rows[0];
-          if (
-            execution !== undefined &&
-            (execution.status === "succeeded" || execution.status === "failed")
-          ) {
-            continue;
-          }
-          const deadlineKind = workflowDeadlineKind(execution, step, run, now);
-          if (deadlineKind === undefined || deadlineKind === "whole_run") continue;
-          if (execution === undefined) {
-            const reason = deadlineKind === "step_idle" ? "step_idle_timeout" : "step_hard_timeout";
-            await client.query(
-              `update workflow_step_runs
+            [run.id],
+          );
+          for (const step of steps.rows) {
+            const executionRows =
+              step.agent_execution_id === null
+                ? { rows: [] as AgentExecutionRow[] }
+                : await client.query<AgentExecutionRow>(
+                    `select * from agent_executions where id = $1 for update`,
+                    [step.agent_execution_id],
+                  );
+            const execution = executionRows.rows[0];
+            if (
+              execution !== undefined &&
+              (execution.status === "succeeded" || execution.status === "failed")
+            ) {
+              continue;
+            }
+            const deadlineKind = workflowDeadlineKind(execution, step, run, now);
+            if (deadlineKind === undefined || deadlineKind === "whole_run") continue;
+            if (execution === undefined) {
+              const reason =
+                deadlineKind === "step_idle" ? "step_idle_timeout" : "step_hard_timeout";
+              await client.query(
+                `update workflow_step_runs
                set status = 'timed_out', failure_reason = $2, deadline_kind = $3, completed_at = $4
                where id = $1 and status = 'running'`,
-              [step.id, reason, deadlineKind, now],
-            );
-            await client.query(
-              `update trigger_runs
+                [step.id, reason, deadlineKind, now],
+              );
+              await client.query(
+                `update trigger_runs
                set status = 'failed', deadline_kind = $2, failure_reason = $3, completed_at = $4
                where id = $1 and status = 'running'`,
-              [run.id, deadlineKind, reason, now],
-            );
-            await client.query(`delete from workflow_wakeups where trigger_run_id = $1`, [run.id]);
-            recoveries.push({ triggerRunId: run.id, executionIds: [] });
-          } else {
-            const updated = await timeoutWorkflowStepOnClient(
-              client,
-              execution,
-              step,
-              run,
-              deadlineKind,
-              now,
-            );
-            recoveries.push({ triggerRunId: run.id, executionIds: [updated.id] });
+                [run.id, deadlineKind, reason, now],
+              );
+              await client.query(`delete from workflow_wakeups where trigger_run_id = $1`, [
+                run.id,
+              ]);
+              recoveries.push({ triggerRunId: run.id, executionIds: [] });
+            } else {
+              const updated = await timeoutWorkflowStepOnClient(
+                client,
+                execution,
+                step,
+                run,
+                deadlineKind,
+                now,
+              );
+              recoveries.push({ triggerRunId: run.id, executionIds: [updated.id] });
+            }
           }
         }
-      }
-      await client.query("commit");
-      return recoveries;
+        return recoveries;
+      });
     } catch (error) {
-      await client.query("rollback").catch(() => undefined);
       throw toDatabaseError(error);
-    } finally {
-      client.release();
     }
   }
 
   async issueEnrollmentToken(input: EnrollmentTokenRecord): Promise<boolean> {
     if (input.issuedByCliCredentialId !== undefined && input.issuedByCliCredentialId !== null) {
-      const client = await this.pool.connect();
-      try {
-        await client.query("begin");
-        await client.query(`select pg_advisory_xact_lock(hashtext($1))`, [
-          input.issuedByCliCredentialId,
-        ]);
+      return this.pool.transaction(async (client) => {
+        await this.locks.withTxLock(client, input.issuedByCliCredentialId!);
         const credential = await client.query(
           `select id from organization_cli_credentials
            where id = $1 and organization_id = $2 and revoked_at is null for update`,
           [input.issuedByCliCredentialId, input.organizationId],
         );
-        if (credential.rowCount !== 1) {
-          await client.query("rollback");
-          return false;
-        }
+        if (credential.rowCount !== 1) return false;
         await client.query(
           `insert into daemon_enrollment_tokens
              (id, verifier, organization_id, issued_by_cli_credential_id,
@@ -1378,14 +1310,8 @@ class PgDatabase implements Database {
             input.expiresAt,
           ],
         );
-        await client.query("commit");
         return true;
-      } catch (error) {
-        await client.query("rollback").catch(() => undefined);
-        throw error;
-      } finally {
-        client.release();
-      }
+      });
     }
     if (input.issuedByApiKeyId === undefined || input.issuedByApiKeyId === null) {
       await query(
@@ -1399,10 +1325,8 @@ class PgDatabase implements Database {
     }
 
     return withApiKeySerialization(input.issuedByApiKeyId, async () => {
-      const client = await this.pool.connect();
-      try {
-        await client.query("begin");
-        await client.query(`select pg_advisory_xact_lock(hashtext($1))`, [input.issuedByApiKeyId]);
+      return this.pool.transaction(async (client) => {
+        await this.locks.withTxLock(client, input.issuedByApiKeyId!);
         const key = await client.query(
           `select id
            from organization_api_keys
@@ -1410,78 +1334,62 @@ class PgDatabase implements Database {
            for update`,
           [input.issuedByApiKeyId, input.organizationId],
         );
-        if (key.rowCount !== 1) {
-          await client.query("rollback");
-          return false;
-        }
+        if (key.rowCount !== 1) return false;
         await client.query(
           `insert into daemon_enrollment_tokens
              (id, verifier, organization_id, issued_by_api_key_id, expires_at)
            values ($1, $2, $3, $4, $5)`,
           [input.id, input.verifier, input.organizationId, input.issuedByApiKeyId, input.expiresAt],
         );
-        await client.query("commit");
         return true;
-      } catch (error) {
-        await client.query("rollback").catch(() => undefined);
-        throw error;
-      } finally {
-        client.release();
-      }
+      });
     });
   }
 
   async startCliAuthorization(
     input: StartCliAuthorizationInput,
   ): Promise<CliAuthorizationRecord | undefined> {
-    const client = await this.pool.connect();
     try {
-      await client.query("begin");
-      await client.query(
-        `select pg_advisory_xact_lock(hashtext('paseo-cli-authorization-issuance'))`,
-      );
-      const capacity = await client.query<{
-        fingerprint_count: number;
-        global_count: number;
-      }>(
-        `select
+      return await this.pool.transaction(async (client) => {
+        await this.locks.withTxLock(client, "paseo-cli-authorization-issuance");
+        const capacity = await client.query<{
+          fingerprint_count: number;
+          global_count: number;
+        }>(
+          `select
            count(*) filter (where fingerprint_verifier = $1)::integer as fingerprint_count,
            count(*)::integer as global_count
          from cli_authorizations
          where status in ('pending', 'approved') and expires_at > now()`,
-        [input.fingerprintVerifier],
-      );
-      const counts = capacity.rows[0]!;
-      if (
-        counts.fingerprint_count >= input.perFingerprintLimit ||
-        counts.global_count >= input.globalLimit
-      ) {
-        await client.query("rollback");
-        return undefined;
-      }
-      const inserted = await client.query<CliAuthorizationRow>(
-        `insert into cli_authorizations
+          [input.fingerprintVerifier],
+        );
+        const counts = capacity.rows[0]!;
+        if (
+          counts.fingerprint_count >= input.perFingerprintLimit ||
+          counts.global_count >= input.globalLimit
+        ) {
+          return client.rollback(undefined);
+        }
+        const inserted = await client.query<CliAuthorizationRow>(
+          `insert into cli_authorizations
            (id, device_verifier, user_code_verifier, fingerprint_verifier,
             status, poll_interval_seconds, next_poll_at, expires_at)
          values ($1, $2, $3, $4, 'pending', $5, now(),
                  now() + ($6 * interval '1 second'))
          returning *`,
-        [
-          input.id,
-          input.deviceVerifier,
-          input.userCodeVerifier,
-          input.fingerprintVerifier,
-          input.pollIntervalSeconds,
-          input.lifetimeSeconds,
-        ],
-      );
-      await client.query("commit");
-      return toCliAuthorization(inserted.rows[0]!);
+          [
+            input.id,
+            input.deviceVerifier,
+            input.userCodeVerifier,
+            input.fingerprintVerifier,
+            input.pollIntervalSeconds,
+            input.lifetimeSeconds,
+          ],
+        );
+        return toCliAuthorization(inserted.rows[0]!);
+      });
     } catch (error) {
-      await client.query("rollback");
       throw toDatabaseError(error);
-    } finally {
-      client.release();
     }
   }
 
@@ -1507,27 +1415,25 @@ class PgDatabase implements Database {
   async decideCliAuthorization(
     input: CliAuthorizationDecisionInput,
   ): Promise<"approved" | "denied" | "unavailable" | "forbidden"> {
-    const client = await this.pool.connect();
     try {
-      await client.query("begin");
-      await client.query(
-        `update cli_authorizations set status = 'expired'
+      return await this.pool.transaction(async (client) => {
+        await client.query(
+          `update cli_authorizations set status = 'expired'
          where user_code_verifier = $1 and status in ('pending', 'approved')
            and expires_at <= now()`,
-        [input.userCodeVerifier],
-      );
-      const authorization = await client.query<CliAuthorizationRow>(
-        `select * from cli_authorizations
+          [input.userCodeVerifier],
+        );
+        const authorization = await client.query<CliAuthorizationRow>(
+          `select * from cli_authorizations
          where user_code_verifier = $1 and status = 'pending' and expires_at > now()
          for update`,
-        [input.userCodeVerifier],
-      );
-      if (authorization.rows[0] === undefined) {
-        await client.query("rollback");
-        return "unavailable";
-      }
-      const authority = await client.query(
-        `select 1
+          [input.userCodeVerifier],
+        );
+        if (authorization.rows[0] === undefined) {
+          return client.rollback("unavailable" as const);
+        }
+        const authority = await client.query(
+          `select 1
          from session
          join member on member.id = $3 and member.user_id = session.user_id
            and member.organization_id = session.active_organization_id
@@ -1535,33 +1441,29 @@ class PgDatabase implements Database {
            and session.active_organization_id = $4 and session.expires_at > now()
            and member.role in ('owner', 'admin')
          for update of session, member`,
-        [
-          input.access.sessionId,
-          input.access.userId,
-          input.access.membershipId,
-          input.access.organizationId,
-        ],
-      );
-      if (authority.rowCount !== 1) {
-        await client.query("rollback");
-        return "forbidden";
-      }
-      const status = input.decision === "approve" ? "approved" : "denied";
-      await client.query(
-        `update cli_authorizations
+          [
+            input.access.sessionId,
+            input.access.userId,
+            input.access.membershipId,
+            input.access.organizationId,
+          ],
+        );
+        if (authority.rowCount !== 1) {
+          return client.rollback("forbidden" as const);
+        }
+        const status = input.decision === "approve" ? "approved" : "denied";
+        await client.query(
+          `update cli_authorizations
          set status = $2, approved_organization_id = case when $2 = 'approved' then $3 end,
              approved_by_user_id = case when $2 = 'approved' then $4 end,
              decided_at = now()
          where id = $1`,
-        [authorization.rows[0].id, status, input.access.organizationId, input.access.userId],
-      );
-      await client.query("commit");
-      return status;
+          [authorization.rows[0].id, status, input.access.organizationId, input.access.userId],
+        );
+        return status;
+      });
     } catch (error) {
-      await client.query("rollback");
       throw toDatabaseError(error);
-    } finally {
-      client.release();
     }
   }
 
@@ -1569,173 +1471,136 @@ class PgDatabase implements Database {
     deviceVerifier: string;
     credential: { id: string; prefix: string; verifier: string };
   }): Promise<CliAuthorizationPollResult> {
-    const client = await this.pool.connect();
     try {
-      await client.query("begin");
-      const selected = await client.query<CliAuthorizationRow>(
-        `select *, now() as database_now
+      return await this.pool.transaction(async (client) => {
+        const selected = await client.query<CliAuthorizationRow>(
+          `select *, now() as database_now
          from cli_authorizations where device_verifier = $1 for update`,
-        [input.deviceVerifier],
-      );
-      const authorization = selected.rows[0];
-      if (authorization !== undefined && authorization.expires_at <= authorization.database_now) {
-        await client.query(`update cli_authorizations set status = 'expired' where id = $1`, [
-          authorization.id,
-        ]);
-        await client.query("commit");
-        return {
-          status: "expired",
-          intervalSeconds: authorization.poll_interval_seconds,
-        };
-      }
-      if (authorization === undefined) {
-        await client.query("rollback");
-        return { status: "expired", intervalSeconds: 5 };
-      }
-      if (
-        authorization.status === "denied" ||
-        authorization.status === "expired" ||
-        authorization.status === "disclosed"
-      ) {
-        await client.query("commit");
+          [input.deviceVerifier],
+        );
+        const authorization = selected.rows[0];
+        if (authorization !== undefined && authorization.expires_at <= authorization.database_now) {
+          await client.query(`update cli_authorizations set status = 'expired' where id = $1`, [
+            authorization.id,
+          ]);
+          return {
+            status: "expired",
+            intervalSeconds: authorization.poll_interval_seconds,
+          };
+        }
+        if (authorization === undefined) {
+          return client.rollback({ status: "expired" as const, intervalSeconds: 5 });
+        }
+        if (
+          authorization.status === "denied" ||
+          authorization.status === "expired" ||
+          authorization.status === "disclosed"
+        ) {
+          return {
+            status: authorization.status,
+            intervalSeconds: authorization.poll_interval_seconds,
+          };
+        }
+        if (authorization.next_poll_at > authorization.database_now) {
+          const intervalSeconds = authorization.poll_interval_seconds + 5;
+          await client.query(
+            `update cli_authorizations
+           set poll_interval_seconds = $2::integer,
+               next_poll_at = now() + ($2::integer * interval '1 second')
+           where id = $1`,
+            [authorization.id, intervalSeconds],
+          );
+          return { status: "slow_down", intervalSeconds };
+        }
+        await client.query(
+          `update cli_authorizations
+         set next_poll_at = now() + (poll_interval_seconds * interval '1 second')
+         where id = $1`,
+          [authorization.id],
+        );
+        if (authorization.status === "approved") {
+          await client.query(
+            `insert into organization_cli_credentials
+             (id, organization_id, prefix, verifier, created_by_user_id)
+           values ($1, $2, $3, $4, $5)`,
+            [
+              input.credential.id,
+              authorization.approved_organization_id,
+              input.credential.prefix,
+              input.credential.verifier,
+              authorization.approved_by_user_id,
+            ],
+          );
+          await client.query(
+            `update cli_authorizations set status = 'disclosed', credential_id = $2 where id = $1`,
+            [authorization.id, input.credential.id],
+          );
+          return {
+            status: "authorized",
+            intervalSeconds: authorization.poll_interval_seconds,
+            organizationId: authorization.approved_organization_id!,
+          };
+        }
         return {
           status: authorization.status,
           intervalSeconds: authorization.poll_interval_seconds,
         };
-      }
-      if (authorization.next_poll_at > authorization.database_now) {
-        const intervalSeconds = authorization.poll_interval_seconds + 5;
-        await client.query(
-          `update cli_authorizations
-           set poll_interval_seconds = $2::integer,
-               next_poll_at = now() + ($2::integer * interval '1 second')
-           where id = $1`,
-          [authorization.id, intervalSeconds],
-        );
-        await client.query("commit");
-        return { status: "slow_down", intervalSeconds };
-      }
-      await client.query(
-        `update cli_authorizations
-         set next_poll_at = now() + (poll_interval_seconds * interval '1 second')
-         where id = $1`,
-        [authorization.id],
-      );
-      if (authorization.status === "approved") {
-        await client.query(
-          `insert into organization_cli_credentials
-             (id, organization_id, prefix, verifier, created_by_user_id)
-           values ($1, $2, $3, $4, $5)`,
-          [
-            input.credential.id,
-            authorization.approved_organization_id,
-            input.credential.prefix,
-            input.credential.verifier,
-            authorization.approved_by_user_id,
-          ],
-        );
-        await client.query(
-          `update cli_authorizations set status = 'disclosed', credential_id = $2 where id = $1`,
-          [authorization.id, input.credential.id],
-        );
-        await client.query("commit");
-        return {
-          status: "authorized",
-          intervalSeconds: authorization.poll_interval_seconds,
-          organizationId: authorization.approved_organization_id!,
-        };
-      }
-      await client.query("commit");
-      return {
-        status: authorization.status,
-        intervalSeconds: authorization.poll_interval_seconds,
-      };
+      });
     } catch (error) {
-      await client.query("rollback");
       throw toDatabaseError(error);
-    } finally {
-      client.release();
     }
   }
 
   async enrollDaemon(input: EnrollDaemonInput) {
-    const client = await this.pool.connect();
     let requestedSlug: string | undefined;
     try {
-      await client.query("begin");
-      const existing = await client.query<DaemonRow>(
-        `select * from daemons where idempotency_key = $1`,
-        [input.idempotencyKey],
-      );
-      if (
-        existing.rows[0] &&
-        existing.rows[0].id === input.daemonId &&
-        existing.rows[0].enrollment_verifier === input.tokenVerifier
-      ) {
-        await client.query("commit");
-        return toDaemon(existing.rows[0]);
-      }
-      const token = await client.query<{
-        id: string;
-        organization_id: string | null;
-        issued_by_api_key_id: string | null;
-        issued_by_cli_credential_id: string | null;
-      }>(
-        `update daemon_enrollment_tokens
+      return await this.pool.transaction(async (client) => {
+        const existing = await client.query<DaemonRow>(
+          `select * from daemons where idempotency_key = $1`,
+          [input.idempotencyKey],
+        );
+        if (
+          existing.rows[0] &&
+          existing.rows[0].id === input.daemonId &&
+          existing.rows[0].enrollment_verifier === input.tokenVerifier
+        ) {
+          return toDaemon(existing.rows[0]);
+        }
+        const token = await client.query<{
+          id: string;
+          organization_id: string | null;
+          issued_by_api_key_id: string | null;
+          issued_by_cli_credential_id: string | null;
+        }>(
+          `update daemon_enrollment_tokens
          set consumed_at = $2
          where verifier = $1 and organization_id is not null and consumed_at is null
            and expires_at > $2
          returning id, organization_id, issued_by_api_key_id, issued_by_cli_credential_id`,
-        [input.tokenVerifier, input.now],
-      );
-      const consumedToken = token.rows[0];
-      if (consumedToken?.organization_id === null || consumedToken === undefined) {
-        await client.query("rollback");
-        return undefined;
-      }
-      const machine = await client.query<MachineRow>(
-        `insert into machines (org_id, source, status) values ($1, $2, 'alive') returning *`,
-        [consumedToken.organization_id, { kind: "daemon", daemonId: input.daemonId }],
-      );
-      const suggestedSlug = input.suggestedSlug ?? `daemon-${input.daemonId.slice(0, 8)}`;
-      requestedSlug = suggestedSlug;
-      let daemon = await client.query<DaemonRow>(
-        `insert into daemons
+          [input.tokenVerifier, input.now],
+        );
+        const consumedToken = token.rows[0];
+        if (consumedToken?.organization_id === null || consumedToken === undefined)
+          return client.rollback(undefined);
+        const machine = await client.query<MachineRow>(
+          `insert into machines (org_id, source, status) values ($1, $2, 'alive') returning *`,
+          [consumedToken.organization_id, { kind: "daemon", daemonId: input.daemonId }],
+        );
+        const suggestedSlug = input.suggestedSlug ?? `daemon-${input.daemonId.slice(0, 8)}`;
+        requestedSlug = suggestedSlug;
+        let daemon = await client.query<DaemonRow>(
+          `insert into daemons
            (id, idempotency_key, enrollment_verifier, slug, machine_id, organization_id, server_id,
             daemon_public_key, credential_verifier, scopes,
             registered_by_api_key_id, registered_by_cli_credential_id, status)
          values ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,'active')
          on conflict (organization_id, slug) do nothing
          returning *`,
-        [
-          input.daemonId,
-          input.idempotencyKey,
-          input.tokenVerifier,
-          suggestedSlug,
-          machine.rows[0]!.id,
-          consumedToken.organization_id,
-          input.serverId,
-          input.daemonPublicKey,
-          input.credentialVerifier,
-          JSON.stringify(input.scopes),
-          consumedToken.issued_by_api_key_id,
-          consumedToken.issued_by_cli_credential_id,
-        ],
-      );
-      if (daemon.rows[0] === undefined) {
-        const uniqueSlug = `${suggestedSlug}-${input.daemonId.slice(0, 8)}`;
-        requestedSlug = uniqueSlug;
-        daemon = await client.query<DaemonRow>(
-          `insert into daemons
-             (id, idempotency_key, enrollment_verifier, slug, machine_id, organization_id, server_id,
-              daemon_public_key, credential_verifier, scopes,
-              registered_by_api_key_id, registered_by_cli_credential_id, status)
-           values ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,'active') returning *`,
           [
             input.daemonId,
             input.idempotencyKey,
             input.tokenVerifier,
-            uniqueSlug,
+            suggestedSlug,
             machine.rows[0]!.id,
             consumedToken.organization_id,
             input.serverId,
@@ -1746,17 +1611,38 @@ class PgDatabase implements Database {
             consumedToken.issued_by_cli_credential_id,
           ],
         );
-      }
-      await client.query("commit");
-      return toDaemon(daemon.rows[0]!);
+        if (daemon.rows[0] === undefined) {
+          const uniqueSlug = `${suggestedSlug}-${input.daemonId.slice(0, 8)}`;
+          requestedSlug = uniqueSlug;
+          daemon = await client.query<DaemonRow>(
+            `insert into daemons
+             (id, idempotency_key, enrollment_verifier, slug, machine_id, organization_id, server_id,
+              daemon_public_key, credential_verifier, scopes,
+              registered_by_api_key_id, registered_by_cli_credential_id, status)
+           values ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,'active') returning *`,
+            [
+              input.daemonId,
+              input.idempotencyKey,
+              input.tokenVerifier,
+              uniqueSlug,
+              machine.rows[0]!.id,
+              consumedToken.organization_id,
+              input.serverId,
+              input.daemonPublicKey,
+              input.credentialVerifier,
+              JSON.stringify(input.scopes),
+              consumedToken.issued_by_api_key_id,
+              consumedToken.issued_by_cli_credential_id,
+            ],
+          );
+        }
+        return toDaemon(daemon.rows[0]!);
+      });
     } catch (error) {
-      await client.query("rollback");
       if (requestedSlug !== undefined && isDaemonSlugConflict(error)) {
         return { status: "slug_conflict" as const, slug: requestedSlug };
       }
       throw toDatabaseError(error);
-    } finally {
-      client.release();
     }
   }
 
@@ -1869,49 +1755,48 @@ class PgDatabase implements Database {
     observedAt: Date,
     processedAt: Date,
   ): Promise<AgentExecutionRecord> {
-    const client = await this.pool.connect();
     try {
-      await client.query("begin");
-      const existingRows = await client.query<AgentExecutionRow>(
-        `select * from agent_executions where id = $1`,
-        [executionId],
-      );
-      const existing = existingRows.rows[0];
-      if (existing === undefined) throw new Error(`agent execution not found: ${executionId}`);
-
-      let workflowRefreshAllowed = true;
-      if (existing.workflow_step_run_id !== null) {
-        const stepRows = await client.query<WorkflowStepRunRow>(
-          `select * from workflow_step_runs where id = $1`,
-          [existing.workflow_step_run_id],
+      return await this.pool.transaction(async (client) => {
+        const existingRows = await client.query<AgentExecutionRow>(
+          `select * from agent_executions where id = $1`,
+          [executionId],
         );
-        const stepCandidate = stepRows.rows[0];
-        if (stepCandidate !== undefined) {
-          const runRows = await client.query<TriggerRunRow>(
-            `select * from trigger_runs where id = $1 for update`,
-            [stepCandidate.trigger_run_id],
-          );
-          const lockedStepRows = await client.query<WorkflowStepRunRow>(
-            `select * from workflow_step_runs where id = $1 for update`,
-            [stepCandidate.id],
-          );
-          const step = lockedStepRows.rows[0];
-          const run = runRows.rows[0];
-          workflowRefreshAllowed =
-            step !== undefined &&
-            step.status === "running" &&
-            run !== undefined &&
-            run.status === "running" &&
-            (run.deadline_at === null || run.deadline_at > processedAt);
-        } else {
-          workflowRefreshAllowed = false;
-        }
-      }
+        const existing = existingRows.rows[0];
+        if (existing === undefined) throw new Error(`agent execution not found: ${executionId}`);
 
-      let row: AgentExecutionRow | undefined;
-      if (workflowRefreshAllowed) {
-        const rows = await client.query<AgentExecutionRow>(
-          `update agent_executions
+        let workflowRefreshAllowed = true;
+        if (existing.workflow_step_run_id !== null) {
+          const stepRows = await client.query<WorkflowStepRunRow>(
+            `select * from workflow_step_runs where id = $1`,
+            [existing.workflow_step_run_id],
+          );
+          const stepCandidate = stepRows.rows[0];
+          if (stepCandidate !== undefined) {
+            const runRows = await client.query<TriggerRunRow>(
+              `select * from trigger_runs where id = $1 for update`,
+              [stepCandidate.trigger_run_id],
+            );
+            const lockedStepRows = await client.query<WorkflowStepRunRow>(
+              `select * from workflow_step_runs where id = $1 for update`,
+              [stepCandidate.id],
+            );
+            const step = lockedStepRows.rows[0];
+            const run = runRows.rows[0];
+            workflowRefreshAllowed =
+              step !== undefined &&
+              step.status === "running" &&
+              run !== undefined &&
+              run.status === "running" &&
+              (run.deadline_at === null || run.deadline_at > processedAt);
+          } else {
+            workflowRefreshAllowed = false;
+          }
+        }
+
+        let row: AgentExecutionRow | undefined;
+        if (workflowRefreshAllowed) {
+          const rows = await client.query<AgentExecutionRow>(
+            `update agent_executions
            set idle_deadline_at = case
              when $2::timestamptz is null then null
              when deadline_at is null then $2::timestamptz
@@ -1921,34 +1806,31 @@ class PgDatabase implements Database {
              and ($3::timestamptz is null or deadline_at is null or deadline_at > $3)
              and (idle_deadline_at is null or idle_deadline_at > $4)
            returning *`,
-          [executionId, idleDeadlineAt, processedAt, observedAt],
-        );
-        row = rows.rows[0];
-      }
-      if (row !== undefined && row.workflow_step_run_id !== null) {
-        await client.query(
-          `update workflow_step_runs
+            [executionId, idleDeadlineAt, processedAt, observedAt],
+          );
+          row = rows.rows[0];
+        }
+        if (row !== undefined && row.workflow_step_run_id !== null) {
+          await client.query(
+            `update workflow_step_runs
            set idle_deadline_at = $2
            where id = $1 and status = 'running'`,
-          [row.workflow_step_run_id, row.idle_deadline_at],
-        );
-      }
-      const current =
-        row === undefined
-          ? ((
-              await client.query<AgentExecutionRow>(
-                `select * from agent_executions where id = $1`,
-                [executionId],
-              )
-            ).rows[0] ?? existing)
-          : row;
-      await client.query("commit");
-      return toAgentExecutionRecord(current);
+            [row.workflow_step_run_id, row.idle_deadline_at],
+          );
+        }
+        const current =
+          row === undefined
+            ? ((
+                await client.query<AgentExecutionRow>(
+                  `select * from agent_executions where id = $1`,
+                  [executionId],
+                )
+              ).rows[0] ?? existing)
+            : row;
+        return toAgentExecutionRecord(current);
+      });
     } catch (error) {
-      await client.query("rollback").catch(() => undefined);
       throw toDatabaseError(error);
-    } finally {
-      client.release();
     }
   }
 
@@ -2110,60 +1992,54 @@ class PgDatabase implements Database {
     maxOutputs: number,
     startedAt: Date,
   ): Promise<AgentExecutionOutputAttempt | undefined> {
-    const client = await this.pool.connect();
     try {
-      await client.query("begin");
-      const selected = await client.query<AgentExecutionRow>(
-        `select * from agent_executions where id = $1 for update`,
-        [executionId],
-      );
-      const row = selected.rows[0];
-      if (row === undefined) {
-        await client.query("commit");
-        return undefined;
-      }
-      const execution = toAgentExecutionRecord(row);
-      const activeAttempts = Object.values(execution.outputDeliveryAttempts).filter(
-        (attempt) =>
-          attempt.outputType === outputType &&
-          attempt.status === "pending" &&
-          attempt.leaseExpiresAt > startedAt,
-      ).length;
-      if (
-        maxOutputs < 1 ||
-        (execution.status !== "spawning" && execution.status !== "running") ||
-        (execution.outputEmissions[outputType] ?? 0) + activeAttempts >= maxOutputs
-      ) {
-        await client.query("commit");
-        return undefined;
-      }
-      const attempt: AgentExecutionOutputAttempt = {
-        id: randomUUID(),
-        outputType,
-        status: "pending",
-        startedAt,
-        leaseExpiresAt: new Date(startedAt.getTime() + OUTPUT_ATTEMPT_LEASE_MS),
-        completedAt: null,
-      };
-      await client.query(
-        `update agent_executions
+      return await this.pool.transaction(async (client) => {
+        const selected = await client.query<AgentExecutionRow>(
+          `select * from agent_executions where id = $1 for update`,
+          [executionId],
+        );
+        const row = selected.rows[0];
+        if (row === undefined) {
+          return undefined;
+        }
+        const execution = toAgentExecutionRecord(row);
+        const activeAttempts = Object.values(execution.outputDeliveryAttempts).filter(
+          (attempt) =>
+            attempt.outputType === outputType &&
+            attempt.status === "pending" &&
+            attempt.leaseExpiresAt > startedAt,
+        ).length;
+        if (
+          maxOutputs < 1 ||
+          (execution.status !== "spawning" && execution.status !== "running") ||
+          (execution.outputEmissions[outputType] ?? 0) + activeAttempts >= maxOutputs
+        ) {
+          return undefined;
+        }
+        const attempt: AgentExecutionOutputAttempt = {
+          id: randomUUID(),
+          outputType,
+          status: "pending",
+          startedAt,
+          leaseExpiresAt: new Date(startedAt.getTime() + OUTPUT_ATTEMPT_LEASE_MS),
+          completedAt: null,
+        };
+        await client.query(
+          `update agent_executions
          set output_delivery_attempts = $2::jsonb
          where id = $1`,
-        [
-          executionId,
-          JSON.stringify({
-            ...execution.outputDeliveryAttempts,
-            [attempt.id]: attempt,
-          }),
-        ],
-      );
-      await client.query("commit");
-      return attempt;
+          [
+            executionId,
+            JSON.stringify({
+              ...execution.outputDeliveryAttempts,
+              [attempt.id]: attempt,
+            }),
+          ],
+        );
+        return attempt;
+      });
     } catch (error) {
-      await client.query("rollback").catch(() => undefined);
       throw toDatabaseError(error);
-    } finally {
-      client.release();
     }
   }
 
@@ -2172,74 +2048,65 @@ class PgDatabase implements Database {
     attemptId: string,
     completedAt: Date,
   ): Promise<AgentExecutionRecord | undefined> {
-    const client = await this.pool.connect();
     try {
-      await client.query("begin");
-      const selected = await client.query<AgentExecutionRow>(
-        `select * from agent_executions where id = $1 for update`,
-        [executionId],
-      );
-      const row = selected.rows[0];
-      if (row === undefined) {
-        await client.query("commit");
-        return undefined;
-      }
-      const execution = toAgentExecutionRecord(row);
-      const attempt = execution.outputDeliveryAttempts[attemptId];
-      if (attempt === undefined) {
-        await client.query("commit");
-        return undefined;
-      }
-      if (attempt.status === "succeeded") {
-        await client.query("commit");
-        return execution;
-      }
-      if (attempt.status !== "pending") {
-        await client.query("commit");
-        return undefined;
-      }
-      if (attempt.leaseExpiresAt <= completedAt) {
-        await client.query(
-          `update agent_executions
+      return await this.pool.transaction(async (client) => {
+        const selected = await client.query<AgentExecutionRow>(
+          `select * from agent_executions where id = $1 for update`,
+          [executionId],
+        );
+        const row = selected.rows[0];
+        if (row === undefined) {
+          return undefined;
+        }
+        const execution = toAgentExecutionRecord(row);
+        const attempt = execution.outputDeliveryAttempts[attemptId];
+        if (attempt === undefined) {
+          return undefined;
+        }
+        if (attempt.status === "succeeded") {
+          return execution;
+        }
+        if (attempt.status !== "pending") {
+          return undefined;
+        }
+        if (attempt.leaseExpiresAt <= completedAt) {
+          await client.query(
+            `update agent_executions
            set output_delivery_attempts = $2::jsonb
            where id = $1`,
-          [
-            executionId,
-            JSON.stringify({
-              ...execution.outputDeliveryAttempts,
-              [attemptId]: { ...attempt, status: "failed" as const, completedAt: null },
-            }),
-          ],
-        );
-        await client.query("commit");
-        return undefined;
-      }
-      const outputEmissions = {
-        ...execution.outputEmissions,
-        [attempt.outputType]: (execution.outputEmissions[attempt.outputType] ?? 0) + 1,
-      };
-      const updated = await client.query<AgentExecutionRow>(
-        `update agent_executions
+            [
+              executionId,
+              JSON.stringify({
+                ...execution.outputDeliveryAttempts,
+                [attemptId]: { ...attempt, status: "failed" as const, completedAt: null },
+              }),
+            ],
+          );
+          return undefined;
+        }
+        const outputEmissions = {
+          ...execution.outputEmissions,
+          [attempt.outputType]: (execution.outputEmissions[attempt.outputType] ?? 0) + 1,
+        };
+        const updated = await client.query<AgentExecutionRow>(
+          `update agent_executions
          set output_emissions = $2::jsonb,
              output_delivery_attempts = $3::jsonb
          where id = $1
          returning *`,
-        [
-          executionId,
-          JSON.stringify(outputEmissions),
-          JSON.stringify({
-            ...execution.outputDeliveryAttempts,
-            [attemptId]: { ...attempt, status: "succeeded" as const, completedAt },
-          }),
-        ],
-      );
-      await client.query("commit");
-      return updated.rows[0] === undefined ? undefined : toAgentExecutionRecord(updated.rows[0]);
+          [
+            executionId,
+            JSON.stringify(outputEmissions),
+            JSON.stringify({
+              ...execution.outputDeliveryAttempts,
+              [attemptId]: { ...attempt, status: "succeeded" as const, completedAt },
+            }),
+          ],
+        );
+        return updated.rows[0] === undefined ? undefined : toAgentExecutionRecord(updated.rows[0]);
+      });
     } catch (error) {
-      await client.query("rollback").catch(() => undefined);
       throw toDatabaseError(error);
-    } finally {
-      client.release();
     }
   }
 
@@ -2248,43 +2115,37 @@ class PgDatabase implements Database {
     attemptId: string,
     _failedAt: Date,
   ): Promise<boolean> {
-    const client = await this.pool.connect();
     try {
-      await client.query("begin");
-      const selected = await client.query<AgentExecutionRow>(
-        `select * from agent_executions where id = $1 for update`,
-        [executionId],
-      );
-      const row = selected.rows[0];
-      if (row === undefined) {
-        await client.query("commit");
-        return false;
-      }
-      const execution = toAgentExecutionRecord(row);
-      const attempt = execution.outputDeliveryAttempts[attemptId];
-      if (attempt === undefined || attempt.status !== "pending") {
-        await client.query("commit");
-        return false;
-      }
-      await client.query(
-        `update agent_executions
+      return await this.pool.transaction(async (client) => {
+        const selected = await client.query<AgentExecutionRow>(
+          `select * from agent_executions where id = $1 for update`,
+          [executionId],
+        );
+        const row = selected.rows[0];
+        if (row === undefined) {
+          return false;
+        }
+        const execution = toAgentExecutionRecord(row);
+        const attempt = execution.outputDeliveryAttempts[attemptId];
+        if (attempt === undefined || attempt.status !== "pending") {
+          return false;
+        }
+        await client.query(
+          `update agent_executions
          set output_delivery_attempts = $2::jsonb
          where id = $1`,
-        [
-          executionId,
-          JSON.stringify({
-            ...execution.outputDeliveryAttempts,
-            [attemptId]: { ...attempt, status: "failed" as const, completedAt: null },
-          }),
-        ],
-      );
-      await client.query("commit");
-      return true;
+          [
+            executionId,
+            JSON.stringify({
+              ...execution.outputDeliveryAttempts,
+              [attemptId]: { ...attempt, status: "failed" as const, completedAt: null },
+            }),
+          ],
+        );
+        return true;
+      });
     } catch (error) {
-      await client.query("rollback").catch(() => undefined);
       throw toDatabaseError(error);
-    } finally {
-      client.release();
     }
   }
 
@@ -2560,117 +2421,105 @@ class PgDatabase implements Database {
   async stampOrganizationEntitlements(
     input: StampOrganizationEntitlementsInput,
   ): Promise<OrganizationEntitlementsRecord> {
-    const client = await this.pool.connect();
     try {
-      await client.query("begin");
-      const record = await stampEntitlementsWithinTransaction(client, input);
-      await client.query("commit");
-      return record;
+      return await this.pool.transaction(async (client) => {
+        const record = await stampEntitlementsWithinTransaction(client, input);
+        return record;
+      });
     } catch (error) {
-      await client.query("rollback").catch(() => undefined);
       throw toDatabaseError(error);
-    } finally {
-      client.release();
     }
   }
 
   async overrideOrganizationEntitlements(
     input: OverrideOrganizationEntitlementsInput,
   ): Promise<OrganizationEntitlementsRecord> {
-    const client = await this.pool.connect();
     try {
-      await client.query("begin");
-      const existing = await client.query<OrganizationEntitlementsRow>(
-        `select * from organization_entitlements where organization_id = $1 for update`,
-        [input.organizationId],
-      );
-      const before = existing.rows[0];
-      if (before === undefined) {
-        throw new Error(`organization has no entitlements record: ${input.organizationId}`);
-      }
-      // Merge the patch against the row we hold locked, so a concurrent override serializes
-      // behind this one instead of reading a stale base and clobbering its keys.
-      const overrides = mergeOverrides(
-        entitlementOverridesSchema.parse(before.overrides),
-        input.patch,
-      );
-      const updated = await client.query<OrganizationEntitlementsRow>(
-        `update organization_entitlements
+      return await this.pool.transaction(async (client) => {
+        const existing = await client.query<OrganizationEntitlementsRow>(
+          `select * from organization_entitlements where organization_id = $1 for update`,
+          [input.organizationId],
+        );
+        const before = existing.rows[0];
+        if (before === undefined) {
+          throw new Error(`organization has no entitlements record: ${input.organizationId}`);
+        }
+        // Merge the patch against the row we hold locked, so a concurrent override serializes
+        // behind this one instead of reading a stale base and clobbering its keys.
+        const overrides = mergeOverrides(
+          entitlementOverridesSchema.parse(before.overrides),
+          input.patch,
+        );
+        const updated = await client.query<OrganizationEntitlementsRow>(
+          `update organization_entitlements
            set overrides = $2::jsonb, updated_at = now()
          where organization_id = $1
          returning *`,
-        [input.organizationId, JSON.stringify(overrides)],
-      );
-      const after = updated.rows[0];
-      if (after === undefined) throw new Error("entitlements override returned no row");
-      await client.query(
-        `insert into entitlement_changes (organization_id, actor, source, before, after, reason)
+          [input.organizationId, JSON.stringify(overrides)],
+        );
+        const after = updated.rows[0];
+        if (after === undefined) throw new Error("entitlements override returned no row");
+        await client.query(
+          `insert into entitlement_changes (organization_id, actor, source, before, after, reason)
          values ($1, $2, 'override', $3::jsonb, $4::jsonb, $5)`,
-        [
-          input.organizationId,
-          input.actor,
-          JSON.stringify(entitlementSnapshot(before)),
-          JSON.stringify(entitlementSnapshot(after)),
-          input.reason,
-        ],
-      );
-      await client.query("commit");
-      return toOrganizationEntitlementsRecord(after);
+          [
+            input.organizationId,
+            input.actor,
+            JSON.stringify(entitlementSnapshot(before)),
+            JSON.stringify(entitlementSnapshot(after)),
+            input.reason,
+          ],
+        );
+        return toOrganizationEntitlementsRecord(after);
+      });
     } catch (error) {
-      await client.query("rollback").catch(() => undefined);
       throw toDatabaseError(error);
-    } finally {
-      client.release();
     }
   }
 
   async clearOrganizationEntitlementsOverride(
     input: ClearOrganizationEntitlementsOverrideInput,
   ): Promise<OrganizationEntitlementsRecord> {
-    const client = await this.pool.connect();
     try {
-      await client.query("begin");
-      const existing = await client.query<OrganizationEntitlementsRow>(
-        `select * from organization_entitlements where organization_id = $1 for update`,
-        [input.organizationId],
-      );
-      const before = existing.rows[0];
-      if (before === undefined) {
-        throw new Error(`organization has no entitlements record: ${input.organizationId}`);
-      }
-      // Remove the key from the row we hold locked, the same lock the merge takes, so a clear and
-      // a concurrent override serialize instead of racing on a stale base.
-      const overrides = clearOverrideKey(
-        entitlementOverridesSchema.parse(before.overrides),
-        input.key,
-      );
-      const updated = await client.query<OrganizationEntitlementsRow>(
-        `update organization_entitlements
+      return await this.pool.transaction(async (client) => {
+        const existing = await client.query<OrganizationEntitlementsRow>(
+          `select * from organization_entitlements where organization_id = $1 for update`,
+          [input.organizationId],
+        );
+        const before = existing.rows[0];
+        if (before === undefined) {
+          throw new Error(`organization has no entitlements record: ${input.organizationId}`);
+        }
+        // Remove the key from the row we hold locked, the same lock the merge takes, so a clear and
+        // a concurrent override serialize instead of racing on a stale base.
+        const overrides = clearOverrideKey(
+          entitlementOverridesSchema.parse(before.overrides),
+          input.key,
+        );
+        const updated = await client.query<OrganizationEntitlementsRow>(
+          `update organization_entitlements
            set overrides = $2::jsonb, updated_at = now()
          where organization_id = $1
          returning *`,
-        [input.organizationId, JSON.stringify(overrides)],
-      );
-      const after = updated.rows[0];
-      if (after === undefined) throw new Error("entitlements override clear returned no row");
-      await client.query(
-        `insert into entitlement_changes (organization_id, actor, source, before, after, reason)
+          [input.organizationId, JSON.stringify(overrides)],
+        );
+        const after = updated.rows[0];
+        if (after === undefined) throw new Error("entitlements override clear returned no row");
+        await client.query(
+          `insert into entitlement_changes (organization_id, actor, source, before, after, reason)
          values ($1, $2, 'override', $3::jsonb, $4::jsonb, $5)`,
-        [
-          input.organizationId,
-          input.actor,
-          JSON.stringify(entitlementSnapshot(before)),
-          JSON.stringify(entitlementSnapshot(after)),
-          input.reason,
-        ],
-      );
-      await client.query("commit");
-      return toOrganizationEntitlementsRecord(after);
+          [
+            input.organizationId,
+            input.actor,
+            JSON.stringify(entitlementSnapshot(before)),
+            JSON.stringify(entitlementSnapshot(after)),
+            input.reason,
+          ],
+        );
+        return toOrganizationEntitlementsRecord(after);
+      });
     } catch (error) {
-      await client.query("rollback").catch(() => undefined);
       throw toDatabaseError(error);
-    } finally {
-      client.release();
     }
   }
 
@@ -2731,11 +2580,10 @@ class PgDatabase implements Database {
   }
 
   async syncBillingPlan(input: SyncBillingPlanInput): Promise<BillingPlanRecord> {
-    const client = await this.pool.connect();
     try {
-      await client.query("begin");
-      const planRow = await client.query<BillingPlanRow>(
-        `insert into billing_plans (id, slug, name, template, template_hash, marketing, active, synced_at)
+      return await this.pool.transaction(async (client) => {
+        const planRow = await client.query<BillingPlanRow>(
+          `insert into billing_plans (id, slug, name, template, template_hash, marketing, active, synced_at)
          values ($1, $2, $3, $4::jsonb, $5, $6::jsonb, $7, now())
          on conflict (id) do update
            set slug = excluded.slug,
@@ -2746,49 +2594,46 @@ class PgDatabase implements Database {
                active = excluded.active,
                synced_at = now()
          returning *`,
-        [
-          input.id,
-          input.slug,
-          input.name,
-          JSON.stringify(input.template),
-          input.templateHash,
-          JSON.stringify(input.marketing),
-          input.active,
-        ],
-      );
-      const plan = planRow.rows[0];
-      if (plan === undefined) throw new Error("billing plan sync returned no row");
-      // Prices are replaced wholesale rather than diffed: the catalog is small and this runs
-      // only on boot or a product/price webhook, so a delete-and-reinsert is simple and correct.
-      await client.query(`delete from billing_plan_prices where plan_id = $1`, [input.id]);
-      const prices: BillingPlanPriceRow[] = [];
-      for (const price of input.prices) {
-        const priceRow = await client.query<BillingPlanPriceRow>(
-          `insert into billing_plan_prices (id, plan_id, lookup_key, interval, unit_amount, currency, active)
-           values ($1, $2, $3, $4, $5, $6, $7)
-           returning *`,
           [
-            price.id,
             input.id,
-            price.lookupKey,
-            price.interval,
-            price.unitAmount,
-            price.currency,
-            price.active,
+            input.slug,
+            input.name,
+            JSON.stringify(input.template),
+            input.templateHash,
+            JSON.stringify(input.marketing),
+            input.active,
           ],
         );
-        const insertedPrice = priceRow.rows[0];
-        if (insertedPrice === undefined)
-          throw new Error("billing plan price insert returned no row");
-        prices.push(insertedPrice);
-      }
-      await client.query("commit");
-      return toBillingPlanRecord(plan, prices);
+        const plan = planRow.rows[0];
+        if (plan === undefined) throw new Error("billing plan sync returned no row");
+        // Prices are replaced wholesale rather than diffed: the catalog is small and this runs
+        // only on boot or a product/price webhook, so a delete-and-reinsert is simple and correct.
+        await client.query(`delete from billing_plan_prices where plan_id = $1`, [input.id]);
+        const prices: BillingPlanPriceRow[] = [];
+        for (const price of input.prices) {
+          const priceRow = await client.query<BillingPlanPriceRow>(
+            `insert into billing_plan_prices (id, plan_id, lookup_key, interval, unit_amount, currency, active)
+           values ($1, $2, $3, $4, $5, $6, $7)
+           returning *`,
+            [
+              price.id,
+              input.id,
+              price.lookupKey,
+              price.interval,
+              price.unitAmount,
+              price.currency,
+              price.active,
+            ],
+          );
+          const insertedPrice = priceRow.rows[0];
+          if (insertedPrice === undefined)
+            throw new Error("billing plan price insert returned no row");
+          prices.push(insertedPrice);
+        }
+        return toBillingPlanRecord(plan, prices);
+      });
     } catch (error) {
-      await client.query("rollback").catch(() => undefined);
       throw toDatabaseError(error);
-    } finally {
-      client.release();
     }
   }
 
@@ -2824,11 +2669,10 @@ class PgDatabase implements Database {
   async reconcileOrganizationSubscription(
     input: ReconcileOrganizationSubscriptionInput,
   ): Promise<OrganizationSubscriptionRecord> {
-    const client = await this.pool.connect();
     try {
-      await client.query("begin");
-      const rows = await client.query<OrganizationSubscriptionRow>(
-        `insert into organization_subscriptions
+      return await this.pool.transaction(async (client) => {
+        const rows = await client.query<OrganizationSubscriptionRow>(
+          `insert into organization_subscriptions
            (organization_id, stripe_customer_id, stripe_subscription_id, plan_id, status,
             current_period_end, cancel_at_period_end, updated_at)
          values ($1, $2, $3, $4, $5, $6, $7, now())
@@ -2841,51 +2685,35 @@ class PgDatabase implements Database {
                cancel_at_period_end = excluded.cancel_at_period_end,
                updated_at = now()
          returning *`,
-        [
-          input.organizationId,
-          input.stripeCustomerId,
-          input.stripeSubscriptionId,
-          input.planId,
-          input.status,
-          input.currentPeriodEnd,
-          input.cancelAtPeriodEnd,
-        ],
-      );
-      const row = rows.rows[0];
-      if (row === undefined) throw new Error("organization subscription upsert returned no row");
-      // Same transaction as the mirror upsert: the plan the org is billed on and the entitlements
-      // it enforces can never diverge across a crash between the two writes.
-      if (input.stamp !== undefined) {
-        await stampEntitlementsWithinTransaction(client, {
-          organizationId: input.organizationId,
-          ...input.stamp,
-        });
-      }
-      await client.query("commit");
-      return toOrganizationSubscriptionRecord(row);
+          [
+            input.organizationId,
+            input.stripeCustomerId,
+            input.stripeSubscriptionId,
+            input.planId,
+            input.status,
+            input.currentPeriodEnd,
+            input.cancelAtPeriodEnd,
+          ],
+        );
+        const row = rows.rows[0];
+        if (row === undefined) throw new Error("organization subscription upsert returned no row");
+        // Same transaction as the mirror upsert: the plan the org is billed on and the entitlements
+        // it enforces can never diverge across a crash between the two writes.
+        if (input.stamp !== undefined) {
+          await stampEntitlementsWithinTransaction(client, {
+            organizationId: input.organizationId,
+            ...input.stamp,
+          });
+        }
+        return toOrganizationSubscriptionRecord(row);
+      });
     } catch (error) {
-      await client.query("rollback").catch(() => undefined);
       throw toDatabaseError(error);
-    } finally {
-      client.release();
     }
   }
 
   async withAdvisoryLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
-    // A session-level advisory lock on a dedicated connection: it serializes the critical section
-    // across processes, and it is held for the whole of `fn` (including any external re-read),
-    // not just a single statement. `hashtextextended` maps the string key to the bigint the
-    // advisory-lock functions take.
-    const client = await this.pool.connect();
-    try {
-      await client.query(`select pg_advisory_lock(hashtextextended($1, 0))`, [key]);
-      return await fn();
-    } finally {
-      await client
-        .query(`select pg_advisory_unlock(hashtextextended($1, 0))`, [key])
-        .catch(() => undefined);
-      client.release();
-    }
+    return this.locks.withLock(key, fn);
   }
 
   async getOrganizationSubscription(
@@ -2989,50 +2817,46 @@ class PgDatabase implements Database {
   }
 
   async archiveProject(organizationId: string, projectId: string, userId: string) {
-    const client = await this.pool.connect();
     try {
-      await client.query("begin");
-      const access = await client.query<ProjectRow>(
-        `select projects.*
+      return await this.pool.transaction(async (client) => {
+        const access = await client.query<ProjectRow>(
+          `select projects.*
          from projects
          join member on member.organization_id = projects.organization_id
          where projects.id = $1 and projects.organization_id = $2
            and member.user_id = $3 and member.role in ('owner', 'admin')
          for update of projects`,
-        [projectId, organizationId, userId],
-      );
-      if (access.rows[0] === undefined) throw new Error("project access denied");
-      await client.query(
-        `update project_configuration_sources
+          [projectId, organizationId, userId],
+        );
+        if (access.rows[0] === undefined) throw new Error("project access denied");
+        await client.query(
+          `update project_configuration_sources
          set kind = 'manual', github_connection_id = null, github_repository_id = null,
              github_repository_full_name = null, github_default_branch = null,
              automatic_deployment_enabled = false, updated_at = clock_timestamp()
          where project_id = $1`,
-        [projectId],
-      );
-      await client.query(`delete from project_trigger_routes where project_id = $1`, [projectId]);
-      const archived = await client.query<ProjectRow>(
-        `update projects
+          [projectId],
+        );
+        await client.query(`delete from project_trigger_routes where project_id = $1`, [projectId]);
+        const archived = await client.query<ProjectRow>(
+          `update projects
          set status = 'archived', active_configuration_revision_id = null,
              archived_at = clock_timestamp(), updated_at = clock_timestamp()
          where id = $1 returning *`,
-        [projectId],
-      );
-      await client.query(
-        `insert into audit_events
+          [projectId],
+        );
+        await client.query(
+          `insert into audit_events
            (organization_id, project_id, actor_kind, actor_identity, action,
             subject_type, subject_id, evidence)
          values ($1, $2, 'user', $3, 'project.archived', 'project', $4,
                  '{"releasedRoutes":true}')`,
-        [organizationId, projectId, userId, projectId],
-      );
-      await client.query("commit");
-      return toProjectRecord(archived.rows[0]!);
+          [organizationId, projectId, userId, projectId],
+        );
+        return toProjectRecord(archived.rows[0]!);
+      });
     } catch (error) {
-      await client.query("rollback").catch(() => undefined);
       throw toDatabaseError(error);
-    } finally {
-      client.release();
     }
   }
 
@@ -3092,69 +2916,65 @@ class PgDatabase implements Database {
     revisionId: string,
     routes?: readonly ProjectTriggerRoute[],
   ) {
-    const client = await this.pool.connect();
     try {
-      await client.query("begin");
-      const revision = await lockValidProjectRevision(client, projectId, revisionId);
-      const compiledRoutes =
-        routes ??
-        (
-          await client.query<{
-            provider: ConnectionProvider;
-            connection_id: string;
-            resource_id: string | null;
-            trigger_name: string;
-          }>(
-            `select provider, connection_id, resource_id, trigger_name
+      return await this.pool.transaction(async (client) => {
+        const revision = await lockValidProjectRevision(client, projectId, revisionId);
+        const compiledRoutes =
+          routes ??
+          (
+            await client.query<{
+              provider: ConnectionProvider;
+              connection_id: string;
+              resource_id: string | null;
+              trigger_name: string;
+            }>(
+              `select provider, connection_id, resource_id, trigger_name
              from project_trigger_routes where configuration_revision_id = $1`,
-            [revisionId],
-          )
-        ).rows.map((row) => ({
-          provider: row.provider,
-          connectionId: row.connection_id,
-          resourceId: row.resource_id,
-          triggerName: row.trigger_name,
-        }));
-      await client.query(`delete from project_trigger_routes where project_id = $1`, [projectId]);
-      for (const route of compiledRoutes) {
-        await client.query(
-          `insert into project_trigger_routes
+              [revisionId],
+            )
+          ).rows.map((row) => ({
+            provider: row.provider,
+            connectionId: row.connection_id,
+            resourceId: row.resource_id,
+            triggerName: row.trigger_name,
+          }));
+        await client.query(`delete from project_trigger_routes where project_id = $1`, [projectId]);
+        for (const route of compiledRoutes) {
+          await client.query(
+            `insert into project_trigger_routes
              (organization_id, project_id, configuration_revision_id, provider,
               connection_id, resource_id, trigger_name)
            values ($1, $2, $3, $4, $5, $6, $7)`,
-          [
-            revision.organization_id,
-            projectId,
-            revisionId,
-            route.provider,
-            route.connectionId,
-            route.resourceId,
-            route.triggerName,
-          ],
-        );
-      }
-      await client.query(
-        `update projects
+            [
+              revision.organization_id,
+              projectId,
+              revisionId,
+              route.provider,
+              route.connectionId,
+              route.resourceId,
+              route.triggerName,
+            ],
+          );
+        }
+        await client.query(
+          `update projects
          set active_configuration_revision_id = $2, updated_at = clock_timestamp()
          where id = $1`,
-        [projectId, revisionId],
-      );
-      await client.query(
-        `insert into audit_events
+          [projectId, revisionId],
+        );
+        await client.query(
+          `insert into audit_events
            (organization_id, project_id, actor_kind, actor_identity, action,
             subject_type, subject_id, evidence)
          select organization_id, id, 'system', 'configuration', 'configuration.activated',
                 'configuration_revision', $2::text, jsonb_build_object('version', $3::integer)
          from projects where id = $1`,
-        [projectId, revisionId, revision.version],
-      );
-      await client.query("commit");
-      return toProjectConfigurationRevisionRecord(revision);
+          [projectId, revisionId, revision.version],
+        );
+        return toProjectConfigurationRevisionRecord(revision);
+      });
     } catch (error) {
-      await client.query("rollback").catch(() => undefined);
       throw toDatabaseError(error);
-    } finally {
-      client.release();
     }
   }
 
@@ -3184,11 +3004,10 @@ class PgDatabase implements Database {
     targetRevisionId: string,
     routes: readonly ProjectTriggerRoute[],
   ) {
-    const client = await this.pool.connect();
     try {
-      await client.query("begin");
-      const candidates = await client.query<ProjectConfigurationRevisionRow>(
-        `select prior.*
+      return await this.pool.transaction(async (client) => {
+        const candidates = await client.query<ProjectConfigurationRevisionRow>(
+          `select prior.*
          from projects
          join project_configuration_revisions current
            on current.id = projects.active_configuration_revision_id
@@ -3200,40 +3019,37 @@ class PgDatabase implements Database {
          ) prior on true
          where projects.id = $1
          for update of projects`,
-        [projectId, targetRevisionId],
-      );
-      const target = candidates.rows[0];
-      if (target === undefined) throw new Error("configuration rollback target changed");
-      await client.query(`delete from project_trigger_routes where project_id = $1`, [projectId]);
-      for (const route of routes) {
-        await client.query(
-          `insert into project_trigger_routes
+          [projectId, targetRevisionId],
+        );
+        const target = candidates.rows[0];
+        if (target === undefined) throw new Error("configuration rollback target changed");
+        await client.query(`delete from project_trigger_routes where project_id = $1`, [projectId]);
+        for (const route of routes) {
+          await client.query(
+            `insert into project_trigger_routes
              (organization_id, project_id, configuration_revision_id, provider,
               connection_id, resource_id, trigger_name)
            values ($1, $2, $3, $4, $5, $6, $7)`,
-          [
-            target.organization_id,
-            projectId,
-            target.id,
-            route.provider,
-            route.connectionId,
-            route.resourceId,
-            route.triggerName,
-          ],
-        );
-      }
-      await client.query(
-        `update projects set active_configuration_revision_id = $2, updated_at = clock_timestamp()
+            [
+              target.organization_id,
+              projectId,
+              target.id,
+              route.provider,
+              route.connectionId,
+              route.resourceId,
+              route.triggerName,
+            ],
+          );
+        }
+        await client.query(
+          `update projects set active_configuration_revision_id = $2, updated_at = clock_timestamp()
          where id = $1`,
-        [projectId, target.id],
-      );
-      await client.query("commit");
-      return toProjectConfigurationRevisionRecord(target);
+          [projectId, target.id],
+        );
+        return toProjectConfigurationRevisionRecord(target);
+      });
     } catch (error) {
-      await client.query("rollback").catch(() => undefined);
       throw toDatabaseError(error);
-    } finally {
-      client.release();
     }
   }
 
@@ -3266,23 +3082,22 @@ class PgDatabase implements Database {
   async switchProjectConfigurationToManual(
     input: SwitchProjectConfigurationToManualInput,
   ): Promise<ProjectConfigurationRevisionRecord> {
-    const client = await this.pool.connect();
     try {
-      await client.query("begin");
-      const project = await client.query<ProjectRow>(
-        `select project.*
+      return await this.pool.transaction(async (client) => {
+        const project = await client.query<ProjectRow>(
+          `select project.*
          from projects project
          join member on member.organization_id = project.organization_id
          where project.id = $1 and project.status = 'active'
            and member.user_id = $2 and member.role in ('owner', 'admin')
            and project.active_configuration_revision_id is not null
          for update of project`,
-        [input.projectId, input.userId],
-      );
-      const projectRow = project.rows[0];
-      if (projectRow === undefined) throw new Error("project access denied");
-      const inserted = await client.query<ProjectConfigurationRevisionRow>(
-        `insert into project_configuration_revisions (
+          [input.projectId, input.userId],
+        );
+        const projectRow = project.rows[0];
+        if (projectRow === undefined) throw new Error("project access denied");
+        const inserted = await client.query<ProjectConfigurationRevisionRow>(
+          `insert into project_configuration_revisions (
            project_id, organization_id, version, source_kind, source_evidence, raw_yaml,
            normalized_configuration, content_hash, created_by_user_id, received_at, validated_at
          ) values (
@@ -3290,63 +3105,60 @@ class PgDatabase implements Database {
            coalesce((select max(version) + 1 from project_configuration_revisions where project_id = $1), 1),
            'manual', $3, $4, $5, $6, $7, clock_timestamp(), clock_timestamp()
          ) returning *`,
-        [
-          input.projectId,
-          projectRow.organization_id,
-          {
-            kind: "authority-switch",
-            fromRevisionId: projectRow.active_configuration_revision_id,
-            formattingPreserved: true,
-            bundle: input.bundle,
-          },
-          input.rawYaml,
-          input.normalizedConfiguration,
-          input.contentHash,
-          input.userId,
-        ],
-      );
-      const revision = inserted.rows[0]!;
-      await client.query(
-        `update project_configuration_sources
+          [
+            input.projectId,
+            projectRow.organization_id,
+            {
+              kind: "authority-switch",
+              fromRevisionId: projectRow.active_configuration_revision_id,
+              formattingPreserved: true,
+              bundle: input.bundle,
+            },
+            input.rawYaml,
+            input.normalizedConfiguration,
+            input.contentHash,
+            input.userId,
+          ],
+        );
+        const revision = inserted.rows[0]!;
+        await client.query(
+          `update project_configuration_sources
          set kind = 'manual', github_connection_id = null, github_repository_id = null,
              github_repository_full_name = null, github_default_branch = null,
              automatic_deployment_enabled = false, selected_by_user_id = $2,
              updated_at = clock_timestamp()
          where project_id = $1`,
-        [input.projectId, input.userId],
-      );
-      await client.query(`delete from project_trigger_routes where project_id = $1`, [
-        input.projectId,
-      ]);
-      for (const route of input.routes) {
-        await client.query(
-          `insert into project_trigger_routes
+          [input.projectId, input.userId],
+        );
+        await client.query(`delete from project_trigger_routes where project_id = $1`, [
+          input.projectId,
+        ]);
+        for (const route of input.routes) {
+          await client.query(
+            `insert into project_trigger_routes
              (organization_id, project_id, configuration_revision_id, provider,
               connection_id, resource_id, trigger_name)
            values ($1, $2, $3, $4, $5, $6, $7)`,
-          [
-            revision.organization_id,
-            input.projectId,
-            revision.id,
-            route.provider,
-            route.connectionId,
-            route.resourceId,
-            route.triggerName,
-          ],
-        );
-      }
-      await client.query(
-        `update projects set active_configuration_revision_id = $2,
+            [
+              revision.organization_id,
+              input.projectId,
+              revision.id,
+              route.provider,
+              route.connectionId,
+              route.resourceId,
+              route.triggerName,
+            ],
+          );
+        }
+        await client.query(
+          `update projects set active_configuration_revision_id = $2,
              updated_at = clock_timestamp() where id = $1`,
-        [input.projectId, revision.id],
-      );
-      await client.query("commit");
-      return toProjectConfigurationRevisionRecord(revision);
+          [input.projectId, revision.id],
+        );
+        return toProjectConfigurationRevisionRecord(revision);
+      });
     } catch (error) {
-      await client.query("rollback").catch(() => undefined);
       throw toDatabaseError(error);
-    } finally {
-      client.release();
     }
   }
 
@@ -3837,7 +3649,7 @@ class PgDatabase implements Database {
   }
 
   async close(): Promise<void> {
-    await this.pool.end();
+    await this.pool.close();
   }
 
   async findProviderEventReceiptById(id: string): Promise<ProviderEventReceiptRecord | undefined> {
@@ -3931,7 +3743,7 @@ class PgDatabase implements Database {
 }
 
 async function lockValidProjectRevision(
-  client: PoolClient,
+  client: QueryHandle,
   projectId: string,
   revisionId: string,
 ): Promise<ProjectConfigurationRevisionRow> {
@@ -3949,55 +3761,12 @@ async function lockValidProjectRevision(
   return revision;
 }
 
-async function runMigrations(pool: Pool): Promise<void> {
-  await migrate(drizzle(pool), { migrationsFolder: MIGRATIONS_FOLDER });
-}
-
-async function ensureDatabaseExists(url: string): Promise<void> {
-  const targetUrl = new URL(url);
-  const databaseName = basename(targetUrl.pathname);
-  const postgresUrl = new URL(url);
-
-  postgresUrl.pathname = `/${DEFAULT_POSTGRES_DATABASE}`;
-
-  const pool = createPostgresPool(postgresUrl.toString());
-
-  try {
-    const existsResult = await query(pool, "select 1 from pg_database where datname = $1", [
-      databaseName,
-    ]);
-
-    if (existsResult.rowCount === 0) {
-      await query(pool, `create database ${quoteIdentifier(databaseName)}`);
-    }
-  } catch (error) {
-    throw toDatabaseError(error);
-  } finally {
-    await pool.end();
-  }
-}
-
-export function createPostgresPool(connectionString: string): Pool {
-  const config: PoolConfig = {
-    connectionString,
-    connectionTimeoutMillis: QUERY_DEADLINE_MS,
-    query_timeout: QUERY_DEADLINE_MS,
-    statement_timeout: QUERY_DEADLINE_MS,
-  };
-
-  const pool = new Pool(config);
-  pool.on("error", (error) => {
-    logger.error({ err: error }, "PostgreSQL pool client error");
-  });
-  return pool;
-}
-
-async function query<T extends QueryResultRow = QueryResultRow>(
-  pool: Pool,
+async function query<T extends QueryRow = QueryRow>(
+  pool: QueryHandle,
   text: string,
   values: unknown[] = [],
 ) {
-  return withDatabaseDeadline(pool.query<T>(text, values));
+  return pool.query<T>(text, values);
 }
 
 function stringArray(value: unknown): string[] {
@@ -4013,35 +3782,8 @@ function isDaemonSlugConflict(error: unknown): boolean {
   );
 }
 
-async function withDatabaseDeadline<T>(promise: Promise<T>): Promise<T> {
-  let timeout: NodeJS.Timeout | undefined;
-
-  try {
-    return await Promise.race([
-      promise,
-      new Promise<never>((_, reject) => {
-        timeout = setTimeout(() => {
-          reject(new DatabaseUnavailableError("database query timed out"));
-        }, QUERY_DEADLINE_MS);
-      }),
-    ]);
-  } finally {
-    if (timeout !== undefined) {
-      clearTimeout(timeout);
-    }
-  }
-}
-
-function quoteIdentifier(value: string): string {
-  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(value)) {
-    throw new Error(`invalid database name: ${value}`);
-  }
-
-  return `"${value.replaceAll('"', '""')}"`;
-}
-
 async function insertAgentExecutionOnClient(
-  client: PoolClient,
+  client: QueryHandle,
   input: InsertAgentExecutionInput,
 ): Promise<AgentExecutionRow> {
   const rows = await client.query<AgentExecutionRow>(
@@ -4097,7 +3839,7 @@ async function insertAgentExecutionOnClient(
 
 const TERMINAL_AGENT_EXECUTION_STATUSES = ["succeeded", "failed"] satisfies AgentExecutionStatus[];
 
-export interface ProviderEventReceiptRow extends QueryResultRow {
+export interface ProviderEventReceiptRow extends QueryRow {
   id: string;
   organization_id: string;
   provider: ProviderEventReceiptRecord["provider"];
@@ -4113,7 +3855,7 @@ export interface ProviderEventReceiptRow extends QueryResultRow {
   accepted_routes: unknown;
 }
 
-interface TriggerRunRow extends QueryResultRow {
+interface TriggerRunRow extends QueryRow {
   id: string;
   organization_id: string;
   project_id: string;
@@ -4166,7 +3908,7 @@ interface ProjectActivityRunListRow extends TriggerRunRow {
   dropped_reason: string | null;
 }
 
-interface WorkflowStepRunRow extends QueryResultRow {
+interface WorkflowStepRunRow extends QueryRow {
   id: string;
   trigger_run_id: string;
   step_id: string;
@@ -4183,7 +3925,7 @@ interface WorkflowStepRunRow extends QueryResultRow {
   dispatch_intent: LaunchMachineIntent | null;
 }
 
-interface WorkflowWakeupRow extends QueryResultRow {
+interface WorkflowWakeupRow extends QueryRow {
   trigger_run_id: string;
   available_at: Date;
   lease_expires_at: Date | null;
@@ -4269,7 +4011,7 @@ function toWorkflowWakeupRecord(
   };
 }
 
-export interface MachineRow extends QueryResultRow {
+export interface MachineRow extends QueryRow {
   id: string;
   org_id: string;
   source: MachineSource;
@@ -4282,7 +4024,7 @@ export interface MachineRow extends QueryResultRow {
   specs: unknown;
 }
 
-export interface AgentExecutionRow extends QueryResultRow {
+export interface AgentExecutionRow extends QueryRow {
   id: string;
   organization_id: string;
   project_id: string;
@@ -4313,7 +4055,7 @@ export interface AgentExecutionRow extends QueryResultRow {
   hub_action_acknowledgements: unknown;
 }
 
-export interface AttachmentRow extends QueryResultRow {
+export interface AttachmentRow extends QueryRow {
   id: string;
   provider_event_receipt_id: string;
   organization_id: string;
@@ -4327,7 +4069,7 @@ export interface AttachmentRow extends QueryResultRow {
   created_at: Date;
 }
 
-interface DaemonRow extends QueryResultRow {
+interface DaemonRow extends QueryRow {
   id: string;
   enrollment_verifier: string;
   slug: string;
@@ -4346,7 +4088,7 @@ interface DaemonRow extends QueryResultRow {
   created_at: Date;
 }
 
-interface CliAuthorizationRow extends QueryResultRow {
+interface CliAuthorizationRow extends QueryRow {
   id: string;
   device_verifier: string;
   user_code_verifier: string;
@@ -4393,7 +4135,7 @@ function toCliAuthorization(row: CliAuthorizationRow): CliAuthorizationRecord {
   };
 }
 
-export interface OrganizationEntitlementsRow extends QueryResultRow {
+export interface OrganizationEntitlementsRow extends QueryRow {
   organization_id: string;
   granted: unknown;
   overrides: unknown;
@@ -4416,7 +4158,7 @@ export interface OrganizationEntitlementsRow extends QueryResultRow {
  * together.
  */
 async function stampEntitlementsWithinTransaction(
-  client: PoolClient,
+  client: QueryHandle,
   input: StampOrganizationEntitlementsInput,
 ): Promise<OrganizationEntitlementsRecord> {
   const existing = await client.query<OrganizationEntitlementsRow & { changed: boolean }>(
@@ -4489,7 +4231,7 @@ function toOrganizationEntitlementsRecord(
   };
 }
 
-interface OperatorOrganizationRow extends QueryResultRow {
+interface OperatorOrganizationRow extends QueryRow {
   id: string;
   name: string;
   slug: string;
@@ -4499,7 +4241,7 @@ function toOperatorOrganizationRecord(row: OperatorOrganizationRow): OperatorOrg
   return { id: row.id, name: row.name, slug: row.slug };
 }
 
-export interface EntitlementChangeRow extends QueryResultRow {
+export interface EntitlementChangeRow extends QueryRow {
   id: string;
   organization_id: string;
   actor: string | null;
@@ -4525,7 +4267,7 @@ function toEntitlementChangeRecord(row: EntitlementChangeRow): EntitlementChange
   };
 }
 
-export interface OrganizationUsageRow extends QueryResultRow {
+export interface OrganizationUsageRow extends QueryRow {
   organization_id: string;
   meter: string;
   period_start: Date;
@@ -4541,7 +4283,7 @@ function toOrganizationUsageRecord(row: OrganizationUsageRow): OrganizationUsage
   };
 }
 
-export interface BillingPlanRow extends QueryResultRow {
+export interface BillingPlanRow extends QueryRow {
   id: string;
   slug: string;
   name: string;
@@ -4552,7 +4294,7 @@ export interface BillingPlanRow extends QueryResultRow {
   synced_at: Date;
 }
 
-export interface BillingPlanPriceRow extends QueryResultRow {
+export interface BillingPlanPriceRow extends QueryRow {
   id: string;
   plan_id: string;
   lookup_key: string;
@@ -4587,7 +4329,7 @@ function toBillingPlanRecord(
   };
 }
 
-export interface OrganizationSubscriptionRow extends QueryResultRow {
+export interface OrganizationSubscriptionRow extends QueryRow {
   organization_id: string;
   stripe_customer_id: string;
   stripe_subscription_id: string;
@@ -4622,25 +4364,23 @@ function toOrganizationSubscriptionRecord(
  * when a non-null limit would be exceeded.
  */
 async function reserveOrganizationUsageOnClient(
-  client: Pool | PoolClient,
+  client: QueryHandle,
   input: ConsumeOrganizationUsageInput,
 ): Promise<OrganizationUsageRecord | undefined> {
-  const rows = await withDatabaseDeadline(
-    client.query<OrganizationUsageRow>(
-      `insert into organization_usage (organization_id, meter, period_start, used)
+  const rows = await client.query<OrganizationUsageRow>(
+    `insert into organization_usage (organization_id, meter, period_start, used)
        select $1, $2, $3, $4::bigint
        where $5::bigint is null or $4::bigint <= $5::bigint
        on conflict (organization_id, meter, period_start) do update
          set used = organization_usage.used + excluded.used
        where $5::bigint is null or organization_usage.used + excluded.used <= $5::bigint
        returning *`,
-      [input.organizationId, input.meter, input.periodStart, input.amount, input.limit],
-    ),
+    [input.organizationId, input.meter, input.periodStart, input.amount, input.limit],
   );
   return rows.rows[0] === undefined ? undefined : toOrganizationUsageRecord(rows.rows[0]);
 }
 
-export interface ProjectRow extends QueryResultRow {
+export interface ProjectRow extends QueryRow {
   id: string;
   organization_id: string;
   name: string;
@@ -4653,7 +4393,7 @@ export interface ProjectRow extends QueryResultRow {
   active_configuration_revision_id: string | null;
 }
 
-export interface ProjectConfigurationRevisionRow extends QueryResultRow {
+export interface ProjectConfigurationRevisionRow extends QueryRow {
   id: string;
   project_id: string;
   organization_id: string;
@@ -4670,7 +4410,7 @@ export interface ProjectConfigurationRevisionRow extends QueryResultRow {
   validated_at: Date | null;
 }
 
-interface GitHubRepositoryRow extends QueryResultRow {
+interface GitHubRepositoryRow extends QueryRow {
   id: string;
   organization_id: string;
   connection_id: string;
@@ -4715,7 +4455,7 @@ function workflowDeadlineKind(
 }
 
 async function timeoutWorkflowStepOnClient(
-  client: PoolClient,
+  client: QueryHandle,
   execution: AgentExecutionRow,
   step: WorkflowStepRunRow,
   run: TriggerRunRow,
@@ -4760,7 +4500,7 @@ async function timeoutWorkflowStepOnClient(
 }
 
 async function timeoutWorkflowRunOnClient(
-  client: PoolClient,
+  client: QueryHandle,
   run: TriggerRunRow,
   observedAt: Date,
 ): Promise<WorkflowDeadlineRecovery> {
@@ -4806,7 +4546,7 @@ async function timeoutWorkflowRunOnClient(
 }
 
 async function transitionWorkflowAgentExecution(
-  client: PoolClient,
+  client: QueryHandle,
   execution: AgentExecutionRow,
   input: WorkflowAgentCompletionInput,
 ): Promise<{ execution: AgentExecutionRow; transitioned: boolean } | undefined> {
@@ -4851,7 +4591,7 @@ async function transitionWorkflowAgentExecution(
 }
 
 async function finishWorkflowStepAndRun(
-  client: PoolClient,
+  client: QueryHandle,
   step: WorkflowStepRunRow,
   run: TriggerRunRow,
   input: WorkflowAgentCompletionInput,
@@ -4904,7 +4644,7 @@ async function finishWorkflowStepAndRun(
 }
 
 async function findTriggerRunOnClient(
-  client: PoolClient,
+  client: QueryHandle,
   triggerRunId: string,
 ): Promise<TriggerRunRecord | undefined> {
   const rows = await client.query<TriggerRunRow>(`select * from trigger_runs where id = $1`, [
@@ -4914,7 +4654,7 @@ async function findTriggerRunOnClient(
 }
 
 async function findAgentExecutionOnClient(
-  client: PoolClient,
+  client: QueryHandle,
   executionId: string,
 ): Promise<AgentExecutionRecord | undefined> {
   const rows = await client.query<AgentExecutionRow>(
@@ -4925,7 +4665,7 @@ async function findAgentExecutionOnClient(
 }
 
 async function wakeWorkflowRun(
-  client: PoolClient,
+  client: QueryHandle,
   triggerRunId: string,
   availableAt: Date,
 ): Promise<void> {
@@ -4959,7 +4699,7 @@ function toGitHubRepositoryRecord(row: GitHubRepositoryRow): GitHubRepositoryRec
   };
 }
 
-interface TenantRouteAccessRow extends QueryResultRow {
+interface TenantRouteAccessRow extends QueryRow {
   organization_id: string;
   organization_name: string;
   organization_slug: string;

--- a/src/db/runtime/embedded.smoke.integration.test.ts
+++ b/src/db/runtime/embedded.smoke.integration.test.ts
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { it } from "vitest";
+import { createApplicationRuntime } from "../../application-runtime.js";
+import { createAuthServer } from "../../auth/server.js";
+import { composeEntitlements } from "../../auth/entitlements.js";
+import { createDatabase } from "../pg.js";
+import { embeddedDatabaseRuntime } from "./index.js";
+
+it("runs the bootstrap, credential lock, and lease claim flows on embedded storage", async () => {
+  const root = await mkdtemp(join(tmpdir(), "hub-pglite-smoke-"));
+  const { runtime, locks } = await embeddedDatabaseRuntime(join(root, "database"));
+  await runtime.migrate();
+  const database = createDatabase(runtime, locks);
+  const entitlements = composeEntitlements(database, runtime);
+  const auth = createAuthServer({
+    database: runtime,
+    locks,
+    entitlements: entitlements.service,
+    secret: "embedded-smoke-secret".padEnd(32, "-"),
+    baseURL: "http://embedded.test",
+    policy: {
+      registrationMode: "invite_only",
+      organizationCreation: "disabled",
+      bootstrap: {
+        ownerEmail: "owner@embedded.test",
+        ownerPassword: "embedded-owner-password",
+        organizationName: "Embedded organization",
+      },
+    },
+  });
+  const application = await createApplicationRuntime({
+    database,
+    auth,
+    entitlements: entitlements.service,
+    billing: null,
+    registrations: [],
+    publicBaseUrl: "http://embedded.test",
+    async close() {
+      await auth.close();
+      await entitlements.close();
+      await database.close();
+    },
+  });
+
+  try {
+    await auth.initialize?.();
+    const owner = await runtime.query<{
+      organization_id: string;
+      project_id: string;
+      user_id: string;
+    }>(
+      `select member.organization_id, projects.id as project_id, member.user_id
+         from member
+         join projects on projects.organization_id = member.organization_id
+         where member.role = 'owner'`,
+    );
+    const identity = owner.rows[0];
+    assert.ok(identity);
+
+    const apiKey = await auth.apiKeys!.create(
+      identity.organization_id,
+      identity.user_id,
+      "embedded smoke",
+      ["daemons:enroll"],
+    );
+    const tokenIssued = await database.issueEnrollmentToken({
+      id: randomUUID(),
+      verifier: "embedded-smoke-enrollment",
+      organizationId: identity.organization_id,
+      issuedByApiKeyId: apiKey.summary.id,
+      expiresAt: new Date(Date.now() + 60_000),
+      consumedAt: null,
+    });
+    assert.equal(tokenIssued, true);
+
+    const revision = await database.insertProjectConfigurationRevision({
+      projectId: identity.project_id,
+      sourceKind: "manual",
+      sourceEvidence: { kind: "embedded-smoke" },
+      normalizedConfiguration: { environments: [], triggers: [] },
+      contentHash: "embedded-smoke-configuration",
+    });
+    await database.activateProjectConfigurationRevision(identity.project_id, revision.id);
+    const receipt = await database.persistManualEvent({
+      organizationId: identity.organization_id,
+      projectId: identity.project_id,
+      deliveryId: "embedded-smoke-delivery",
+      source: "embedded.smoke",
+      payload: {},
+      receivedAt: new Date(),
+    });
+    assert.equal(receipt.status, "accepted");
+    if (receipt.status !== "accepted") throw new Error("manual event was not accepted");
+    const run = await database.createAcceptedTriggerRun({
+      organizationId: identity.organization_id,
+      projectId: identity.project_id,
+      configurationRevisionId: revision.id,
+      providerEventReceiptId: receipt.event.providerEventReceiptId,
+      configuredTriggerName: "embedded-smoke",
+      rawPrompt: "embedded smoke",
+      prompt: "embedded smoke",
+      inputs: {},
+      triggerContext: {},
+      outputContext: {},
+      deadlineAt: new Date(Date.now() + 60_000),
+      stepIds: ["embedded-step"],
+    });
+    const wakeup = await database.claimWorkflowWakeup(new Date(), 30_000);
+    assert.equal(wakeup?.triggerRunId, run.run.id);
+    assert.ok(application.hub);
+  } finally {
+    await application.stop();
+    await rm(root, { recursive: true, force: true });
+  }
+}, 120_000);

--- a/src/db/runtime/index.ts
+++ b/src/db/runtime/index.ts
@@ -1,0 +1,61 @@
+import type { PgDatabase } from "drizzle-orm/pg-core";
+import type { PgQueryResultHKT } from "drizzle-orm/pg-core/session";
+import type * as schema from "../schema.js";
+import type { Locks } from "./locks/index.js";
+import { createEmbeddedRuntime } from "./internal/embedded.js";
+import { createPostgresRuntime } from "./internal/postgres.js";
+
+export type QueryRow = Record<string, unknown>;
+
+export interface QueryResult<Row extends QueryRow = QueryRow> {
+  rows: Row[];
+  rowCount: number;
+}
+
+export interface QueryHandle {
+  query<Row extends QueryRow = QueryRow>(
+    sql: string,
+    params?: readonly unknown[],
+  ): Promise<QueryResult<Row>>;
+}
+
+export interface TransactionHandle extends QueryHandle {
+  drizzle(): DrizzleHandle;
+  rollback(result: unknown): never;
+}
+interface RuntimeDrizzleResult<Row> {
+  rows: Row[];
+  rowCount: number;
+}
+
+interface RuntimeQueryResultHKT extends PgQueryResultHKT {
+  type: RuntimeDrizzleResult<this["row"]>;
+}
+
+/** The driver-neutral PostgreSQL-dialect Drizzle surface consumed by repositories. */
+export type DrizzleHandle = PgDatabase<RuntimeQueryResultHKT, typeof schema>;
+
+export interface DatabaseRuntime extends QueryHandle {
+  transaction<T>(operation: (transaction: TransactionHandle) => Promise<T>): Promise<T>;
+  drizzle(): DrizzleHandle;
+  migrate(): Promise<void>;
+  close(): Promise<void>;
+}
+
+export interface DatabaseRuntimeBundle {
+  runtime: DatabaseRuntime;
+  locks: Locks;
+}
+
+export function postgresDatabaseRuntime(connectionString: string): Promise<DatabaseRuntimeBundle> {
+  return createPostgresRuntime(connectionString);
+}
+
+export function embeddedDatabaseRuntime(dataDirectory: string): Promise<DatabaseRuntimeBundle> {
+  return createEmbeddedRuntime(dataDirectory);
+}
+
+/** @package */
+export class TransactionRollback {
+  constructor(readonly result: unknown) {}
+}

--- a/src/db/runtime/internal/embedded.ts
+++ b/src/db/runtime/internal/embedded.ts
@@ -1,0 +1,123 @@
+import { join } from "node:path";
+import { PGlite } from "@electric-sql/pglite";
+import { readMigrationFiles } from "drizzle-orm/migrator";
+import { drizzle } from "drizzle-orm/pglite";
+import * as schema from "../../schema.js";
+import { TransactionRollback } from "../index.js";
+import type {
+  DatabaseRuntime,
+  DatabaseRuntimeBundle,
+  DrizzleHandle,
+  QueryResult,
+  QueryRow,
+  TransactionHandle,
+} from "../index.js";
+import { embeddedLocks } from "../locks/index.js";
+import type { EmbeddedLockLifecycle } from "../locks/index.js";
+
+const MIGRATIONS_FOLDER = join(process.cwd(), "drizzle");
+
+export async function createEmbeddedRuntime(dataDirectory: string): Promise<DatabaseRuntimeBundle> {
+  const client = new PGlite(dataDirectory);
+  await client.waitReady;
+  const locks = embeddedLocks();
+  return { runtime: new EmbeddedRuntime(client, locks), locks };
+}
+
+class EmbeddedRuntime implements DatabaseRuntime {
+  private readonly database;
+
+  constructor(
+    private readonly client: PGlite,
+    private readonly locks: EmbeddedLockLifecycle,
+  ) {
+    this.database = drizzle(client, { schema });
+  }
+
+  async query<Row extends QueryRow = QueryRow>(
+    sql: string,
+    params: readonly unknown[] = [],
+  ): Promise<QueryResult<Row>> {
+    const result = await this.client.query<Row>(sql, [...params]);
+    return {
+      rows: [...result.rows],
+      rowCount: result.rows.length > 0 ? result.rows.length : (result.affectedRows ?? 0),
+    };
+  }
+
+  async transaction<T>(operation: (transaction: TransactionHandle) => Promise<T>): Promise<T> {
+    let handle: TransactionHandle | undefined;
+    try {
+      return await this.client.transaction(async (transaction) =>
+        operation(
+          (handle = {
+            async query<Row extends QueryRow = QueryRow>(
+              sql: string,
+              params: readonly unknown[] = [],
+            ): Promise<QueryResult<Row>> {
+              const result = await transaction.query<Row>(sql, [...params]);
+              return {
+                rows: [...result.rows],
+                rowCount: result.rows.length > 0 ? result.rows.length : (result.affectedRows ?? 0),
+              };
+            },
+            drizzle: () =>
+              // PGlite's transaction implements its query client at runtime, but its public
+              // Drizzle overload accepts only the top-level client type.
+              // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
+              drizzle(transaction as unknown as PGlite, { schema }) as unknown as DrizzleHandle,
+            rollback(result: unknown): never {
+              throw new TransactionRollback(result);
+            },
+          }),
+        ),
+      );
+    } catch (error) {
+      // The rollback value originated in this same generic transaction callback.
+      // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
+      if (error instanceof TransactionRollback) return error.result as T;
+      throw error;
+    } finally {
+      if (handle !== undefined) this.locks.releaseTransaction(handle);
+    }
+  }
+
+  drizzle() {
+    // Both drivers expose the same PostgreSQL-dialect Drizzle operations; Drizzle's driver
+    // generics are invariant, so the implementation-specific result type is hidden here.
+    // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
+    return this.database as unknown as DrizzleHandle;
+  }
+
+  async migrate(): Promise<void> {
+    const migrations = readMigrationFiles({ migrationsFolder: MIGRATIONS_FOLDER });
+    await this.client.exec(`
+      create schema if not exists drizzle;
+      create table if not exists drizzle.__drizzle_migrations (
+        id serial primary key,
+        hash text not null,
+        created_at bigint
+      );
+    `);
+    const applied = await this.client.query<{ created_at: number | string | null }>(
+      `select created_at from drizzle.__drizzle_migrations order by created_at desc limit 1`,
+    );
+    const lastCreatedAt = Number(applied.rows[0]?.created_at ?? 0);
+    await this.client.transaction(async (transaction) => {
+      for (const migration of migrations) {
+        if (lastCreatedAt >= migration.folderMillis) continue;
+        // PGlite's exec path accepts the intentional multi-command breakpoint chunks used by
+        // historical migrations; its prepared-query path rejects those chunks.
+        for (const statement of migration.sql) await transaction.exec(statement);
+        await transaction.query(
+          `insert into drizzle.__drizzle_migrations (hash, created_at) values ($1, $2)`,
+          [migration.hash, migration.folderMillis],
+        );
+      }
+    });
+  }
+
+  async close(): Promise<void> {
+    await this.client.close();
+  }
+}

--- a/src/db/runtime/internal/postgres.test.ts
+++ b/src/db/runtime/internal/postgres.test.ts
@@ -1,9 +1,9 @@
 import assert from "node:assert/strict";
 import { it } from "vitest";
-import { createPostgresPool } from "./pg.js";
+import { createPool } from "./postgres.js";
 
 it("handles errors emitted by idle PostgreSQL pool clients", async () => {
-  const pool = createPostgresPool("postgresql://unused:unused@127.0.0.1:1/unused");
+  const pool = createPool("postgresql://unused:unused@127.0.0.1:1/unused");
 
   assert.doesNotThrow(() => {
     pool.emit("error", new Error("database connection terminated"));

--- a/src/db/runtime/internal/postgres.ts
+++ b/src/db/runtime/internal/postgres.ts
@@ -1,0 +1,174 @@
+import { basename, join } from "node:path";
+import { drizzle } from "drizzle-orm/node-postgres";
+import { migrate } from "drizzle-orm/node-postgres/migrator";
+import { Pool } from "pg";
+import type { PoolClient, PoolConfig, QueryResultRow } from "pg";
+import { logger } from "../../../logger.js";
+import * as schema from "../../schema.js";
+import { DatabaseUnavailableError, toDatabaseError } from "../../errors.js";
+import { TransactionRollback } from "../index.js";
+import type {
+  DatabaseRuntime,
+  DatabaseRuntimeBundle,
+  QueryHandle,
+  DrizzleHandle,
+  QueryResult,
+  QueryRow,
+  TransactionHandle,
+} from "../index.js";
+import { postgresLocks } from "../locks/index.js";
+
+const QUERY_DEADLINE_MS = 3_000;
+const MIGRATIONS_FOLDER = join(process.cwd(), "drizzle");
+const DEFAULT_POSTGRES_DATABASE = "postgres";
+
+export async function createPostgresRuntime(
+  connectionString: string,
+): Promise<DatabaseRuntimeBundle> {
+  await ensureDatabaseExists(connectionString);
+  const pool = createPool(connectionString);
+  const runtime = new PostgresRuntime(pool);
+  return {
+    runtime,
+    locks: postgresLocks((operation) => runtime.withConnection(operation)),
+  };
+}
+
+class PostgresRuntime implements DatabaseRuntime {
+  private readonly database;
+
+  constructor(private readonly pool: Pool) {
+    this.database = drizzle(pool, { schema });
+  }
+
+  query<Row extends QueryRow = QueryRow>(sql: string, params: readonly unknown[] = []) {
+    return query<Row>(this.pool, sql, params);
+  }
+
+  async transaction<T>(operation: (transaction: TransactionHandle) => Promise<T>): Promise<T> {
+    const client = await this.pool.connect();
+    const connection = new PostgresTransactionHandle(client);
+    try {
+      await connection.query("begin");
+      try {
+        const result = await operation(connection);
+        await connection.query("commit");
+        return result;
+      } catch (error) {
+        await connection.query("rollback").catch(() => undefined);
+        // The rollback value originated in this same generic transaction callback.
+        // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
+        if (error instanceof TransactionRollback) return error.result as T;
+        throw error;
+      }
+    } finally {
+      client.release();
+    }
+  }
+
+  drizzle() {
+    // Drizzle's driver query-result generics are invariant; the shared public surface hides the
+    // node-postgres result envelope while preserving the PostgreSQL-dialect query builders.
+    // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
+    return this.database as unknown as DrizzleHandle;
+  }
+
+  async migrate(): Promise<void> {
+    await migrate(this.database, { migrationsFolder: MIGRATIONS_FOLDER });
+  }
+
+  async close(): Promise<void> {
+    await this.pool.end();
+  }
+
+  async withConnection<T>(operation: (connection: QueryHandle) => Promise<T>): Promise<T> {
+    const client = await this.pool.connect();
+    try {
+      return await operation(new PostgresQueryHandle(client));
+    } finally {
+      client.release();
+    }
+  }
+}
+
+class PostgresQueryHandle implements TransactionHandle {
+  constructor(private readonly client: PoolClient) {}
+
+  query<Row extends QueryRow = QueryRow>(sql: string, params: readonly unknown[] = []) {
+    return query<Row>(this.client, sql, params);
+  }
+
+  drizzle() {
+    // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
+    return drizzle(this.client, { schema }) as unknown as DrizzleHandle;
+  }
+
+  rollback(result: unknown): never {
+    throw new TransactionRollback(result);
+  }
+}
+
+class PostgresTransactionHandle extends PostgresQueryHandle {}
+
+async function ensureDatabaseExists(connectionString: string): Promise<void> {
+  const targetUrl = new URL(connectionString);
+  const databaseName = basename(targetUrl.pathname);
+  const postgresUrl = new URL(connectionString);
+  postgresUrl.pathname = `/${DEFAULT_POSTGRES_DATABASE}`;
+  const pool = createPool(postgresUrl.toString());
+  try {
+    const exists = await query(pool, "select 1 from pg_database where datname = $1", [
+      databaseName,
+    ]);
+    if (exists.rowCount === 0)
+      await query(pool, `create database ${quoteIdentifier(databaseName)}`, []);
+  } catch (error) {
+    throw toDatabaseError(error);
+  } finally {
+    await pool.end();
+  }
+}
+
+/** @package */
+export function createPool(connectionString: string): Pool {
+  const config: PoolConfig = {
+    connectionString,
+    connectionTimeoutMillis: QUERY_DEADLINE_MS,
+    query_timeout: QUERY_DEADLINE_MS,
+    statement_timeout: QUERY_DEADLINE_MS,
+  };
+  const pool = new Pool(config);
+  pool.on("error", (error) => logger.error({ err: error }, "PostgreSQL pool client error"));
+  return pool;
+}
+
+async function query<Row extends QueryRow>(
+  handle: Pick<Pool, "query"> | Pick<PoolClient, "query">,
+  sql: string,
+  params: readonly unknown[],
+): Promise<QueryResult<Row>> {
+  const result = await withDatabaseDeadline(handle.query<Row & QueryResultRow>(sql, [...params]));
+  return { rows: result.rows, rowCount: result.rowCount ?? 0 };
+}
+
+async function withDatabaseDeadline<T>(promise: Promise<T>): Promise<T> {
+  let timeout: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(
+          () => reject(new DatabaseUnavailableError("database query timed out")),
+          QUERY_DEADLINE_MS,
+        );
+      }),
+    ]);
+  } finally {
+    if (timeout !== undefined) clearTimeout(timeout);
+  }
+}
+
+function quoteIdentifier(value: string): string {
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(value)) throw new Error(`invalid database name: ${value}`);
+  return `"${value.replaceAll('"', '""')}"`;
+}

--- a/src/db/runtime/locks/index.ts
+++ b/src/db/runtime/locks/index.ts
@@ -1,0 +1,25 @@
+import type { QueryHandle, TransactionHandle } from "../index.js";
+import { EmbeddedLocks } from "./internal/embedded.js";
+import { PostgresLocks } from "./internal/postgres.js";
+
+export interface Locks {
+  withLock<T>(key: string, operation: () => Promise<T>): Promise<T>;
+  withTxLock(transaction: TransactionHandle, key: string): Promise<void>;
+}
+
+/** @package */
+export interface EmbeddedLockLifecycle extends Locks {
+  releaseTransaction(transaction: TransactionHandle): void;
+}
+
+/** @package */
+export function postgresLocks(
+  withConnection: <T>(operation: (connection: QueryHandle) => Promise<T>) => Promise<T>,
+): Locks {
+  return new PostgresLocks(withConnection);
+}
+
+/** @package */
+export function embeddedLocks(): EmbeddedLockLifecycle {
+  return new EmbeddedLocks();
+}

--- a/src/db/runtime/locks/internal/embedded.ts
+++ b/src/db/runtime/locks/internal/embedded.ts
@@ -1,0 +1,45 @@
+import type { TransactionHandle } from "../../index.js";
+import type { EmbeddedLockLifecycle } from "../index.js";
+
+export class EmbeddedLocks implements EmbeddedLockLifecycle {
+  private readonly tails = new Map<string, Promise<void>>();
+  private readonly transactionReleases = new WeakMap<TransactionHandle, Map<string, () => void>>();
+
+  async withLock<T>(key: string, operation: () => Promise<T>): Promise<T> {
+    const release = await this.acquire(key);
+    try {
+      return await operation();
+    } finally {
+      release();
+    }
+  }
+
+  async withTxLock(transaction: TransactionHandle, key: string): Promise<void> {
+    const held = this.transactionReleases.get(transaction) ?? new Map<string, () => void>();
+    if (held.has(key)) return;
+    held.set(key, await this.acquire(key));
+    this.transactionReleases.set(transaction, held);
+  }
+
+  releaseTransaction(transaction: TransactionHandle): void {
+    const held = this.transactionReleases.get(transaction);
+    if (held === undefined) return;
+    this.transactionReleases.delete(transaction);
+    for (const release of held.values()) release();
+  }
+
+  private async acquire(key: string): Promise<() => void> {
+    const previous = this.tails.get(key) ?? Promise.resolve();
+    let release!: () => void;
+    const current = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const tail = previous.then(() => current);
+    this.tails.set(key, tail);
+    await previous;
+    return () => {
+      release();
+      if (this.tails.get(key) === tail) this.tails.delete(key);
+    };
+  }
+}

--- a/src/db/runtime/locks/internal/postgres.ts
+++ b/src/db/runtime/locks/internal/postgres.ts
@@ -1,0 +1,27 @@
+import type { QueryHandle, TransactionHandle } from "../../index.js";
+import type { Locks } from "../index.js";
+
+export class PostgresLocks implements Locks {
+  constructor(
+    private readonly withConnection: <T>(
+      operation: (connection: QueryHandle) => Promise<T>,
+    ) => Promise<T>,
+  ) {}
+
+  withLock<T>(key: string, operation: () => Promise<T>): Promise<T> {
+    return this.withConnection(async (connection) => {
+      await connection.query(`select pg_advisory_lock(hashtextextended($1, 0))`, [key]);
+      try {
+        return await operation();
+      } finally {
+        await connection
+          .query(`select pg_advisory_unlock(hashtextextended($1, 0))`, [key])
+          .catch(() => undefined);
+      }
+    });
+  }
+
+  async withTxLock(transaction: TransactionHandle, key: string): Promise<void> {
+    await transaction.query(`select pg_advisory_xact_lock(hashtextextended($1, 0))`, [key]);
+  }
+}

--- a/src/db/runtime/locks/runtime-locks.integration.test.ts
+++ b/src/db/runtime/locks/runtime-locks.integration.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { PostgreSqlContainer } from "@testcontainers/postgresql";
+import { describe, it } from "vitest";
+import { embeddedDatabaseRuntime, postgresDatabaseRuntime } from "../index.js";
+import type { DatabaseRuntimeBundle } from "../index.js";
+
+describe("database runtime locks", () => {
+  it("serializes concurrent embedded callers holding the same key", async () => {
+    const root = await mkdtemp(join(tmpdir(), "hub-embedded-locks-"));
+    const bundle = await embeddedDatabaseRuntime(join(root, "database"));
+    try {
+      await assertSameKeySerializes(bundle);
+    } finally {
+      await bundle.runtime.close();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("serializes concurrent Postgres callers holding the same key", async () => {
+    const postgres = await new PostgreSqlContainer("postgres:17-alpine").start();
+    const bundle = await postgresDatabaseRuntime(postgres.getConnectionUri());
+    try {
+      await assertSameKeySerializes(bundle);
+    } finally {
+      await bundle.runtime.close();
+      await postgres.stop();
+    }
+  }, 120_000);
+});
+
+async function assertSameKeySerializes(bundle: DatabaseRuntimeBundle): Promise<void> {
+  const events: string[] = [];
+  let releaseFirst!: () => void;
+  let firstEntered!: () => void;
+  const entered = new Promise<void>((resolve) => {
+    firstEntered = resolve;
+  });
+  const release = new Promise<void>((resolve) => {
+    releaseFirst = resolve;
+  });
+  const first = bundle.locks.withLock("shared", async () => {
+    events.push("first:start");
+    firstEntered();
+    await release;
+    events.push("first:end");
+  });
+  await entered;
+  const second = bundle.locks.withLock("shared", async () => {
+    events.push("second:start");
+    events.push("second:end");
+  });
+  await new Promise((resolve) => setTimeout(resolve, 25));
+  assert.deepEqual(events, ["first:start"]);
+  releaseFirst();
+  await Promise.all([first, second]);
+  assert.deepEqual(events, ["first:start", "first:end", "second:start", "second:end"]);
+}

--- a/src/db/test-utils/runtime.ts
+++ b/src/db/test-utils/runtime.ts
@@ -1,0 +1,43 @@
+import { createDatabase } from "../pg.js";
+import { postgresDatabaseRuntime } from "../runtime/index.js";
+import type { DatabaseRuntimeBundle } from "../runtime/index.js";
+import type { Database } from "../types.js";
+
+const testRuntimes = new WeakMap<Database, DatabaseRuntimeBundle>();
+
+export async function createPostgresTestRuntime(connectionString: string) {
+  const bundle = await postgresDatabaseRuntime(connectionString);
+  try {
+    await bundle.runtime.migrate();
+    return { ...bundle, database: createDatabase(bundle.runtime, bundle.locks) };
+  } catch (error) {
+    await bundle.runtime.close().catch(() => undefined);
+    throw error;
+  }
+}
+
+export async function createPostgresTestDatabase(connectionString: string) {
+  const composed = await createPostgresTestRuntime(connectionString);
+  testRuntimes.set(composed.database, composed);
+  return composed.database;
+}
+
+export { createPostgresTestDatabase as createDatabase };
+
+export async function createPostgresQueryRuntime(connectionString: string) {
+  return (await postgresDatabaseRuntime(connectionString)).runtime;
+}
+
+export { createPostgresQueryRuntime as createPostgresPool };
+
+export function testDatabaseRuntime(database: Database) {
+  const bundle = testRuntimes.get(database);
+  if (bundle === undefined) throw new Error("database was not created by the test runtime");
+  return bundle.runtime;
+}
+
+export function testDatabaseLocks(database: Database) {
+  const bundle = testRuntimes.get(database);
+  if (bundle === undefined) throw new Error("database was not created by the test runtime");
+  return bundle.locks;
+}

--- a/src/db/trigger-acceptance.integration.test.ts
+++ b/src/db/trigger-acceptance.integration.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
 import { afterAll, beforeAll, describe, it } from "vitest";
 import { PostgreSqlContainer, type StartedPostgreSqlContainer } from "@testcontainers/postgresql";
-import { Client } from "pg";
-import { createDatabase } from "./pg.js";
+import { createPostgresQueryRuntime } from "./test-utils/runtime.js";
+import { createDatabase } from "./test-utils/runtime.js";
 
 describe("manual trigger tenant idempotency", () => {
   let postgres: StartedPostgreSqlContainer;
@@ -19,8 +19,8 @@ describe("manual trigger tenant idempotency", () => {
 
   it("does not resolve another organization when delivery keys collide", async () => {
     const database = await createDatabase(databaseUrl);
-    const client = new Client({ connectionString: databaseUrl });
-    await client.connect();
+    const client = await createPostgresQueryRuntime(databaseUrl);
+
     await client.query(`
       insert into organization (id, name, slug) values
         ('manual-org-a', 'Manual A', 'manual-a'),
@@ -30,7 +30,7 @@ describe("manual trigger tenant idempotency", () => {
         ('10000000-0000-4000-8000-000000000001', 'manual-org-a', 'Default', 'same-project'),
         ('20000000-0000-4000-8000-000000000001', 'manual-org-b', 'Default', 'same-project');
     `);
-    await client.end();
+    await client.close();
     for (const [projectId, contentHash] of [
       ["10000000-0000-4000-8000-000000000001", "manual-org-a-config"],
       ["20000000-0000-4000-8000-000000000001", "manual-org-b-config"],
@@ -70,15 +70,15 @@ describe("manual trigger tenant idempotency", () => {
 
   it("lists only receipts with a committed bounded drop reason", async () => {
     const database = await createDatabase(databaseUrl);
-    const client = new Client({ connectionString: databaseUrl });
-    await client.connect();
+    const client = await createPostgresQueryRuntime(databaseUrl);
+
     await client.query(`
       insert into organization (id, name, slug)
       values ('drop-reason-org', 'Drop Reason', 'drop-reason');
       insert into projects (id, organization_id, name, slug)
       values ('30000000-0000-4000-8000-000000000001', 'drop-reason-org', 'Default', 'default');
     `);
-    await client.end();
+    await client.close();
     const revision = await database.insertProjectConfigurationRevision({
       projectId: "30000000-0000-4000-8000-000000000001",
       sourceKind: "manual",

--- a/src/db/trigger-acceptance.ts
+++ b/src/db/trigger-acceptance.ts
@@ -1,5 +1,5 @@
 import { and, eq, isNull, or } from "drizzle-orm";
-import type { NodePgDatabase } from "drizzle-orm/node-postgres";
+import type { DrizzleHandle } from "./runtime/index.js";
 import * as schema from "./schema.js";
 import { ConnectionRepository } from "./connections.js";
 import type {
@@ -16,7 +16,7 @@ import type {
   ProviderEventRouteSnapshot,
 } from "./types.js";
 
-type HubDatabase = NodePgDatabase<typeof schema>;
+type HubDatabase = DrizzleHandle;
 type HubTransaction = Parameters<Parameters<HubDatabase["transaction"]>[0]>[0];
 
 const GITHUB_LIFECYCLE = "github_lifecycle";

--- a/src/e2e/harness/browser-child.ts
+++ b/src/e2e/harness/browser-child.ts
@@ -6,7 +6,8 @@ import { createAuthServer } from "../../auth/server.js";
 import { composeBilling, type BillingConfig, type BillingRuntime } from "../../billing/index.js";
 import { composeEntitlements } from "../../auth/entitlements.js";
 import { readInstanceAuthPolicy } from "../../auth/instance-policy.js";
-import { createDatabase, createPostgresPool } from "../../db/pg.js";
+import { createPostgresTestRuntime } from "../../db/test-utils/runtime.js";
+import type { DatabaseRuntime } from "../../db/runtime/index.js";
 import type { Database } from "../../db/types.js";
 import { createFetchServer } from "../../http/node-server.js";
 import { loadBuiltStartServer } from "../../server/build.js";
@@ -71,8 +72,12 @@ async function main(): Promise<void> {
   const databaseUrl = requiredEnvironment("DATABASE_URL");
   const publicBaseUrl = requiredEnvironment("PASEO_HUB_APP_URL");
   const scenario = readScenario();
-  const database = await createDatabase(databaseUrl);
-  const entitlements = composeEntitlements(database, databaseUrl);
+  const {
+    database,
+    runtime: databaseRuntime,
+    locks,
+  } = await createPostgresTestRuntime(databaseUrl);
+  const entitlements = composeEntitlements(database, databaseRuntime);
   // Compose (and sync) billing before auth: a billing-configured harness provisions new
   // organizations onto the Free plan, so the resolver must exist before createAuthServer, and the
   // catalog must be synced before auth.initialize runs any bootstrap.
@@ -84,7 +89,8 @@ async function main(): Promise<void> {
   const authSecret = requiredEnvironment("PASEO_HUB_AUTH_SECRET");
   const auth = browserAuthEnabled()
     ? createAuthServer({
-        databaseUrl,
+        database: databaseRuntime,
+        locks,
         entitlements: entitlements.service,
         baseURL: requiredEnvironment("PASEO_HUB_APP_URL"),
         secret: authSecret,
@@ -96,7 +102,7 @@ async function main(): Promise<void> {
   const machineAuth = machineAuthEnabled();
   const databaseProfile = requiredEnvironment("PASEO_E2E_DATABASE_PROFILE");
   if (auth !== null && machineAuth && databaseProfile === "fresh") {
-    await seedMachineAuthTarget(databaseUrl);
+    await seedMachineAuthTarget(databaseRuntime);
   }
   const machineKey =
     auth === null || !machineAuth
@@ -217,10 +223,8 @@ function billingAuthOptions(billing: BillingRuntime | null) {
   };
 }
 
-async function seedMachineAuthTarget(databaseUrl: string): Promise<void> {
-  const pool = createPostgresPool(databaseUrl);
-  try {
-    await pool.query(`
+async function seedMachineAuthTarget(database: DatabaseRuntime): Promise<void> {
+  await database.query(`
       insert into organization (id, name, slug)
       values ('phase-zero', 'E2E machine organization', 'phase-zero')
       on conflict (id) do nothing;
@@ -236,10 +240,7 @@ async function seedMachineAuthTarget(databaseUrl: string): Promise<void> {
       insert into member (id, organization_id, user_id, role)
       values ('phase-zero-owner', 'phase-zero', 'phase-zero-user', 'owner')
       on conflict (id) do nothing;
-    `);
-  } finally {
-    await pool.end();
-  }
+  `);
 }
 
 async function acceptCommand(

--- a/src/e2e/harness/hub-child.ts
+++ b/src/e2e/harness/hub-child.ts
@@ -2,8 +2,7 @@ import { appendFile, writeFile } from "node:fs/promises";
 import type { IncomingMessage } from "node:http";
 import type { Duplex } from "node:stream";
 import { createHubApplication } from "../../app.js";
-import { createDatabase } from "../../db/pg.js";
-import { Client } from "pg";
+import { createPostgresTestRuntime } from "../../db/test-utils/runtime.js";
 import { dump } from "js-yaml";
 import {
   OutputExecutorRegistry,
@@ -26,38 +25,35 @@ async function main(): Promise<void> {
   const databaseUrl = requiredEnvironment("DATABASE_URL");
   const port = Number(requiredEnvironment("PORT"));
   const outputFile = requiredEnvironment("HUB_E2E_OUTPUT_FILE");
-  const database = await createDatabase(databaseUrl);
+  const { database, runtime, locks } = await createPostgresTestRuntime(databaseUrl);
   const organizationId = "hub-e2e";
-  const client = new Client({ connectionString: databaseUrl });
-  await client.connect();
-  await client.query(
+  await runtime.query(
     `insert into organization (id, name, slug) values ($1, $2, $3) on conflict (id) do nothing`,
     [organizationId, "Hub E2E", organizationId],
   );
-  await client.query(
+  await runtime.query(
     `insert into organization_entitlements
        (organization_id, granted, overrides, plan_id, plan_version, stamped_at, updated_at)
      values ($1, $2::jsonb, '{}'::jsonb, null, $3, now(), now())
      on conflict (organization_id) do nothing`,
     [organizationId, JSON.stringify(UNLIMITED_TEMPLATE), hashTemplate(UNLIMITED_TEMPLATE)],
   );
-  await client.query(
+  await runtime.query(
     `insert into "user" (id, name, email, email_verified)
      values ('hub-e2e', 'Hub E2E', 'hub-e2e@paseo.test', true)
      on conflict (id) do nothing`,
   );
-  await client.query(
+  await runtime.query(
     `insert into member (id, organization_id, user_id, role)
      values ('hub-e2e-owner', $1, 'hub-e2e', 'owner')
      on conflict (id) do nothing`,
     [organizationId],
   );
-  await client.query(
+  await runtime.query(
     `insert into projects (id, organization_id, name, slug, created_by_user_id)
      values ($1, $2, $3, $4, 'hub-e2e') on conflict (id) do nothing`,
     [E2E_PROJECT_ID, organizationId, "Default", "default"],
   );
-  await client.end();
   const configuration = new ProjectConfigurationStore(database, E2E_PROJECT_ID);
   const outputs = new OutputExecutorRegistry();
   outputs.register({
@@ -68,9 +64,10 @@ async function main(): Promise<void> {
       await appendFile(outputFile, `${JSON.stringify(output)}\n`);
     },
   });
-  const entitlements = composeEntitlements(database, databaseUrl);
+  const entitlements = composeEntitlements(database, runtime);
   const auth = createAuthServer({
-    databaseUrl,
+    database: runtime,
+    locks,
     entitlements: entitlements.service,
     baseURL: requiredEnvironment("PASEO_HUB_APP_URL"),
     secret: requiredEnvironment("PASEO_HUB_AUTH_SECRET"),

--- a/src/e2e/harness/index.ts
+++ b/src/e2e/harness/index.ts
@@ -4,7 +4,8 @@ import { dirname, join } from "node:path";
 import { promisify } from "node:util";
 import { mkdtemp, mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { PostgreSqlContainer, type StartedPostgreSqlContainer } from "@testcontainers/postgresql";
-import { Pool } from "pg";
+import type { DatabaseRuntime } from "../../db/runtime/index.js";
+import { createPostgresQueryRuntime } from "../../db/test-utils/runtime.js";
 import { z } from "zod";
 import { isHubFinishExecutionToolName } from "../../hub/protocol.js";
 import { DispatchedManualRunSchema, ProblemSchema } from "../../public-api/contracts.js";
@@ -144,7 +145,7 @@ export class HubE2E {
   private hubOrigin = "";
   private proxy: HubFaultProxy | undefined;
   private postgres: StartedPostgreSqlContainer | undefined;
-  private pool: Pool | undefined;
+  private pool: DatabaseRuntime | undefined;
   private hub: ManagedChild | undefined;
   private completionRunner: ManagedChild | undefined;
   private daemonHost = "";
@@ -1173,7 +1174,7 @@ export class HubE2E {
       failures,
     );
     await this.attempt(() => this.proxy?.stop(), failures);
-    await this.attempt(() => this.pool?.end(), failures);
+    await this.attempt(() => this.pool?.close(), failures);
     await this.attempt(() => this.postgres?.stop(), failures);
     if (this.root)
       await rm(this.root, { recursive: true, force: true }).catch((error) => failures.push(error));
@@ -1243,9 +1244,7 @@ export class HubE2E {
     this.hubOrigin = `http://127.0.0.1:${hubPort}`;
     this.daemonHost = `127.0.0.1:${daemonPort}`;
     this.postgres = await new PostgreSqlContainer("postgres:17-alpine").start();
-    this.pool = new Pool({
-      connectionString: this.postgres.getConnectionUri(),
-    });
+    this.pool = await createPostgresQueryRuntime(this.postgres.getConnectionUri());
     this.proxy = await HubFaultProxy.start(this.hubOrigin, proxyPort);
     this.hub = await this.startHub();
     if (this.options.realAgent !== true) {
@@ -1550,7 +1549,7 @@ export class HubE2E {
     return this.source;
   }
 
-  private requirePool(): Pool {
+  private requirePool(): DatabaseRuntime {
     if (!this.pool) throw new Error("Postgres is unavailable");
     return this.pool;
   }

--- a/src/entitlements/service.integration.test.ts
+++ b/src/entitlements/service.integration.test.ts
@@ -2,8 +2,8 @@ import assert from "node:assert/strict";
 import { randomUUID } from "node:crypto";
 import { afterAll, beforeAll, describe, it } from "vitest";
 import { PostgreSqlContainer, type StartedPostgreSqlContainer } from "@testcontainers/postgresql";
-import { Client } from "pg";
-import { createDatabase } from "../db/pg.js";
+import { createPostgresQueryRuntime } from "../db/test-utils/runtime.js";
+import { createDatabase } from "../db/test-utils/runtime.js";
 import type { Database } from "../db/types.js";
 import { EntitlementDenied, UNLIMITED_TEMPLATE } from "./catalog.js";
 import { EntitlementsService } from "./service.js";
@@ -24,8 +24,8 @@ describe("EntitlementsService.consume against PostgreSQL", () => {
 
   async function seedOrganization(): Promise<string> {
     const organizationId = `org-${randomUUID()}`;
-    const client = new Client({ connectionString: postgres.getConnectionUri() });
-    await client.connect();
+    const client = await createPostgresQueryRuntime(postgres.getConnectionUri());
+
     try {
       await client.query(`insert into organization (id, name, slug) values ($1, $2, $3)`, [
         organizationId,
@@ -33,7 +33,7 @@ describe("EntitlementsService.consume against PostgreSQL", () => {
         organizationId,
       ]);
     } finally {
-      await client.end();
+      await client.close();
     }
     return organizationId;
   }
@@ -47,8 +47,8 @@ describe("EntitlementsService.consume against PostgreSQL", () => {
 
   async function seedPreMetersOrganization(): Promise<string> {
     const organizationId = await seedOrganization();
-    const client = new Client({ connectionString: postgres.getConnectionUri() });
-    await client.connect();
+    const client = await createPostgresQueryRuntime(postgres.getConnectionUri());
+
     try {
       await client.query(
         `insert into organization_entitlements
@@ -63,7 +63,7 @@ describe("EntitlementsService.consume against PostgreSQL", () => {
         [organizationId, PRE_METERS_SNAPSHOT, "Backfilled unlimited entitlements."],
       );
     } finally {
-      await client.end();
+      await client.close();
     }
     return organizationId;
   }

--- a/src/index.bootstrap.test.ts
+++ b/src/index.bootstrap.test.ts
@@ -1,9 +1,9 @@
 import assert from "node:assert/strict";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, it } from "vitest";
 import { PostgreSqlContainer, type StartedPostgreSqlContainer } from "@testcontainers/postgresql";
-import { Client } from "pg";
+import { createPostgresQueryRuntime } from "./db/test-utils/runtime.js";
 import { HubHarness } from "./daemons/test-utils/hub-harness.js";
-import { createDatabase } from "./db/pg.js";
+import { createDatabase, testDatabaseLocks, testDatabaseRuntime } from "./db/test-utils/runtime.js";
 import { createAuthServer } from "./auth/server.js";
 import { composeEntitlements, type ComposedEntitlements } from "./auth/entitlements.js";
 import { startProductionRuntime, stopProductionRuntime } from "./index.js";
@@ -69,12 +69,12 @@ describe("production Hub cold start", () => {
     const database = await createDatabase(databaseUrl);
     await database.close();
 
-    const client = new Client({ connectionString: databaseUrl });
-    await client.connect();
+    const client = await createPostgresQueryRuntime(databaseUrl);
+
     await client.query(
       `insert into organization (id, name, slug) values ('existing-org', 'Existing', 'existing')`,
     );
-    await client.end();
+    await client.close();
 
     process.env["DATABASE_URL"] = databaseUrl;
     process.env["PASEO_REGISTRATION_MODE"] = "disabled";
@@ -83,12 +83,12 @@ describe("production Hub cold start", () => {
     delete process.env["PASEO_BOOTSTRAP_OWNER_PASSWORD"];
 
     const runtime = await startProductionRuntime();
-    const verification = new Client({ connectionString: databaseUrl });
-    await verification.connect();
+    const verification = await createPostgresQueryRuntime(databaseUrl);
+
     const result = await verification.query<{ count: number }>(
       `select count(*)::integer as count from instance_bootstrap`,
     );
-    await verification.end();
+    await verification.close();
     assert.equal(result.rows[0]?.count, 0);
     assert.ok(runtime);
   }, 120_000);
@@ -121,8 +121,8 @@ describe("production Hub cold start", () => {
     try {
       const runtime = await startProductionRuntime();
       assert.ok(runtime);
-      const client = new Client({ connectionString: databaseUrl });
-      await client.connect();
+      const client = await createPostgresQueryRuntime(databaseUrl);
+
       const result = await client.query<{
         organizations: number;
         owners: number;
@@ -133,7 +133,7 @@ describe("production Hub cold start", () => {
           (select count(*)::integer from member where role = 'owner') as owners,
           (select count(*)::integer from instance_bootstrap where completed_at is not null) as bootstrap
       `);
-      await client.end();
+      await client.close();
       assert.deepEqual(result.rows[0], { organizations: 1, owners: 1, bootstrap: 1 });
     } finally {
       for (const [name, value] of previous) restoreEnvironment(name, value);
@@ -171,18 +171,22 @@ describe("production Hub cold start", () => {
     let keyAuthorityEntitlements: ComposedEntitlements | undefined;
     try {
       const runtime = await startProductionRuntime();
-      const client = new Client({ connectionString: databaseUrl });
-      await client.connect();
+      const client = await createPostgresQueryRuntime(databaseUrl);
+
       const owner = await client.query<{ organization_id: string; user_id: string }>(
         `select organization_id, user_id from member where role = 'owner'`,
       );
-      await client.end();
+      await client.close();
       const identity = owner.rows[0];
       assert.ok(identity);
       keyAuthorityDatabase = await createDatabase(databaseUrl);
-      keyAuthorityEntitlements = composeEntitlements(keyAuthorityDatabase, databaseUrl);
+      keyAuthorityEntitlements = composeEntitlements(
+        keyAuthorityDatabase,
+        testDatabaseRuntime(keyAuthorityDatabase),
+      );
       keyAuthority = createAuthServer({
-        databaseUrl,
+        database: testDatabaseRuntime(keyAuthorityDatabase),
+        locks: testDatabaseLocks(keyAuthorityDatabase),
         entitlements: keyAuthorityEntitlements.service,
         secret,
         baseURL: "http://localhost:3000",
@@ -228,11 +232,11 @@ describe("production Hub cold start", () => {
 async function isolatedDatabaseUrl(baseUrl: string, name: string): Promise<string> {
   const base = new URL(baseUrl);
   base.pathname = "/postgres";
-  const admin = new Client({ connectionString: base.toString() });
-  await admin.connect();
+  const admin = await createPostgresQueryRuntime(base.toString());
+
   const databaseName = `${name}_${Date.now()}`;
   await admin.query(`create database "${databaseName}"`);
-  await admin.end();
+  await admin.close();
   base.pathname = `/${databaseName}`;
   return base.toString();
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,12 @@ import type { RuntimeConfig } from "./config/index.js";
 import { DatabaseUnavailableError } from "./db/errors.js";
 import { createDatabase } from "./db/pg.js";
 import type { Database } from "./db/types.js";
+import {
+  postgresDatabaseRuntime,
+  type DatabaseRuntime,
+  type DatabaseRuntimeBundle,
+} from "./db/runtime/index.js";
+import type { Locks } from "./db/runtime/locks/index.js";
 import { logger } from "./logger.js";
 import { createFetchServer } from "./http/node-server.js";
 import { loadBuiltStartServer } from "./server/build.js";
@@ -49,8 +55,8 @@ export async function handleDaemonUpgrade(
 async function createProductionRuntime(): Promise<ApplicationRuntime> {
   const config = loadRuntimeConfig();
   const identity = readHubIdentity();
-  const database = await createDatabaseHandle(config.databaseUrl);
-  const entitlements = composeEntitlements(database, config.databaseUrl);
+  const { database, runtime, locks } = await createDatabaseHandle(config.databaseUrl);
+  const entitlements = composeEntitlements(database, runtime);
   const billingConfig = readBillingConfig();
   const billing =
     billingConfig === undefined
@@ -69,7 +75,8 @@ async function createProductionRuntime(): Promise<ApplicationRuntime> {
   });
   const auth = createProductionAuthServer(
     entitlements,
-    config.databaseUrl,
+    runtime,
+    locks,
     config.authPolicy,
     identity,
     config.trustedClientIpHeader,
@@ -108,7 +115,8 @@ async function createProductionRuntime(): Promise<ApplicationRuntime> {
 
 function createProductionAuthServer(
   entitlements: ComposedEntitlements,
-  databaseUrl: string,
+  database: DatabaseRuntime,
+  locks: Locks,
   authPolicy: RuntimeConfig["authPolicy"],
   identity: HubIdentity,
   trustedClientIpHeader: string | undefined,
@@ -119,7 +127,8 @@ function createProductionAuthServer(
     return null;
   }
   return createAuthServer({
-    databaseUrl,
+    database,
+    locks,
     entitlements: entitlements.service,
     secret: identity.authSecret,
     baseURL: identity.appUrl,
@@ -136,10 +145,16 @@ function createProductionAuthServer(
   });
 }
 
-async function createDatabaseHandle(databaseUrl: string): Promise<Database> {
+async function createDatabaseHandle(
+  databaseUrl: string,
+): Promise<DatabaseRuntimeBundle & { database: Database }> {
+  let bundle: DatabaseRuntimeBundle | undefined;
   try {
-    return await createDatabase(databaseUrl);
+    bundle = await postgresDatabaseRuntime(databaseUrl);
+    await bundle.runtime.migrate();
+    return { ...bundle, database: createDatabase(bundle.runtime, bundle.locks) };
   } catch (error) {
+    await bundle?.runtime.close().catch(() => undefined);
     if (!(error instanceof DatabaseUnavailableError)) throw error;
     logger.error(
       { err: error },

--- a/src/operator/console.integration.test.ts
+++ b/src/operator/console.integration.test.ts
@@ -2,11 +2,15 @@ import assert from "node:assert/strict";
 import { randomUUID } from "node:crypto";
 import { afterAll, afterEach, beforeAll, describe, it } from "vitest";
 import { PostgreSqlContainer, type StartedPostgreSqlContainer } from "@testcontainers/postgresql";
-import { Client } from "pg";
+import { createPostgresQueryRuntime } from "../db/test-utils/runtime.js";
 import { z } from "zod";
 import { composeEntitlements, type ComposedEntitlements } from "../auth/entitlements.js";
 import { createAuthServer, type AuthServer } from "../auth/server.js";
-import { createDatabase } from "../db/pg.js";
+import {
+  createDatabase,
+  testDatabaseLocks,
+  testDatabaseRuntime,
+} from "../db/test-utils/runtime.js";
 import type { Database } from "../db/types.js";
 import { OperatorConsole, OperatorForbiddenError } from "./console.js";
 
@@ -130,9 +134,10 @@ class OperatorHarness {
   static async start(postgres: StartedPostgreSqlContainer): Promise<OperatorHarness> {
     const url = isolatedDatabaseUrl(postgres);
     const database = await createDatabase(url);
-    const entitlements = composeEntitlements(database, url);
+    const entitlements = composeEntitlements(database, testDatabaseRuntime(database));
     const auth = createAuthServer({
-      databaseUrl: url,
+      database: testDatabaseRuntime(database),
+      locks: testDatabaseLocks(database),
       entitlements: entitlements.service,
       secret: "operator-auth-secret-at-least-32-characters",
       baseURL: "http://localhost:3000",
@@ -174,12 +179,12 @@ class OperatorHarness {
     text: string,
     values: unknown[] = [],
   ): Promise<TRow[]> {
-    const client = new Client({ connectionString: this.url });
-    await client.connect();
+    const client = await createPostgresQueryRuntime(this.url);
+
     try {
       return (await client.query<TRow>(text, values)).rows;
     } finally {
-      await client.end();
+      await client.close();
     }
   }
 }

--- a/src/organizations/provisioning.ts
+++ b/src/organizations/provisioning.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import type { PoolClient } from "pg";
+import type { QueryHandle } from "../db/runtime/index.js";
 import {
   hashTemplate,
   UNLIMITED_TEMPLATE,
@@ -35,7 +35,7 @@ export const UNLIMITED_PROVISIONING: ProvisioningEntitlement = {
 };
 
 export async function provisionOrganization(
-  client: PoolClient,
+  client: QueryHandle,
   input: { organizationId: string; name: string; ownerUserId: string },
   entitlement: ProvisioningEntitlement,
 ): Promise<ProvisionedOrganization> {
@@ -73,7 +73,7 @@ export async function provisionOrganization(
  * organization itself.
  */
 async function stampProvisioningEntitlements(
-  client: PoolClient,
+  client: QueryHandle,
   organizationId: string,
   ownerUserId: string,
   entitlement: ProvisioningEntitlement,

--- a/src/public-api/built-server.integration.test.ts
+++ b/src/public-api/built-server.integration.test.ts
@@ -2,12 +2,16 @@ import assert from "node:assert/strict";
 import { randomUUID } from "node:crypto";
 import { afterAll, beforeAll, describe, it } from "vitest";
 import { PostgreSqlContainer, type StartedPostgreSqlContainer } from "@testcontainers/postgresql";
-import { Client } from "pg";
+import { createPostgresQueryRuntime } from "../db/test-utils/runtime.js";
 import { createApplicationRuntime } from "../application-runtime.js";
 import { createAuthServer, type AuthServer } from "../auth/server.js";
 import { composeEntitlements } from "../auth/entitlements.js";
 import { CliAuthorizations } from "../cli-authorizations/index.js";
-import { createDatabase } from "../db/pg.js";
+import {
+  createDatabase,
+  testDatabaseLocks,
+  testDatabaseRuntime,
+} from "../db/test-utils/runtime.js";
 import { TEST_DAEMON_SLUG } from "../test-utils/project-configuration.js";
 import { configurationBundleFixture } from "../test-utils/configuration-bundle.js";
 import {
@@ -34,8 +38,8 @@ builtServerTests("built TanStack public API PostgreSQL contract", () => {
     postgres = await new PostgreSqlContainer("postgres:17-alpine").start();
     databaseUrl = postgres.getConnectionUri();
     const database = await createDatabase(databaseUrl);
-    const client = new Client({ connectionString: databaseUrl });
-    await client.connect();
+    const client = await createPostgresQueryRuntime(databaseUrl);
+
     await client.query(`
       insert into organization (id, name, slug) values
         ('organization-a', 'Organization A', 'organization-a'),
@@ -49,7 +53,7 @@ builtServerTests("built TanStack public API PostgreSQL contract", () => {
       insert into session (id, token, user_id, active_organization_id, expires_at) values
         ('session-a', 'session-token-a', 'user-a', 'organization-a', now() + interval '1 day');
     `);
-    await client.end();
+    await client.close();
     for (const [organizationId, userId] of [
       ["organization-a", "user-a"],
       ["organization-b", "user-b"],
@@ -89,9 +93,10 @@ builtServerTests("built TanStack public API PostgreSQL contract", () => {
         now: new Date("2026-08-07T00:00:00.000Z"),
       });
     }
-    const entitlements = composeEntitlements(database, databaseUrl);
+    const entitlements = composeEntitlements(database, testDatabaseRuntime(database));
     auth = createAuthServer({
-      databaseUrl,
+      database: testDatabaseRuntime(database),
+      locks: testDatabaseLocks(database),
       entitlements: entitlements.service,
       secret: "built-public-api-test-secret".padEnd(32, "-"),
       baseURL: "http://hub.test",
@@ -140,10 +145,10 @@ builtServerTests("built TanStack public API PostgreSQL contract", () => {
       ).status,
       200,
     );
-    const pollClient = new Client({ connectionString: databaseUrl });
-    await pollClient.connect();
+    const pollClient = await createPostgresQueryRuntime(databaseUrl);
+
     await pollClient.query("update cli_authorizations set next_poll_at = now()");
-    await pollClient.end();
+    await pollClient.close();
     const cliPoll = CliAuthorizationPollSchema.parse(
       await (
         await cliAuthorizations.poll(
@@ -223,8 +228,8 @@ builtServerTests("built TanStack public API PostgreSQL contract", () => {
       assert.equal(typeof EnrollmentTokenSchema.parse(await enrollment.json()).token, "string");
     }
 
-    const client = new Client({ connectionString: databaseUrl });
-    await client.connect();
+    const client = await createPostgresQueryRuntime(databaseUrl);
+
     const revisions = await client.query<{ organization_id: string; project_slug: string }>(`
       select revision.organization_id, project.slug as project_slug
       from project_configuration_revisions revision
@@ -248,7 +253,7 @@ builtServerTests("built TanStack public API PostgreSQL contract", () => {
       select organization_id, count(*)::text as count
       from daemon_enrollment_tokens group by organization_id order by organization_id
     `);
-    await client.end();
+    await client.close();
     assert.deepEqual(revisions.rows, [
       { organization_id: "organization-a", project_slug: "same-project" },
       { organization_id: "organization-b", project_slug: "same-project" },
@@ -272,10 +277,10 @@ builtServerTests("built TanStack public API PostgreSQL contract", () => {
   }, 120_000);
 
   it("contains unexpected PostgreSQL details behind the canonical internal-error boundary", async () => {
-    const client = new Client({ connectionString: databaseUrl });
-    await client.connect();
+    const client = await createPostgresQueryRuntime(databaseUrl);
+
     await client.query("alter table projects rename to projects_unavailable_for_boundary_test");
-    await client.end();
+    await client.close();
 
     const response = await post("/api/v1/configurations/install", secrets["organization-a"], {
       projectSlug: "same-project",
@@ -283,10 +288,10 @@ builtServerTests("built TanStack public API PostgreSQL contract", () => {
         "environments:\n  - name: runner\n    kind: docker\n    image: paseo/valid\ntriggers: []",
       ),
     });
-    const restore = new Client({ connectionString: databaseUrl });
-    await restore.connect();
+    const restore = await createPostgresQueryRuntime(databaseUrl);
+
     await restore.query("alter table projects_unavailable_for_boundary_test rename to projects");
-    await restore.end();
+    await restore.close();
     assert.equal(response.status, 500);
     const serialized = JSON.stringify(await response.json());
     assert.equal(ProblemSchema.parse(JSON.parse(serialized)).code, "internal_error");
@@ -366,8 +371,8 @@ builtServerTests("built TanStack public API PostgreSQL contract", () => {
     const secondInstalled = InstalledConfigurationSchema.parse(await second.json());
     assert.notEqual(firstInstalled.versionId, secondInstalled.versionId);
 
-    const client = new Client({ connectionString: databaseUrl });
-    await client.connect();
+    const client = await createPostgresQueryRuntime(databaseUrl);
+
     const revisions = await client.query<{
       raw_yaml: string;
       partial_content: string;
@@ -382,7 +387,7 @@ builtServerTests("built TanStack public API PostgreSQL contract", () => {
        where project.organization_id = 'organization-a' and project.slug = 'bundle-project'
        order by revision.version`,
     );
-    await client.end();
+    await client.close();
     assert.deepEqual(
       revisions.rows.map((row) => row.partial_content),
       ["First instructions", "Second instructions"],


### PR DESCRIPTION
## Blurb

Introduce one deep database-runtime boundary for PostgreSQL and embedded PGlite, consolidate production database ownership into one shared runtime, and move advisory locking behind a driver-neutral lock capability.

## Goals

- Expose only query, transaction, Drizzle handle, migrate, and close from the database runtime.
- Keep pg pools, clients, deadlines, database creation, and driver details inside the PostgreSQL implementation.
- Own exactly one PGlite instance in the embedded implementation and run every existing migration without changing historical migration files or hashes.
- Preserve PostgreSQL registration admission locking across Better Auth work.
- Replace direct advisory-lock SQL with session and transaction lock capabilities backed by PostgreSQL advisory locks or embedded keyed mutexes.
- Prove embedded storage through real application composition: bootstrap, credential issuance, and a SKIP LOCKED lease claim.

## Non-goals

- No embedded-default selection or configuration waterfall.
- No packaging, CLI entry, or onboarding behavior.
- No raw SQL rewrite or schema change.

## Why

Database ownership was spread across core persistence, Better Auth, and entitlements, while pg connection types and advisory-lock calls escaped into callers. That made an embedded runtime impossible without teaching the application about driver behavior. This change puts connection and serialization mechanics behind two small capabilities so callers receive the same shape in both modes.

The embedded migrator deliberately leaves applied migration files byte-for-byte stable. It uses the existing Drizzle journal and hashes, but executes breakpoint chunks through the PGlite multi-command path to handle the historical multi-statement chunk in migration 0012.

## Verification

- npm run typecheck
- npm run lint
- npm run format:check
- npm run build
- npm run db:check
- npm run test:release
- Focused touched-file batch: 15 files passed, 1 skipped; 102 tests passed, 3 skipped
- Migration integration suite: 19 passed
- Boundary searches: no pg types, node-postgres Drizzle types, direct advisory-lock SQL, or pool construction outside the runtime

## Test edits

Existing PostgreSQL tests changed only for runtime injection and lifecycle wiring. Concurrency fixtures now open transactions through the runtime callback so their row locks stay on one physical connection; assertions and product expectations are unchanged.

## Risk surface

The meaningful risk is transaction and lock ownership across the mechanically rewired raw SQL paths. Existing PostgreSQL integration coverage exercises those paths, the lock suite runs both implementations, and the embedded smoke runs all migrations and representative real wiring. Production selection remains PostgreSQL-only in this PR.