### PR TITLE
Deploy bundles without pre-creating projects

### DIFF
--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -18,9 +18,9 @@ The canonical, executable operation and schema reference is served by each Hub i
 
 Every canonical `/api/v1` response, including unknown paths and wrong methods, uses RFC 9457 `application/problem+json` on failure and includes `X-Request-ID`; callers may supply that header to correlate a request. Wrong methods return `405` with `Allow`, while unknown paths return `404`. Every `401` response also includes `WWW-Authenticate: Bearer`.
 
-Configuration YAML may include an optional non-empty top-level string `project` as deployment metadata. The authenticated request's `projectSlug` is always authoritative, so an explicit CLI `--project` can override the file. Hub validates and removes the metadata before strict workflow compilation without resolving or comparing it, while preserving the original YAML as revision evidence.
+Configuration YAML may include an optional top-level `name` slug as deployment metadata. An explicit request `projectSlug` (including the CLI's `--project`/`-p` option) is authoritative. Otherwise Hub resolves or creates the named project in the authenticated organization; without either field, it resolves or restores that organization's `default` project. Changing `name` targets a different project and leaves the old project's history intact.
 
-Configuration validation and installation accept the same YAML, `projectSlug`, and optional `partials` bundle. Both use the same parser, compiler, daemon/provider resolution, and business validation. Validation returns success or structured issues without creating a revision or changing the active configuration; installation records and activates only after those boundaries pass.
+Configuration validation and installation accept the same YAML, optional `projectSlug`, and prompt-partial bundle. Both use the same parser, compiler, project selection, daemon/provider resolution, and business validation. Validation returns the resolved `projectSlug` and `wouldCreateProject` without creating a project, recording a revision, or changing active configuration. Installation silently creates a missing bundle-named or default project, then records and activates the revision.
 
 ## Workflow MCP tools
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -6,7 +6,10 @@ import {
   type AttachmentProvider,
   type AttachmentResolver,
 } from "./attachments/capabilities.js";
-import { ProjectConfigurationStore } from "./configuration/store.js";
+import {
+  ProjectConfigurationStore,
+  validateHubBundleForOrganization,
+} from "./configuration/store.js";
 import type {
   AcceptedTriggerRunRecord,
   Database,
@@ -241,7 +244,12 @@ export function createHubApplication(options: HubRuntimeOptions): HubApplication
       }
     },
   };
-  const publicOperations = createAppPublicOperations(options, manualSource, storeForProject);
+  const publicOperations = createAppPublicOperations(
+    options,
+    manualSource,
+    storeForProject,
+    daemons,
+  );
   const publicApi = createPublicApi(options.publicApi, publicOperations);
   const operations: HubOperations = {
     handleDaemonEnrollment: (request) =>
@@ -286,12 +294,21 @@ function createAppPublicOperations(
   options: HubRuntimeOptions,
   manualSource: ReturnType<typeof createManualTriggerSource> | undefined,
   configurationForProject: (projectId: string) => ProjectConfigurationStore,
+  daemonAgentValidator: ActiveDaemonRegistry | null,
 ) {
   if (options.database === null || manualSource === undefined) return null;
+  const database = options.database;
   return createPublicOperations(
-    createDatabasePublicOperationRepository(options.database),
+    createDatabasePublicOperationRepository(database),
     {
       configurationForProject,
+      validateBundleForOrganization: (organizationId, files) =>
+        validateHubBundleForOrganization(
+          database,
+          organizationId,
+          files,
+          daemonAgentValidator ?? undefined,
+        ),
       dispatchManualEvent: (input) => dispatchManualTrigger(manualSource, input),
     },
     options.daemonClock,

--- a/src/config/bundle.test.ts
+++ b/src/config/bundle.test.ts
@@ -83,6 +83,28 @@ function hasBundleIssue(error: unknown, path: string, message: RegExp): boolean 
 }
 
 describe("Hub configuration bundle", () => {
+  it("accepts an optional project name as slug-validated deployment metadata", () => {
+    const bundle = compileHubBundle(filesWithHub(`name: agent-tools\n${hub}`));
+
+    assert.equal(bundle.name, "agent-tools");
+    assert.equal(Object.hasOwn(bundle.configuration, "name"), false);
+  });
+
+  it.each(["Agent Tools", "agent_tools", "-agent-tools", "agent--tools", "a".repeat(101)])(
+    "rejects invalid project name %s with a structured field issue",
+    (name) => {
+      assert.throws(
+        () => compileHubBundle(filesWithHub(`name: ${name}\n${hub}`)),
+        (error) =>
+          hasBundleIssue(
+            error,
+            ".paseo/hub.yml.name",
+            /lowercase letters, numbers, and single hyphens|too big/iu,
+          ),
+      );
+    },
+  );
+
   it("compiles canonical files with provenance and complete finite named resources", () => {
     const bundle = compileHubBundle(canonicalFiles());
     const trigger = bundle.configuration.triggers[0]!;

--- a/src/config/bundle.ts
+++ b/src/config/bundle.ts
@@ -20,6 +20,7 @@ import {
   MAX_PROMPT_PARTIAL_COUNT,
   MAX_PROMPT_PARTIAL_PATH_LENGTH,
 } from "./prompt-partial-limits.js";
+import { projectSlugSchema } from "../project-slug.js";
 import {
   compareBundlePaths,
   HUB_RESOURCE_PATH,
@@ -41,6 +42,7 @@ export interface HubBundleIssue {
 }
 
 export interface CompiledHubBundle {
+  name?: string;
   configuration: CompiledHubConfig;
   agentValidationTargets: readonly HubBundleAgentValidationTarget[];
   files: readonly HubBundleFile[];
@@ -84,6 +86,7 @@ export function compileHubBundle(input: readonly HubBundleFile[]): CompiledHubBu
     );
   }
   rejectResourceKeys(resource);
+  const bundleName = projectName(resource["name"]);
   const environments = namedResources(resource["environments"], "environment", HUB_RESOURCE_PATH);
   const agents = namedAgents(resource["agents"]);
   const workflowFiles = [...files.values()]
@@ -129,6 +132,7 @@ export function compileHubBundle(input: readonly HubBundleFile[]): CompiledHubBu
   }
   const authoredFiles = [...files.values()].sort(byPath);
   return {
+    ...(bundleName === undefined ? {} : { name: bundleName }),
     configuration,
     agentValidationTargets: collectAgentValidationTargets(triggers, configuration, agents),
     files: authoredFiles,
@@ -233,10 +237,19 @@ function parseYamlRecord(file: HubBundleFile): Record<string, unknown> {
 
 function rejectResourceKeys(resource: Record<string, unknown>): void {
   for (const key of Object.keys(resource)) {
-    if (key !== "environments" && key !== "agents") {
+    if (key !== "name" && key !== "environments" && key !== "agents") {
       throw issue([HUB_RESOURCE_PATH, key], `unknown project resource ${key}`);
     }
   }
+}
+
+function projectName(value: unknown): string | undefined {
+  if (value === undefined) return undefined;
+  const parsed = projectSlugSchema.safeParse(value);
+  if (!parsed.success) {
+    throw issue([HUB_RESOURCE_PATH, "name"], parsed.error.issues[0]?.message ?? "invalid slug");
+  }
+  return parsed.data;
 }
 
 function namedResources(value: unknown, kind: string, sourceFile: string): unknown[] {

--- a/src/configuration/store.ts
+++ b/src/configuration/store.ts
@@ -103,22 +103,19 @@ export class ProjectConfigurationStore {
   async validateBundle(
     files: readonly HubBundleFile[],
   ): Promise<{ valid: true } | { valid: false; validationErrors: unknown }> {
-    let bundle: CompiledHubBundle;
-    try {
-      bundle = compileHubBundle(files);
-    } catch (error) {
-      return { valid: false, validationErrors: formatConfigurationError(error) };
+    const project = await this.database.findProjectById(this.projectId);
+    if (project === undefined) {
+      return {
+        valid: false,
+        validationErrors: { formErrors: ["unresolved organization resources: project"] },
+      };
     }
-    const prepared = await prepareCompiledRevision(
+    return validateHubBundleForOrganization(
       this.database,
-      this.projectId,
-      bundle.configuration,
-      bundle.agentValidationTargets,
+      project.organizationId,
+      files,
       this.daemonAgentValidator,
     );
-    return prepared.validationErrors === undefined
-      ? { valid: true }
-      : { valid: false, validationErrors: prepared.validationErrors };
   }
 
   async insertManualBundleRevision(input: {
@@ -284,6 +281,30 @@ export class ProjectConfigurationStore {
   }
 }
 
+export async function validateHubBundleForOrganization(
+  database: Database,
+  organizationId: string,
+  files: readonly HubBundleFile[],
+  daemonAgentValidator?: DaemonAgentConfigurationValidator,
+): Promise<{ valid: true } | { valid: false; validationErrors: unknown }> {
+  let bundle: CompiledHubBundle;
+  try {
+    bundle = compileHubBundle(files);
+  } catch (error) {
+    return { valid: false, validationErrors: formatConfigurationError(error) };
+  }
+  const prepared = await prepareCompiledRevisionForOrganization(
+    database,
+    organizationId,
+    bundle.configuration,
+    bundle.agentValidationTargets,
+    daemonAgentValidator,
+  );
+  return prepared.validationErrors === undefined
+    ? { valid: true }
+    : { valid: false, validationErrors: prepared.validationErrors };
+}
+
 export function parseProjectConfiguration(
   revision: ProjectConfigurationRevisionRecord,
 ): CompiledProjectConfiguration {
@@ -308,7 +329,32 @@ async function prepareCompiledRevision(
   agentValidationTargets: readonly HubBundleAgentValidationTarget[],
   daemonAgentValidator: DaemonAgentConfigurationValidator | undefined,
 ): Promise<Extract<PreparedRevision, { kind: "compiled" }>> {
-  const compiled = await resolveCompiledConfiguration(database, projectId, configuration);
+  const project = await database.findProjectById(projectId);
+  if (project === undefined) {
+    return {
+      kind: "compiled",
+      normalizedConfiguration: configuration,
+      contentHash: compiledConfigurationHash(configuration),
+      validationErrors: { formErrors: ["unresolved organization resources: project"] },
+    };
+  }
+  return prepareCompiledRevisionForOrganization(
+    database,
+    project.organizationId,
+    configuration,
+    agentValidationTargets,
+    daemonAgentValidator,
+  );
+}
+
+async function prepareCompiledRevisionForOrganization(
+  database: Database,
+  organizationId: string,
+  configuration: CompiledHubConfig,
+  agentValidationTargets: readonly HubBundleAgentValidationTarget[],
+  daemonAgentValidator: DaemonAgentConfigurationValidator | undefined,
+): Promise<Extract<PreparedRevision, { kind: "compiled" }>> {
+  const compiled = await resolveCompiledConfiguration(database, organizationId, configuration);
   if (!compiled.success) {
     return {
       kind: "compiled",
@@ -411,20 +457,16 @@ type CompileConfigurationResult =
 
 async function resolveCompiledConfiguration(
   database: Database,
-  projectId: string,
+  organizationId: string,
   configuration: CompiledHubConfig,
 ): Promise<CompileConfigurationResult> {
-  const project = await database.findProjectById(projectId);
-  if (project === undefined) {
-    return { success: false, kind: "compiled", missing: ["project"], configuration };
-  }
   const resolutions = await Promise.all(
     configuration.environments.map(async (environment) =>
       environment.kind === "daemon"
         ? {
             environment,
             daemon: await database.findDaemonBySlugForOrganization(
-              project.organizationId,
+              organizationId,
               environment.daemon,
             ),
           }
@@ -436,7 +478,7 @@ async function resolveCompiledConfiguration(
   );
   const triggerCompilation = await compileTriggers(
     database,
-    project.organizationId,
+    organizationId,
     configuration.triggers,
   );
   const unresolved = [...missing, ...triggerCompilation.missing];

--- a/src/db/memory.ts
+++ b/src/db/memory.ts
@@ -1950,6 +1950,21 @@ class MemoryDatabase implements Database {
     return project;
   }
 
+  async restoreProject(organizationId: string, projectId: string): Promise<ProjectRecord> {
+    const project = this.projects.get(projectId);
+    if (project === undefined || project.organizationId !== organizationId) {
+      throw new Error("project not found");
+    }
+    const restored: ProjectRecord = {
+      ...project,
+      status: "active",
+      archivedAt: null,
+      updatedAt: new Date(),
+    };
+    this.projects.set(projectId, restored);
+    return restored;
+  }
+
   async getOrganizationEntitlements(
     organizationId: string,
   ): Promise<OrganizationEntitlementsRecord | undefined> {

--- a/src/db/pg.ts
+++ b/src/db/pg.ts
@@ -2389,7 +2389,7 @@ class PgDatabase implements Database {
       this.pool,
       `insert into projects (organization_id, name, slug, created_by_user_id)
        select $1, $2, $3, $4
-       where exists (
+       where $4::text is null or exists (
          select 1 from member where organization_id = $1 and user_id = $4
        )
        returning *`,
@@ -2404,6 +2404,20 @@ class PgDatabase implements Database {
        values ($1, $2, 'manual', false, $3)`,
       [project.id, input.organizationId, input.createdByUserId],
     );
+    return toProjectRecord(project);
+  }
+
+  async restoreProject(organizationId: string, projectId: string): Promise<ProjectRecord> {
+    const rows = await query<ProjectRow>(
+      this.pool,
+      `update projects
+       set status = 'active', archived_at = null, updated_at = clock_timestamp()
+       where organization_id = $1 and id = $2
+       returning *`,
+      [organizationId, projectId],
+    );
+    const project = rows.rows[0];
+    if (project === undefined) throw new Error("project not found");
     return toProjectRecord(project);
   }
 

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -726,7 +726,7 @@ export interface CreateProjectInput {
   organizationId: string;
   name: string;
   slug: string;
-  createdByUserId: string;
+  createdByUserId: string | null;
 }
 
 export type EntitlementChangeSource = "provisioning" | "plan_stamp" | "override";
@@ -1196,6 +1196,7 @@ export interface Database {
   ): Promise<AgentExecutionRecord | undefined>;
   completeHubAction(executionId: string, action: HubAction): Promise<boolean>;
   createProject(input: CreateProjectInput): Promise<ProjectRecord>;
+  restoreProject(organizationId: string, projectId: string): Promise<ProjectRecord>;
   getOrganizationEntitlements(
     organizationId: string,
   ): Promise<OrganizationEntitlementsRecord | undefined>;

--- a/src/project-deployments/index.test.ts
+++ b/src/project-deployments/index.test.ts
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import { describe, it } from "vitest";
+import { createMemoryDatabase } from "../db/memory.js";
+import { DeploymentProjects } from "./index.js";
+
+describe("deployment projects", () => {
+  it("lets an explicit project override the bundle name without creating either", async () => {
+    const database = createMemoryDatabase({ organizationIds: ["org"] });
+    const explicit = await database.createProject({
+      organizationId: "org",
+      name: "Explicit",
+      slug: "explicit",
+      createdByUserId: null,
+    });
+    const projects = new DeploymentProjects(database);
+
+    const result = await projects.resolve({
+      organizationId: "org",
+      explicitProjectSlug: "explicit",
+      bundleName: "from-bundle",
+      dryRun: false,
+    });
+
+    assert.equal(result.status, "resolved");
+    if (result.status !== "resolved") return;
+    assert.equal(result.project.id, explicit.id);
+    assert.equal(result.created, false);
+    assert.equal(await database.findProjectBySlugForOrganization("org", "from-bundle"), undefined);
+  });
+
+  it("reports a dry-run creation without writing it", async () => {
+    const database = createMemoryDatabase({ organizationIds: ["org"] });
+    const projects = new DeploymentProjects(database);
+
+    assert.deepEqual(
+      await projects.resolve({ organizationId: "org", bundleName: "new-project", dryRun: true }),
+      { status: "would_create", projectSlug: "new-project" },
+    );
+    assert.deepEqual(await database.listProjectsForOrganization("org"), []);
+  });
+
+  it("upserts the default project when no target is supplied", async () => {
+    const database = createMemoryDatabase({ organizationIds: ["org"] });
+    const projects = new DeploymentProjects(database);
+
+    const result = await projects.resolve({ organizationId: "org", dryRun: false });
+
+    assert.equal(result.status, "resolved");
+    if (result.status !== "resolved") return;
+    assert.equal(result.project.slug, "default");
+    assert.equal(result.created, true);
+  });
+
+  it("restores an archived implicit target instead of colliding with its slug", async () => {
+    const database = createMemoryDatabase({ organizationIds: ["org"] });
+    const archived = await database.createProject({
+      organizationId: "org",
+      name: "Default",
+      slug: "default",
+      createdByUserId: null,
+    });
+    await database.archiveProject("org", archived.id, "user");
+    const projects = new DeploymentProjects(database);
+
+    const result = await projects.resolve({ organizationId: "org", dryRun: false });
+
+    assert.equal(result.status, "resolved");
+    if (result.status !== "resolved") return;
+    assert.equal(result.project.id, archived.id);
+    assert.equal(result.project.status, "active");
+    assert.equal(result.created, false);
+  });
+
+  it("scopes identical names to their organizations", async () => {
+    const database = createMemoryDatabase({ organizationIds: ["org-a", "org-b"] });
+    const projects = new DeploymentProjects(database);
+
+    const [left, right] = await Promise.all([
+      projects.resolve({ organizationId: "org-a", bundleName: "shared", dryRun: false }),
+      projects.resolve({ organizationId: "org-b", bundleName: "shared", dryRun: false }),
+    ]);
+
+    assert.equal(left.status, "resolved");
+    assert.equal(right.status, "resolved");
+    if (left.status !== "resolved" || right.status !== "resolved") return;
+    assert.notEqual(left.project.id, right.project.id);
+  });
+
+  it("serializes concurrent first deployments to one project", async () => {
+    const database = createMemoryDatabase({ organizationIds: ["org"] });
+    const projects = new DeploymentProjects(database);
+
+    const results = await Promise.all(
+      Array.from({ length: 8 }, () =>
+        projects.resolve({ organizationId: "org", bundleName: "racing", dryRun: false }),
+      ),
+    );
+
+    assert.ok(results.every((result) => result.status === "resolved"));
+    assert.equal(
+      results.filter((result) => result.status === "resolved" && result.created).length,
+      1,
+    );
+    assert.deepEqual(
+      (await database.listProjectsForOrganization("org")).map(({ slug }) => slug),
+      ["racing"],
+    );
+  });
+});

--- a/src/project-deployments/index.ts
+++ b/src/project-deployments/index.ts
@@ -1,0 +1,75 @@
+import type { Database, ProjectRecord } from "../db/types.js";
+
+export type DeploymentProjectResolution =
+  | { status: "resolved"; project: ProjectRecord; created: boolean }
+  | { status: "would_create"; projectSlug: string }
+  | { status: "project_not_found" };
+
+/** Resolves the project targeted by one configuration deployment, including race-safe upsert. */
+export class DeploymentProjects {
+  constructor(private readonly database: Database) {}
+
+  async resolve(input: {
+    organizationId: string;
+    explicitProjectSlug?: string | undefined;
+    bundleName?: string | undefined;
+    dryRun: boolean;
+  }): Promise<DeploymentProjectResolution> {
+    if (input.explicitProjectSlug !== undefined) {
+      const project = await this.findActive(input.organizationId, input.explicitProjectSlug);
+      return project === undefined
+        ? { status: "project_not_found" }
+        : { status: "resolved", project, created: false };
+    }
+
+    const projectSlug = input.bundleName ?? "default";
+    const existing = await this.database.findProjectBySlugForOrganization(
+      input.organizationId,
+      projectSlug,
+    );
+    if (existing !== undefined) {
+      if (existing.status === "active" || input.dryRun) {
+        return { status: "resolved", project: existing, created: false };
+      }
+    } else if (input.dryRun) return { status: "would_create", projectSlug };
+
+    return this.database.withAdvisoryLock(
+      projectLock(input.organizationId, projectSlug),
+      async () => {
+        const raced = await this.database.findProjectBySlugForOrganization(
+          input.organizationId,
+          projectSlug,
+        );
+        if (raced !== undefined) {
+          const project =
+            raced.status === "active"
+              ? raced
+              : await this.database.restoreProject(input.organizationId, raced.id);
+          return { status: "resolved", project, created: false };
+        }
+        const project = await this.database.createProject({
+          organizationId: input.organizationId,
+          name: projectSlug,
+          slug: projectSlug,
+          createdByUserId: null,
+        });
+        return { status: "resolved", project, created: true };
+      },
+    );
+  }
+
+  private async findActive(
+    organizationId: string,
+    projectSlug: string,
+  ): Promise<ProjectRecord | undefined> {
+    const project = await this.database.findProjectBySlugForOrganization(
+      organizationId,
+      projectSlug,
+    );
+    return project?.status === "active" ? project : undefined;
+  }
+}
+
+function projectLock(organizationId: string, projectSlug: string): string {
+  return `deployment-project:${JSON.stringify([organizationId, projectSlug])}`;
+}

--- a/src/project-slug.ts
+++ b/src/project-slug.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+export const projectSlugSchema = z
+  .string()
+  .trim()
+  .regex(
+    /^[a-z0-9]+(?:-[a-z0-9]+)*$/u,
+    "must contain only lowercase letters, numbers, and single hyphens",
+  )
+  .max(100);

--- a/src/projects/functions.ts
+++ b/src/projects/functions.ts
@@ -9,6 +9,7 @@ import {
 import { respondError, respondOk, type Result } from "../contract/respond.js";
 import { getApplication } from "../server/runtime.js";
 import { logger } from "../logger.js";
+import { projectSlugSchema } from "../project-slug.js";
 import { isTenantRouteNotFoundError } from "./access.js";
 import { ProjectCommandError, projectCommandErrorCode } from "./command-error.js";
 import { type ManualConfigurationSaveResult, type ProjectDashboard } from "./dashboard.js";
@@ -22,18 +23,10 @@ const projectScopeSchema = organizationScopeSchema
 const activityRunScopeSchema = projectScopeSchema.extend({ runId: z.string().uuid() }).strict();
 const createProjectSchema = organizationScopeSchema.extend({
   name: z.string().trim().min(1).max(100),
-  slug: z
-    .string()
-    .trim()
-    .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/u)
-    .max(100),
+  slug: projectSlugSchema,
 });
-const projectSlugSchema = projectScopeSchema.extend({
-  slug: z
-    .string()
-    .trim()
-    .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/u)
-    .max(100),
+const projectUpdateSchema = projectScopeSchema.extend({
+  slug: projectSlugSchema,
 });
 const configurationRepositorySchema = projectScopeSchema.extend({
   connectionId: z.string().uuid(),
@@ -99,7 +92,7 @@ export const archiveProject = createServerFn({ method: "POST" })
   );
 
 export const updateProjectSlug = createServerFn({ method: "POST" })
-  .validator(projectSlugSchema)
+  .validator(projectUpdateSchema)
   .handler(async ({ data }) =>
     command(data, (dashboard) => dashboard.updateProjectSlug(getRequest(), data, data.slug)),
   );

--- a/src/public-api/contracts.ts
+++ b/src/public-api/contracts.ts
@@ -95,7 +95,7 @@ export const ConfigurationFileSchema = z
 
 export const InstallConfigurationRequestSchema = z
   .object({
-    projectSlug: z.string().trim().min(1).max(100),
+    projectSlug: z.string().trim().min(1).max(100).optional(),
     files: z.array(ConfigurationFileSchema).min(1).max(MAX_PROMPT_PARTIAL_COUNT),
   })
   .strict()
@@ -108,6 +108,7 @@ export const InstallConfigurationRequestSchema = z
         {
           path: ".paseo/hub.yml",
           content: [
+            "name: payments",
             "environments:",
             "  runner:",
             "    kind: daemon",
@@ -163,10 +164,11 @@ export const ValidatedConfigurationSchema = z
   .object({
     projectSlug: z.string(),
     valid: z.literal(true),
+    wouldCreateProject: z.boolean(),
   })
   .strict()
   .openapi("ValidatedConfiguration", {
-    example: { projectSlug: "payments", valid: true },
+    example: { projectSlug: "payments", valid: true, wouldCreateProject: false },
   });
 
 export const ProjectSchema = z

--- a/src/public-api/contracts.ts
+++ b/src/public-api/contracts.ts
@@ -164,11 +164,11 @@ export const ValidatedConfigurationSchema = z
   .object({
     projectSlug: z.string(),
     valid: z.literal(true),
-    wouldCreateProject: z.boolean(),
+    wouldCreateProject: z.literal(true).optional(),
   })
   .strict()
   .openapi("ValidatedConfiguration", {
-    example: { projectSlug: "payments", valid: true, wouldCreateProject: false },
+    example: { projectSlug: "payments", valid: true, wouldCreateProject: true },
   });
 
 export const ProjectSchema = z

--- a/src/public-api/index.ts
+++ b/src/public-api/index.ts
@@ -223,7 +223,7 @@ function validationResponse(requestId: string, result: ValidateConfigurationResu
       return success(requestId, 200, ValidatedConfigurationSchema, {
         projectSlug: result.projectSlug,
         valid: true,
-        wouldCreateProject: result.wouldCreateProject,
+        ...(result.wouldCreateProject === true ? { wouldCreateProject: true } : {}),
       });
     case "project_not_found":
       return problem(

--- a/src/public-api/index.ts
+++ b/src/public-api/index.ts
@@ -223,6 +223,7 @@ function validationResponse(requestId: string, result: ValidateConfigurationResu
       return success(requestId, 200, ValidatedConfigurationSchema, {
         projectSlug: result.projectSlug,
         valid: true,
+        wouldCreateProject: result.wouldCreateProject,
       });
     case "project_not_found":
       return problem(

--- a/src/public-api/operation-manifest.ts
+++ b/src/public-api/operation-manifest.ts
@@ -87,7 +87,7 @@ export const publicOperationManifest: readonly PublicOperationDefinition[] = [
     resultMapping: "validation",
     summary: "Validate configuration",
     description:
-      "Validates and resolves the same YAML, prompt-partial bundle, project, daemon, and provider resources as installation without recording or activating a revision.",
+      "Resolves the deployment project and validates the same YAML, prompt-partial bundle, daemon, and provider resources as installation without creating a project, recording a revision, or changing active configuration.",
     tag: "Configurations",
     responses: {
       200: "The configuration is valid for the project.",
@@ -116,7 +116,7 @@ export const publicOperationManifest: readonly PublicOperationDefinition[] = [
     resultMapping: "configuration",
     summary: "Install and activate configuration",
     description:
-      "Validates and resolves the complete canonical Hub bundle, records a configuration revision, and atomically activates it.",
+      "Resolves or creates the deployment project, validates the complete canonical Hub bundle, records a configuration revision, and atomically activates it.",
     tag: "Configurations",
     responses: {
       201: "The new configuration revision is active.",

--- a/src/public-api/public-api.test.ts
+++ b/src/public-api/public-api.test.ts
@@ -79,6 +79,17 @@ describe("public API interface", () => {
     assert.match(response.headers.get("x-request-id") ?? "", /^[0-9a-f-]{36}$/u);
   });
 
+  it("keeps existing-project validation responses compatible with strict clients", async () => {
+    const api = createPublicApi(
+      { status: "enabled", authenticator: authenticator() },
+      successfulOperations(),
+    );
+
+    const response = await api.handle(installRequest("/api/v1/configurations/validate"));
+
+    assert.deepEqual(await response.json(), { projectSlug: "project", valid: true });
+  });
+
   it("returns RFC 9457 request-correlated 404 and 405 responses at the canonical router", async () => {
     const api = createPublicApi(
       { status: "enabled", authenticator: authenticator() },
@@ -369,7 +380,6 @@ function successfulOperations(): PublicOperations {
         status: "valid",
         projectSlug: "project",
         valid: true,
-        wouldCreateProject: false,
       }),
     installConfiguration: () =>
       Promise.resolve({

--- a/src/public-api/public-api.test.ts
+++ b/src/public-api/public-api.test.ts
@@ -365,7 +365,12 @@ function successfulOperations(): PublicOperations {
         ],
       }),
     validateConfiguration: () =>
-      Promise.resolve({ status: "valid", projectSlug: "project", valid: true }),
+      Promise.resolve({
+        status: "valid",
+        projectSlug: "project",
+        valid: true,
+        wouldCreateProject: false,
+      }),
     installConfiguration: () =>
       Promise.resolve({
         status: "installed",

--- a/src/public-operations/database-adapter.ts
+++ b/src/public-operations/database-adapter.ts
@@ -1,10 +1,12 @@
 import { createHash, randomUUID } from "node:crypto";
 import type { Database } from "../db/types.js";
+import { DeploymentProjects } from "../project-deployments/index.js";
 import type { PublicOperationRepository } from "./types.js";
 
 export function createDatabasePublicOperationRepository(
   database: Database,
 ): PublicOperationRepository {
+  const deploymentProjects = new DeploymentProjects(database);
   return {
     async listActiveProjects(organizationId) {
       return (await database.listProjectsForOrganization(organizationId))
@@ -17,6 +19,7 @@ export function createDatabasePublicOperationRepository(
         ? undefined
         : { id: project.id, slug: project.slug };
     },
+    resolveDeploymentProject: (input) => deploymentProjects.resolve(input),
     async findManualRun(providerEventReceiptId, trigger) {
       return (await database.findTriggerRunsByProviderEventReceiptId(providerEventReceiptId)).find(
         (candidate) => candidate.configuredTriggerName === trigger,

--- a/src/public-operations/index.ts
+++ b/src/public-operations/index.ts
@@ -36,15 +36,14 @@ export function createPublicOperations(
     },
     async validateConfiguration(authorization, input) {
       try {
-        const resolved = resolveConfigurationInput(input);
+        const resolved = await resolveConfigurationDeployment(
+          repository,
+          authorization.organizationId,
+          input,
+          true,
+        );
         if (!resolved.success) return resolved.result;
-        const target = await repository.resolveDeploymentProject({
-          organizationId: authorization.organizationId,
-          ...(input.projectSlug === undefined ? {} : { explicitProjectSlug: input.projectSlug }),
-          ...(resolved.bundleName === undefined ? {} : { bundleName: resolved.bundleName }),
-          dryRun: true,
-        });
-        if (target.status === "project_not_found") return target;
+        const { target } = resolved;
         const result =
           target.status === "would_create"
             ? await capabilities.validateBundleForOrganization(
@@ -73,15 +72,14 @@ export function createPublicOperations(
     },
     async installConfiguration(authorization, input) {
       try {
-        const resolved = resolveConfigurationInput(input);
+        const resolved = await resolveConfigurationDeployment(
+          repository,
+          authorization.organizationId,
+          input,
+          false,
+        );
         if (!resolved.success) return resolved.result;
-        const target = await repository.resolveDeploymentProject({
-          organizationId: authorization.organizationId,
-          ...(input.projectSlug === undefined ? {} : { explicitProjectSlug: input.projectSlug }),
-          ...(resolved.bundleName === undefined ? {} : { bundleName: resolved.bundleName }),
-          dryRun: false,
-        });
-        if (target.status === "project_not_found") return target;
+        const { target } = resolved;
         if (target.status === "would_create") throw new Error("install project was not resolved");
         const project = target.project;
         const configuration = capabilities.configurationForProject(project.id);
@@ -221,26 +219,52 @@ async function dispatchManualRun(
   };
 }
 
-function resolveConfigurationInput(input: { files: readonly { path: string; content: string }[] }):
+async function resolveConfigurationDeployment(
+  repository: PublicOperationRepository,
+  organizationId: string,
+  input: {
+    projectSlug?: string | undefined;
+    files: readonly { path: string; content: string }[];
+  },
+  dryRun: boolean,
+): Promise<
   | {
       success: true;
       files: readonly { path: string; content: string }[];
-      bundleName?: string | undefined;
+      target:
+        | {
+            status: "resolved";
+            project: { id: string; slug: string };
+            created: boolean;
+          }
+        | { status: "would_create"; projectSlug: string };
     }
   | {
       success: false;
-      result: {
-        status: "invalid_bundle";
-        issues: readonly { path: readonly (string | number)[]; message: string }[];
-      };
-    } {
+      result:
+        | { status: "project_not_found" }
+        | {
+            status: "invalid_bundle";
+            issues: readonly { path: readonly (string | number)[]; message: string }[];
+          };
+    }
+> {
+  const explicitTarget =
+    input.projectSlug === undefined
+      ? undefined
+      : await repository.resolveDeploymentProject({
+          organizationId,
+          explicitProjectSlug: input.projectSlug,
+          dryRun,
+        });
+  if (explicitTarget?.status === "project_not_found") {
+    return { success: false, result: explicitTarget };
+  }
+
+  let bundleName: string | undefined;
   try {
     const bundle = compileHubBundle(input.files);
-    return {
-      success: true,
-      files: input.files,
-      ...(bundle.name === undefined ? {} : { bundleName: bundle.name }),
-    };
+    bundleName = bundle.name;
   } catch (error) {
     if (error instanceof HubBundleError) {
       return {
@@ -250,6 +274,17 @@ function resolveConfigurationInput(input: { files: readonly { path: string; cont
     }
     throw error;
   }
+
+  const target =
+    explicitTarget ??
+    (await repository.resolveDeploymentProject({
+      organizationId,
+      ...(bundleName === undefined ? {} : { bundleName }),
+      dryRun,
+    }));
+  return target.status === "project_not_found"
+    ? { success: false, result: target }
+    : { success: true, files: input.files, target };
 }
 
 function internalDeliveryId(

--- a/src/public-operations/index.ts
+++ b/src/public-operations/index.ts
@@ -36,18 +36,33 @@ export function createPublicOperations(
     },
     async validateConfiguration(authorization, input) {
       try {
-        const project = await repository.findActiveProject(
-          authorization.organizationId,
-          input.projectSlug,
-        );
-        if (project === undefined) return { status: "project_not_found" };
         const resolved = resolveConfigurationInput(input);
         if (!resolved.success) return resolved.result;
-        const result = await capabilities
-          .configurationForProject(project.id)
-          .validateBundle(resolved.files);
+        const target = await repository.resolveDeploymentProject({
+          organizationId: authorization.organizationId,
+          ...(input.projectSlug === undefined ? {} : { explicitProjectSlug: input.projectSlug }),
+          ...(resolved.bundleName === undefined ? {} : { bundleName: resolved.bundleName }),
+          dryRun: true,
+        });
+        if (target.status === "project_not_found") return target;
+        const result =
+          target.status === "would_create"
+            ? await capabilities.validateBundleForOrganization(
+                authorization.organizationId,
+                resolved.files,
+              )
+            : await capabilities
+                .configurationForProject(target.project.id)
+                .validateBundle(resolved.files);
+        const projectSlug =
+          target.status === "would_create" ? target.projectSlug : target.project.slug;
         return result.valid
-          ? { status: "valid", projectSlug: project.slug, valid: true }
+          ? {
+              status: "valid",
+              projectSlug,
+              valid: true,
+              wouldCreateProject: target.status === "would_create",
+            }
           : {
               status: "invalid_configuration",
               issues: configurationValidationIssues(result.validationErrors),
@@ -58,13 +73,17 @@ export function createPublicOperations(
     },
     async installConfiguration(authorization, input) {
       try {
-        const project = await repository.findActiveProject(
-          authorization.organizationId,
-          input.projectSlug,
-        );
-        if (project === undefined) return { status: "project_not_found" };
         const resolved = resolveConfigurationInput(input);
         if (!resolved.success) return resolved.result;
+        const target = await repository.resolveDeploymentProject({
+          organizationId: authorization.organizationId,
+          ...(input.projectSlug === undefined ? {} : { explicitProjectSlug: input.projectSlug }),
+          ...(resolved.bundleName === undefined ? {} : { bundleName: resolved.bundleName }),
+          dryRun: false,
+        });
+        if (target.status === "project_not_found") return target;
+        if (target.status === "would_create") throw new Error("install project was not resolved");
+        const project = target.project;
         const configuration = capabilities.configurationForProject(project.id);
         const record = await configuration.insertManualBundleRevision({
           files: resolved.files,
@@ -206,6 +225,7 @@ function resolveConfigurationInput(input: { files: readonly { path: string; cont
   | {
       success: true;
       files: readonly { path: string; content: string }[];
+      bundleName?: string | undefined;
     }
   | {
       success: false;
@@ -215,8 +235,12 @@ function resolveConfigurationInput(input: { files: readonly { path: string; cont
       };
     } {
   try {
-    compileHubBundle(input.files);
-    return { success: true, files: input.files };
+    const bundle = compileHubBundle(input.files);
+    return {
+      success: true,
+      files: input.files,
+      ...(bundle.name === undefined ? {} : { bundleName: bundle.name }),
+    };
   } catch (error) {
     if (error instanceof HubBundleError) {
       return {

--- a/src/public-operations/index.ts
+++ b/src/public-operations/index.ts
@@ -61,7 +61,7 @@ export function createPublicOperations(
               status: "valid",
               projectSlug,
               valid: true,
-              wouldCreateProject: target.status === "would_create",
+              ...(target.status === "would_create" ? { wouldCreateProject: true as const } : {}),
             }
           : {
               status: "invalid_configuration",

--- a/src/public-operations/install-configuration.test.ts
+++ b/src/public-operations/install-configuration.test.ts
@@ -248,6 +248,18 @@ describe("public configuration bundle installation", () => {
     );
   });
 
+  it("preserves explicit missing-project precedence over bundle validation", async () => {
+    const harness = await deploymentHarness();
+
+    const result = await harness.install(files().slice(0, 1), "missing");
+
+    assert.deepEqual(result, { status: "project_not_found" });
+    assert.deepEqual(
+      await harness.database.listProjectsForOrganization(authorization.organizationId),
+      [],
+    );
+  });
+
   it("targets an existing default and upserts it when missing", async () => {
     const existing = await deploymentHarness();
     const defaultProject = await existing.createProject("default");

--- a/src/public-operations/install-configuration.test.ts
+++ b/src/public-operations/install-configuration.test.ts
@@ -84,7 +84,6 @@ describe("public configuration bundle installation", () => {
       status: "valid",
       projectSlug: "payments",
       valid: true,
-      wouldCreateProject: false,
     });
     assert.equal(harness.insertions, 0);
   });

--- a/src/public-operations/install-configuration.test.ts
+++ b/src/public-operations/install-configuration.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "vitest";
 import {
   revisionBundleFiles,
   ProjectConfigurationStore,
+  validateHubBundleForOrganization,
   type DaemonAgentConfigurationValidator,
 } from "../configuration/store.js";
 import { parseCompiledHubConfig } from "../config/compiler.js";
@@ -83,6 +84,7 @@ describe("public configuration bundle installation", () => {
       status: "valid",
       projectSlug: "payments",
       valid: true,
+      wouldCreateProject: false,
     });
     assert.equal(harness.insertions, 0);
   });
@@ -203,7 +205,142 @@ describe("public configuration bundle installation", () => {
     assert.notEqual(first.id, second.id);
     assert.notEqual(first.contentHash, second.contentHash);
   });
+
+  it("installs a named bundle into its existing project", async () => {
+    const harness = await deploymentHarness();
+    const project = await harness.createProject("named-project");
+
+    const result = await harness.install(namedFiles("named-project"));
+
+    assert.equal(result.status, "installed");
+    if (result.status !== "installed") return;
+    assert.equal(result.projectSlug, "named-project");
+    assert.ok((await harness.database.projectConfigurationReadModel(project.id)).activeRevision);
+  });
+
+  it("creates a named project and records its first revision in one deploy", async () => {
+    const harness = await deploymentHarness();
+
+    const result = await harness.install(namedFiles("created-on-deploy"));
+
+    assert.equal(result.status, "installed");
+    const project = await harness.database.findProjectBySlugForOrganization(
+      authorization.organizationId,
+      "created-on-deploy",
+    );
+    assert.ok(project);
+    assert.ok((await harness.database.projectConfigurationReadModel(project.id)).activeRevision);
+  });
+
+  it("lets the explicit project override a different bundle name", async () => {
+    const harness = await deploymentHarness();
+    const explicit = await harness.createProject("explicit");
+
+    const result = await harness.install(namedFiles("ignored-name"), "explicit");
+
+    assert.equal(result.status, "installed");
+    assert.ok((await harness.database.projectConfigurationReadModel(explicit.id)).activeRevision);
+    assert.equal(
+      await harness.database.findProjectBySlugForOrganization(
+        authorization.organizationId,
+        "ignored-name",
+      ),
+      undefined,
+    );
+  });
+
+  it("targets an existing default and upserts it when missing", async () => {
+    const existing = await deploymentHarness();
+    const defaultProject = await existing.createProject("default");
+    assert.equal((await existing.install(files())).status, "installed");
+    assert.ok(
+      (await existing.database.projectConfigurationReadModel(defaultProject.id)).activeRevision,
+    );
+
+    const missing = await deploymentHarness();
+    assert.equal((await missing.install(files())).status, "installed");
+    assert.ok(
+      await missing.database.findProjectBySlugForOrganization(
+        authorization.organizationId,
+        "default",
+      ),
+    );
+  });
+
+  it("reports a dry-run project creation without creating it", async () => {
+    const harness = await deploymentHarness();
+
+    assert.deepEqual(await harness.validate(namedFiles("dry-run-project")), {
+      status: "valid",
+      projectSlug: "dry-run-project",
+      valid: true,
+      wouldCreateProject: true,
+    });
+    assert.equal(
+      await harness.database.findProjectBySlugForOrganization(
+        authorization.organizationId,
+        "dry-run-project",
+      ),
+      undefined,
+    );
+  });
+
+  it("creates exactly one project across concurrent first deploys", async () => {
+    const harness = await deploymentHarness();
+
+    const results = await Promise.all([
+      harness.install(namedFiles("concurrent")),
+      harness.install(namedFiles("concurrent")),
+    ]);
+
+    assert.ok(results.every((result) => result.status === "installed"));
+    assert.equal(
+      (await harness.database.listProjectsForOrganization(authorization.organizationId)).filter(
+        ({ slug }) => slug === "concurrent",
+      ).length,
+      1,
+    );
+  });
 });
+
+async function deploymentHarness() {
+  const database = createMemoryDatabase({ organizationIds: [authorization.organizationId] });
+  await enrollTestDaemon(database, authorization.organizationId);
+  const operations = createPublicOperations(createDatabasePublicOperationRepository(database), {
+    configurationForProject: (projectId) => new ProjectConfigurationStore(database, projectId),
+    validateBundleForOrganization: (organizationId, bundle) =>
+      validateHubBundleForOrganization(database, organizationId, bundle),
+    dispatchManualEvent: () => Promise.resolve(),
+  });
+  return {
+    database,
+    createProject: (slug: string) =>
+      database.createProject({
+        organizationId: authorization.organizationId,
+        name: slug,
+        slug,
+        createdByUserId: null,
+      }),
+    install: (bundle: readonly HubBundleFile[], projectSlug?: string) =>
+      operations.installConfiguration(authorization, {
+        ...(projectSlug === undefined ? {} : { projectSlug }),
+        files: bundle,
+      }),
+    validate: (bundle: readonly HubBundleFile[], projectSlug?: string) =>
+      operations.validateConfiguration(authorization, {
+        ...(projectSlug === undefined ? {} : { projectSlug }),
+        files: bundle,
+      }),
+  };
+}
+
+function namedFiles(name: string): HubBundleFile[] {
+  return files().map((file) =>
+    file.path === ".paseo/hub.yml"
+      ? Object.assign({}, file, { content: `name: ${name}\n${file.content}` })
+      : file,
+  );
+}
 
 async function installHarness(validator?: DaemonAgentConfigurationValidator) {
   const database = createMemoryDatabase({ organizationIds: [authorization.organizationId] });
@@ -225,6 +362,8 @@ async function installHarness(validator?: DaemonAgentConfigurationValidator) {
       },
       activate: (id) => store.activate(id),
     }),
+    validateBundleForOrganization: (organizationId, bundle) =>
+      validateHubBundleForOrganization(database, organizationId, bundle, validator),
     dispatchManualEvent: () => Promise.resolve(),
   });
   return {

--- a/src/public-operations/types.ts
+++ b/src/public-operations/types.ts
@@ -18,7 +18,7 @@ export interface InstallConfigurationInput {
 export type ValidateConfigurationInput = InstallConfigurationInput;
 
 export type ValidateConfigurationResult =
-  | { status: "valid"; projectSlug: string; valid: true; wouldCreateProject: boolean }
+  | { status: "valid"; projectSlug: string; valid: true; wouldCreateProject?: true }
   | { status: "project_not_found" }
   | { status: "invalid_bundle"; issues: readonly DomainIssue[] }
   | { status: "invalid_configuration"; issues: readonly DomainIssue[] }

--- a/src/public-operations/types.ts
+++ b/src/public-operations/types.ts
@@ -1,6 +1,7 @@
 import type { ApiKeyScope } from "../auth/api-key-contract.js";
 import type { HubBundleFile } from "../config/bundle.js";
 import type { TriggerRunRecord } from "../db/types.js";
+import type { DeploymentProjectResolution } from "../project-deployments/index.js";
 
 export interface PublicAuthorization {
   kind: "apiKey" | "cliCredential";
@@ -10,14 +11,14 @@ export interface PublicAuthorization {
 }
 
 export interface InstallConfigurationInput {
-  projectSlug: string;
+  projectSlug?: string | undefined;
   files: readonly HubBundleFile[];
 }
 
 export type ValidateConfigurationInput = InstallConfigurationInput;
 
 export type ValidateConfigurationResult =
-  | { status: "valid"; projectSlug: string; valid: true }
+  | { status: "valid"; projectSlug: string; valid: true; wouldCreateProject: boolean }
   | { status: "project_not_found" }
   | { status: "invalid_bundle"; issues: readonly DomainIssue[] }
   | { status: "invalid_configuration"; issues: readonly DomainIssue[] }
@@ -121,6 +122,12 @@ export interface PublicOperationRepository {
     organizationId: string,
     projectSlug: string,
   ): Promise<{ id: string; slug: string } | undefined>;
+  resolveDeploymentProject(input: {
+    organizationId: string;
+    explicitProjectSlug?: string | undefined;
+    bundleName?: string | undefined;
+    dryRun: boolean;
+  }): Promise<DeploymentProjectResolution>;
   findManualRun(
     providerEventReceiptId: string,
     trigger: string,
@@ -146,6 +153,10 @@ export interface PublicOperationCapabilities {
     }): Promise<{ id: string; validationErrors: unknown }>;
     activate(id: string): Promise<{ revision: { id: string; version: number } }>;
   };
+  validateBundleForOrganization(
+    organizationId: string,
+    files: readonly HubBundleFile[],
+  ): Promise<{ valid: true } | { valid: false; validationErrors: unknown }>;
   dispatchManualEvent(input: {
     organizationId: string;
     projectId: string;


### PR DESCRIPTION
Bundles can now name their project with an optional top-level `name` slug. Hub resolves or silently creates the deployment target server-side, so project setup is no longer a prerequisite and existing explicit-project clients keep their current behavior.

## Goals

- Make explicit `projectSlug`/CLI project selection authoritative.
- Resolve or create a bundle's named project within the authenticated organization.
- Fall back to the organization's `default` project and restore or create it when needed.
- Keep validation write-free while reporting whether deployment would create the project.
- Serialize concurrent first deployments so one project owns the slug.
- Preserve project identity in deployment responses and existing activity scopes.

## Non-goals

- Removing the dashboard's manual project controls.
- Migrating or deleting projects when a bundle name changes.
- Adding project-level permissions or changing CLI behavior.

## Why

Projects remain the deployment and provenance boundary, but they should not be a separate onboarding step. Resolution belongs at the server deployment boundary so every client gets the same precedence, organization scoping, dry-run behavior, and concurrency guarantees.

## Verification

- `npx vitest run src/config/bundle.test.ts src/project-deployments/index.test.ts src/public-operations/install-configuration.test.ts`
- `npx vitest run src/public-api/public-api.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run format`

## Risk surface

The main risk is target selection under missing, archived, or concurrently created project slugs. The resolver owns those states behind one interface and uses the database runtime lock; focused tests cover precedence, organization isolation, default restoration, dry-run no-write behavior, revision placement, and concurrent first deployments.
