### PR TITLE
Make embedded storage the local Hub default

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 base/
 dist/
 node_modules/
+.dev/
 .env
 *.pem
 PLAN.md

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,6 @@
-DATABASE_URL=postgres://postgres:postgres@localhost:5432/paseo_hub
+# Hub uses an embedded database under .dev/paseo-hub by default. Set DATABASE_URL to use PostgreSQL.
+# DATABASE_URL=postgres://postgres:postgres@localhost:5432/paseo_hub
+# PASEO_HUB_DATA_DIR=.dev/paseo-hub
 PASEO_HUB_APP_URL=http://localhost:3000
 # Generate once per deployment and persist it across Hub restarts.
 PASEO_HUB_AUTH_SECRET=

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .env
+.dev/
 *.pem
 dist/
 .output/

--- a/README.md
+++ b/README.md
@@ -28,6 +28,23 @@ Paseo Hub is the self-hosted automation layer for [Paseo](https://paseo.sh). Con
  Discord ┘                 └─ build server
 ```
 
+## Develop locally
+
+You need Node.js and npm. A fresh checkout runs with an embedded database and no external services:
+
+```sh
+npm install
+npm run dev
+```
+
+Open <http://localhost:3000>. Hub stores the embedded database in `.dev/paseo-hub` and keeps it across restarts. Set `PASEO_HUB_DATA_DIR` to use a different directory, or set `DATABASE_URL` to use PostgreSQL instead:
+
+```sh
+DATABASE_URL=postgres://postgres:postgres@localhost:5432/paseo_hub npm run dev
+```
+
+Embedded mode supports one Hub process per data directory. Docker Compose continues to run Hub with PostgreSQL.
+
 ## Run with Docker Compose
 
 You need Docker, Docker Compose, and a public HTTPS URL when connecting external providers.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "type": "module",
   "scripts": {
-    "dev": "vite dev",
+    "dev": "vite dev --port 3000",
     "build": "npm run build:node && npm run build:start",
     "build:node": "tsgo -p tsconfig.json",
     "build:start": "vite build",

--- a/scripts/paseo-workspace.mjs
+++ b/scripts/paseo-workspace.mjs
@@ -1,53 +1,27 @@
 import { spawn } from "node:child_process";
-import { createHash } from "node:crypto";
 import { copyFile, stat } from "node:fs/promises";
-import { basename, join, resolve } from "node:path";
+import { join, resolve } from "node:path";
 import process from "node:process";
-import { Client } from "pg";
-
-const POSTGRES_ADMIN_URL = "postgres://postgres:postgres@127.0.0.1:5432/postgres";
-const DATABASE_PREFIX = "paseo_hub_";
 
 const action = process.argv[2];
 const workspacePath = resolve(process.env.PASEO_WORKTREE_PATH ?? process.cwd());
-const databaseName = workspaceDatabaseName(workspacePath);
-const databaseUrl = workspaceDatabaseUrl(databaseName);
 
 switch (action) {
   case "setup":
     await copyWorkspaceEnvironment();
-    await runNpm(["run", "db:migrate"], { DATABASE_URL: databaseUrl });
     break;
   case "dev":
     await runNpm(
       ["run", "dev", "--", "--host", process.env.HOST ?? "127.0.0.1", "--port", requiredPort()],
       {
-        DATABASE_URL: databaseUrl,
         PASEO_HUB_APP_URL: process.env.PASEO_URL ?? `http://127.0.0.1:${requiredPort()}`,
       },
     );
     break;
   case "teardown":
-    await dropWorkspaceDatabase(databaseName);
     break;
   default:
     throw new Error("Expected one of: setup, dev, teardown");
-}
-
-function workspaceDatabaseName(path) {
-  const label = basename(path)
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "_")
-    .replace(/^_+|_+$/g, "")
-    .slice(0, 32);
-  const digest = createHash("sha256").update(path).digest("hex").slice(0, 12);
-  return `${DATABASE_PREFIX}${label || "workspace"}_${digest}`;
-}
-
-function workspaceDatabaseUrl(name) {
-  const url = new URL(POSTGRES_ADMIN_URL);
-  url.pathname = `/${name}`;
-  return url.toString();
 }
 
 async function copyWorkspaceEnvironment() {
@@ -62,24 +36,6 @@ async function copyWorkspaceEnvironment() {
     throw error;
   }
   await copyFile(source, join(workspacePath, ".env"));
-}
-
-async function dropWorkspaceDatabase(name) {
-  if (!name.startsWith(DATABASE_PREFIX)) {
-    throw new Error(`Refusing to drop unexpected database: ${name}`);
-  }
-
-  const client = new Client({ connectionString: POSTGRES_ADMIN_URL });
-  await client.connect();
-  try {
-    await client.query(`drop database if exists ${quoteIdentifier(name)} with (force)`);
-  } finally {
-    await client.end();
-  }
-}
-
-function quoteIdentifier(identifier) {
-  return `"${identifier.replaceAll('"', '""')}"`;
 }
 
 function requiredPort() {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -44,7 +44,6 @@ export type {
 
 export interface RuntimeConfig {
   bind: string;
-  databaseUrl: string;
   trustedClientIpHeader?: string;
   authPolicy: InstanceAuthPolicy;
 }

--- a/src/daemons/test-utils/hub-harness.ts
+++ b/src/daemons/test-utils/hub-harness.ts
@@ -2548,7 +2548,7 @@ function machineHeaders(auth: "valid" | "missing" | "wrong"): Record<string, str
 }
 
 async function waitFor(observation: () => Promise<boolean>): Promise<void> {
-  for (let attempt = 0; attempt < 50; attempt += 1) {
+  for (let attempt = 0; attempt < 300; attempt += 1) {
     if (await observation()) return;
     await new Promise((resolve) => setTimeout(resolve, 10));
   }

--- a/src/db/runtime/embedded-persistence.integration.test.ts
+++ b/src/db/runtime/embedded-persistence.integration.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, beforeEach, it } from "vitest";
+import { embeddedDatabaseRuntime, type DatabaseRuntimeBundle } from "./index.js";
+
+let root: string;
+let activeRuntime: DatabaseRuntimeBundle | undefined;
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), "hub-pglite-persistence-"));
+});
+
+afterEach(async () => {
+  await activeRuntime?.runtime.close();
+  activeRuntime = undefined;
+  await rm(root, { recursive: true, force: true });
+});
+
+it("persists embedded data across runtime restarts", async () => {
+  const dataDirectory = join(root, "database");
+  activeRuntime = await embeddedDatabaseRuntime(dataDirectory);
+  await activeRuntime.runtime.query(`create table persistence_probe (value text not null)`);
+  await activeRuntime.runtime.query(`insert into persistence_probe (value) values ('kept')`);
+  await activeRuntime.runtime.close();
+
+  activeRuntime = await embeddedDatabaseRuntime(dataDirectory);
+  const result = await activeRuntime.runtime.query<{ value: string }>(
+    `select value from persistence_probe`,
+  );
+
+  assert.deepEqual(result.rows, [{ value: "kept" }]);
+});
+
+it("rejects a second process using the same embedded data directory", async () => {
+  const dataDirectory = join(root, "database");
+  activeRuntime = await embeddedDatabaseRuntime(dataDirectory);
+
+  const result = await openEmbeddedRuntimeInChild(dataDirectory);
+
+  assert.equal(result.exitCode, 23);
+  assert.match(result.stderr, /already in use by another Paseo Hub process/);
+  assert.match(result.stderr, /Embedded mode supports one process per data directory/);
+});
+
+async function openEmbeddedRuntimeInChild(
+  dataDirectory: string,
+): Promise<{ exitCode: number | null; stderr: string }> {
+  const runtimeModule = pathToFileURL(join(process.cwd(), "src", "db", "runtime", "index.ts"));
+  const source = `
+    const { embeddedDatabaseRuntime } = await import(${JSON.stringify(runtimeModule.href)});
+    try {
+      const bundle = await embeddedDatabaseRuntime(process.env.PASEO_TEST_DATA_DIR);
+      await bundle.runtime.close();
+    } catch (error) {
+      console.error(error instanceof Error ? error.message : error);
+      process.exit(23);
+    }
+  `;
+  const child = spawn(
+    process.execPath,
+    ["--import", "tsx", "--input-type=module", "--eval", source],
+    {
+      cwd: process.cwd(),
+      env: { ...process.env, PASEO_TEST_DATA_DIR: dataDirectory },
+      stdio: ["ignore", "ignore", "pipe"],
+    },
+  );
+  let stderr = "";
+  child.stderr.setEncoding("utf8");
+  child.stderr.on("data", (chunk: string) => {
+    stderr += chunk;
+  });
+  const exitCode = await new Promise<number | null>((resolve, reject) => {
+    child.once("error", reject);
+    child.once("exit", resolve);
+  });
+  return { exitCode, stderr };
+}

--- a/src/db/runtime/internal/data-directory-lock.ts
+++ b/src/db/runtime/internal/data-directory-lock.ts
@@ -1,0 +1,111 @@
+import { randomUUID } from "node:crypto";
+import { open, readFile, unlink } from "node:fs/promises";
+import { join } from "node:path";
+
+const LOCK_FILE_NAME = ".paseo-hub.lock";
+const OWNER_READ_ATTEMPTS = 10;
+const OWNER_READ_DELAY_MS = 10;
+
+interface LockOwner {
+  pid: number;
+  token: string;
+}
+
+export interface DataDirectoryLock {
+  release(): Promise<void>;
+}
+
+export async function acquireDataDirectoryLock(dataDirectory: string): Promise<DataDirectoryLock> {
+  const path = join(dataDirectory, LOCK_FILE_NAME);
+  const owner = { pid: process.pid, token: randomUUID() };
+
+  for (;;) {
+    try {
+      const handle = await open(path, "wx", 0o600);
+      try {
+        await handle.writeFile(JSON.stringify(owner));
+      } finally {
+        await handle.close();
+      }
+      return new OwnedDataDirectoryLock(path, owner);
+    } catch (error) {
+      if (!hasCode(error, "EEXIST")) throw error;
+    }
+
+    const existingOwner = await readLockOwner(path);
+    if (existingOwner !== undefined && processIsRunning(existingOwner.pid)) {
+      throw new Error(
+        `Embedded database directory is already in use by another Paseo Hub process (PID ${existingOwner.pid}): ${dataDirectory}. Embedded mode supports one process per data directory.`,
+      );
+    }
+
+    try {
+      await unlink(path);
+    } catch (error) {
+      if (!hasCode(error, "ENOENT")) throw error;
+    }
+  }
+}
+
+class OwnedDataDirectoryLock implements DataDirectoryLock {
+  constructor(
+    private readonly path: string,
+    private readonly owner: LockOwner,
+  ) {}
+
+  async release(): Promise<void> {
+    const currentOwner = await readLockOwner(this.path);
+    if (currentOwner?.token !== this.owner.token) return;
+    try {
+      await unlink(this.path);
+    } catch (error) {
+      if (!hasCode(error, "ENOENT")) throw error;
+    }
+  }
+}
+
+async function readLockOwner(path: string): Promise<LockOwner | undefined> {
+  for (let attempt = 0; attempt < OWNER_READ_ATTEMPTS; attempt += 1) {
+    try {
+      const owner = parseLockOwner(await readFile(path, "utf8"));
+      if (owner !== undefined) return owner;
+    } catch (error) {
+      if (hasCode(error, "ENOENT")) return undefined;
+      throw error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, OWNER_READ_DELAY_MS));
+  }
+  return undefined;
+}
+
+function parseLockOwner(value: string): LockOwner | undefined {
+  try {
+    const parsed: unknown = JSON.parse(value);
+    const pid: unknown = Reflect.get(parsed ?? {}, "pid");
+    const token: unknown = Reflect.get(parsed ?? {}, "token");
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      typeof pid === "number" &&
+      typeof token === "string"
+    ) {
+      return { pid, token };
+    }
+  } catch {
+    // A process may have died before finishing its lock record. The caller recovers it as stale.
+  }
+  return undefined;
+}
+
+function processIsRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return !hasCode(error, "ESRCH");
+  }
+}
+
+function hasCode(error: unknown, code: string): boolean {
+  return typeof error === "object" && error !== null && Reflect.get(error, "code") === code;
+}

--- a/src/db/runtime/internal/embedded.ts
+++ b/src/db/runtime/internal/embedded.ts
@@ -1,4 +1,5 @@
-import { join } from "node:path";
+import { mkdir } from "node:fs/promises";
+import { join, resolve } from "node:path";
 import { PGlite } from "@electric-sql/pglite";
 import { readMigrationFiles } from "drizzle-orm/migrator";
 import { drizzle } from "drizzle-orm/pglite";
@@ -14,14 +15,23 @@ import type {
 } from "../index.js";
 import { embeddedLocks } from "../locks/index.js";
 import type { EmbeddedLockLifecycle } from "../locks/index.js";
+import { acquireDataDirectoryLock, type DataDirectoryLock } from "./data-directory-lock.js";
 
 const MIGRATIONS_FOLDER = join(process.cwd(), "drizzle");
 
 export async function createEmbeddedRuntime(dataDirectory: string): Promise<DatabaseRuntimeBundle> {
-  const client = new PGlite(dataDirectory);
-  await client.waitReady;
-  const locks = embeddedLocks();
-  return { runtime: new EmbeddedRuntime(client, locks), locks };
+  const resolvedDataDirectory = resolve(dataDirectory);
+  await mkdir(resolvedDataDirectory, { recursive: true });
+  const dataDirectoryLock = await acquireDataDirectoryLock(resolvedDataDirectory);
+  try {
+    const client = new PGlite(resolvedDataDirectory);
+    await client.waitReady;
+    const locks = embeddedLocks();
+    return { runtime: new EmbeddedRuntime(client, locks, dataDirectoryLock), locks };
+  } catch (error) {
+    await dataDirectoryLock.release().catch(() => undefined);
+    throw error;
+  }
 }
 
 class EmbeddedRuntime implements DatabaseRuntime {
@@ -30,6 +40,7 @@ class EmbeddedRuntime implements DatabaseRuntime {
   constructor(
     private readonly client: PGlite,
     private readonly locks: EmbeddedLockLifecycle,
+    private readonly dataDirectoryLock: DataDirectoryLock,
   ) {
     this.database = drizzle(client, { schema });
   }
@@ -118,6 +129,10 @@ class EmbeddedRuntime implements DatabaseRuntime {
   }
 
   async close(): Promise<void> {
-    await this.client.close();
+    try {
+      await this.client.close();
+    } finally {
+      await this.dataDirectoryLock.release();
+    }
   }
 }

--- a/src/index.embedded.integration.test.ts
+++ b/src/index.embedded.integration.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, it } from "vitest";
+import { embeddedDatabaseRuntime } from "./db/runtime/index.js";
+import { startProductionRuntime, stopProductionRuntime } from "./index.js";
+
+const ENVIRONMENT_NAMES = [
+  "DATABASE_URL",
+  "PASEO_HUB_DATA_DIR",
+  "PASEO_HUB_AUTH_SECRET",
+  "PASEO_HUB_APP_URL",
+  "PASEO_REGISTRATION_MODE",
+  "PASEO_ORGANIZATION_CREATION",
+  "PASEO_BOOTSTRAP_ORGANIZATION",
+  "PASEO_BOOTSTRAP_OWNER_EMAIL",
+  "PASEO_BOOTSTRAP_OWNER_PASSWORD",
+] as const;
+
+let root: string;
+let previousEnvironment: Map<string, string | undefined>;
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), "hub-production-embedded-"));
+  previousEnvironment = new Map(ENVIRONMENT_NAMES.map((name) => [name, process.env[name]]));
+  delete process.env["DATABASE_URL"];
+  process.env["PASEO_HUB_DATA_DIR"] = join(root, "database");
+  process.env["PASEO_HUB_AUTH_SECRET"] = "embedded-production-secret-at-least-32-characters";
+  process.env["PASEO_HUB_APP_URL"] = "http://localhost:3000";
+  process.env["PASEO_REGISTRATION_MODE"] = "invite_only";
+  process.env["PASEO_ORGANIZATION_CREATION"] = "disabled";
+  process.env["PASEO_BOOTSTRAP_ORGANIZATION"] = "Embedded owner";
+  process.env["PASEO_BOOTSTRAP_OWNER_EMAIL"] = "owner@embedded.test";
+  process.env["PASEO_BOOTSTRAP_OWNER_PASSWORD"] = "embedded-owner-password";
+});
+
+afterEach(async () => {
+  await stopProductionRuntime();
+  for (const [name, value] of previousEnvironment) restoreEnvironment(name, value);
+  await rm(root, { recursive: true, force: true });
+});
+
+it("selects embedded storage without DATABASE_URL and preserves it across restarts", async () => {
+  await startProductionRuntime();
+  await stopProductionRuntime();
+  await startProductionRuntime();
+  await stopProductionRuntime();
+
+  const bundle = await embeddedDatabaseRuntime(process.env["PASEO_HUB_DATA_DIR"]!);
+  const result = await bundle.runtime.query<{ organizations: number; bootstraps: number }>(`
+    select
+      (select count(*)::integer from organization) as organizations,
+      (select count(*)::integer from instance_bootstrap) as bootstraps
+  `);
+  await bundle.runtime.close();
+
+  assert.deepEqual(result.rows[0], { organizations: 1, bootstraps: 1 });
+});
+
+function restoreEnvironment(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import "dotenv/config";
 import { validateHeaderName, type IncomingMessage } from "node:http";
+import { join, resolve as resolvePath } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { Duplex } from "node:stream";
 import type { RuntimeConfig } from "./config/index.js";
@@ -7,6 +8,7 @@ import { DatabaseUnavailableError } from "./db/errors.js";
 import { createDatabase } from "./db/pg.js";
 import type { Database } from "./db/types.js";
 import {
+  embeddedDatabaseRuntime,
   postgresDatabaseRuntime,
   type DatabaseRuntime,
   type DatabaseRuntimeBundle,
@@ -55,7 +57,7 @@ export async function handleDaemonUpgrade(
 async function createProductionRuntime(): Promise<ApplicationRuntime> {
   const config = loadRuntimeConfig();
   const identity = readHubIdentity();
-  const { database, runtime, locks } = await createDatabaseHandle(config.databaseUrl);
+  const { database, runtime, locks } = await createDatabaseHandle();
   const entitlements = composeEntitlements(database, runtime);
   const billingConfig = readBillingConfig();
   const billing =
@@ -145,13 +147,33 @@ function createProductionAuthServer(
   });
 }
 
-async function createDatabaseHandle(
-  databaseUrl: string,
+async function createDatabaseHandle(): Promise<DatabaseRuntimeBundle & { database: Database }> {
+  const databaseUrl = process.env["DATABASE_URL"];
+  if (databaseUrl !== undefined && databaseUrl.length > 0) {
+    return initializeDatabaseRuntime(
+      () => postgresDatabaseRuntime(databaseUrl),
+      "database runtime ready: postgres",
+    );
+  }
+
+  const dataDirectory = resolvePath(
+    process.env["PASEO_HUB_DATA_DIR"] ?? join(process.cwd(), ".dev", "paseo-hub"),
+  );
+  return initializeDatabaseRuntime(
+    () => embeddedDatabaseRuntime(dataDirectory),
+    `database runtime ready: embedded (${dataDirectory})`,
+  );
+}
+
+async function initializeDatabaseRuntime(
+  createRuntime: () => Promise<DatabaseRuntimeBundle>,
+  readyMessage: string,
 ): Promise<DatabaseRuntimeBundle & { database: Database }> {
   let bundle: DatabaseRuntimeBundle | undefined;
   try {
-    bundle = await postgresDatabaseRuntime(databaseUrl);
+    bundle = await createRuntime();
     await bundle.runtime.migrate();
+    logger.info(readyMessage);
     return { ...bundle, database: createDatabase(bundle.runtime, bundle.locks) };
   } catch (error) {
     await bundle?.runtime.close().catch(() => undefined);
@@ -169,8 +191,6 @@ function loadRuntimeConfig(): RuntimeConfig {
   if (trustedClientIpHeader !== undefined) validateHeaderName(trustedClientIpHeader);
   return {
     bind: process.env["PASEO_HUB_BIND"] ?? "0.0.0.0",
-    databaseUrl:
-      process.env["DATABASE_URL"] ?? "postgres://postgres:postgres@localhost:5432/paseo_hub",
     ...(trustedClientIpHeader === undefined ? {} : { trustedClientIpHeader }),
     authPolicy: readInstanceAuthPolicy(),
   };

--- a/src/server/runtime.ts
+++ b/src/server/runtime.ts
@@ -107,26 +107,31 @@ export interface ApplicationRuntime {
 
 type ApplicationFactory = () => ApplicationRuntime | Promise<ApplicationRuntime>;
 
-let application: Promise<ApplicationRuntime> | undefined;
+declare global {
+  // Vite reloads server modules inside one process. Keep the singleton alive across those reloads.
+  var paseoHubApplicationRuntime: Promise<ApplicationRuntime> | undefined;
+}
 
 export function startApplication(factory: ApplicationFactory): Promise<ApplicationRuntime> {
-  application ??= Promise.resolve().then(factory);
-  return application;
+  globalThis.paseoHubApplicationRuntime ??= Promise.resolve().then(factory);
+  return globalThis.paseoHubApplicationRuntime;
 }
 
 export async function stopApplication(): Promise<void> {
-  const active = application;
-  application = undefined;
+  const active = globalThis.paseoHubApplicationRuntime;
+  globalThis.paseoHubApplicationRuntime = undefined;
   await (await active)?.stop();
 }
 
 export function hasApplication(): boolean {
-  return application !== undefined;
+  return globalThis.paseoHubApplicationRuntime !== undefined;
 }
 
 export function getApplication(): Promise<ApplicationRuntime> {
-  if (application === undefined) throw new Error("application is not started");
-  return application;
+  if (globalThis.paseoHubApplicationRuntime === undefined) {
+    throw new Error("application is not started");
+  }
+  return globalThis.paseoHubApplicationRuntime;
 }
 
 export async function handleAuth(request: Request): Promise<Response> {


### PR DESCRIPTION
A fresh Hub checkout now boots on persistent embedded storage with `npm install` and `npm run dev`; no PostgreSQL service or Docker setup is required. Setting `DATABASE_URL` keeps the existing PostgreSQL runtime path unchanged.

## Goals

- Select PostgreSQL when `DATABASE_URL` is non-empty and embedded PGlite otherwise.
- Persist the default embedded database under `.dev/paseo-hub`, overridable with `PASEO_HUB_DATA_DIR`.
- Run migrations on every boot through the existing driver-neutral runtime seam.
- Keep backend details, directory ownership, and single-process enforcement inside the database-runtime module.
- Make bare `npm run dev` serve Hub on its existing default public URL, port 3000.
- Preserve one application runtime across Vite server-module reloads.
- Keep Docker Compose on PostgreSQL.

## Non-goals

- No package or `npx` entry point.
- No operator onboarding, bootstrap-default, or project-upsert changes.
- No multi-process embedded support.
- No PGlite in the production Docker image.
- No duplicated PostgreSQL/embedded test matrix.

## Why

Local development previously manufactured a localhost PostgreSQL URL when `DATABASE_URL` was absent, and Paseo workspaces created a dedicated PostgreSQL database during setup. That made an external service mandatory despite the driver-neutral runtime seam from #45. The composition root now makes the backend choice once, while callers continue receiving the same database and lock capabilities.

PGlite permits concurrent handles on one filesystem directory, so embedded runtime construction owns an atomic PID/token lock. A live owner receives a clear one-process error; stale locks recover after an unclean exit. The process-scoped application singleton keeps Vite reloads on the already-open runtime instead of creating a second handle.

## Fresh-checkout boot transcript

The checkout had no `.env` while collecting this evidence.

```text
$ npm install
added 1 package, and audited 933 packages in 2s

$ npm run dev
> paseo-hub@0.4.0 dev
> vite dev --port 3000

VITE v7.3.6 ready in 1145 ms
➜ Local: http://localhost:3000/
[2026-08-13 12:54:09.871 +0200] INFO: database runtime ready: embedded (.../.dev/paseo-hub)

$ curl http://localhost:3000/health
{"ok":true}
# HTTP 200

$ curl http://localhost:3000/
# HTTP 200, <title>Paseo Hub</title>
```

Restarting the same command against that directory returned `{"ok":true}` again. The persistence integration also writes a probe row, closes the runtime, reopens the same directory, and reads the row back.

A concurrent process against the same directory fails with:

```text
Embedded database directory is already in use by another Paseo Hub process (PID 24773): .../.dev/paseo-hub. Embedded mode supports one process per data directory.
```

## Verification

- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npx vitest run src/db/runtime/embedded-persistence.integration.test.ts src/index.embedded.integration.test.ts` — 3 passed
- Real dev boot: root 200, health 200, restart 200, hot-reload health 200
- Real concurrent dev process: rejected with the documented single-process error
- Boundary search: no `pg` or PGlite imports outside database-runtime internals

## Risk surface

The meaningful risk is embedded directory lifecycle: stale-owner recovery, cleanup after graceful close, and Vite module reloads. Focused integration tests cover persistence and a real child-process collision; the manual dev transcript covers cold boot, HTTP serving, restart, and reload. PostgreSQL selection and Docker Compose wiring remain unchanged.