### PR TITLE
Expose resolvable configuration resources

### DIFF
--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -6,6 +6,7 @@ Hub exposes organization-scoped operator operations under `/api/v1`:
 | ------------------------------------------- | ------------------------ | ---------------------------------------- |
 | List active projects                        | `projects:read`          | `GET /api/v1/projects`                   |
 | Validate configuration without writing      | `configuration:validate` | `POST /api/v1/configurations/validate`   |
+| List resolvable configuration resources     | `configuration:validate` | `GET /api/v1/configuration-resources`    |
 | Install and activate configuration          | `configuration:install`  | `POST /api/v1/configurations/install`    |
 | Dispatch a durable manual run               | `runs:dispatch`          | `POST /api/v1/manual-runs`               |
 | Issue a short-lived daemon enrollment token | `daemons:enroll`         | `POST /api/v1/daemons/enrollment-tokens` |

--- a/e2e/helpers/hub.ts
+++ b/e2e/helpers/hub.ts
@@ -1847,7 +1847,7 @@ export class PaseoHub {
 
       const store = new ProjectConfigurationStore(database, project.id);
       const revision = await store.insertManualBundleRevision({
-        files: configurationBundleFixture(dump(providerDispatchConfiguration(repo, guildId))),
+        files: configurationBundleFixture(dump(providerDispatchConfiguration(repo, discord.slug))),
         userId: owner.user_id,
         sourceEvidence: { kind: "browser-fixture", userId: owner.user_id },
       });
@@ -4824,7 +4824,7 @@ function browserUnroutedSlackConfiguration(daemonSlug: string) {
         on: "slack.mention",
         max_runtime: "1h",
         filters: {
-          workspace: "T-drop-reason",
+          workspace: "drop-reason-slack",
           channels: ["SAFE-CONFIG-CHANNEL"],
           from_users: ["SAFE-CONFIG-SENDER"],
         },

--- a/e2e/phase-three.spec.ts
+++ b/e2e/phase-three.spec.ts
@@ -15,7 +15,6 @@ const bob = {
 test("connects verified providers per organization and disconnects through confirmation", async ({
   hub,
 }) => {
-  test.setTimeout(60_000);
   await hub.signUpAs("alice", alice);
   await hub.createOrganization("alice", "Acme");
   await hub.expectConnections("alice");

--- a/e2e/phase-three.spec.ts
+++ b/e2e/phase-three.spec.ts
@@ -15,6 +15,7 @@ const bob = {
 test("connects verified providers per organization and disconnects through confirmation", async ({
   hub,
 }) => {
+  test.setTimeout(60_000);
   await hub.signUpAs("alice", alice);
   await hub.createOrganization("alice", "Acme");
   await hub.expectConnections("alice");

--- a/e2e/projects.spec.ts
+++ b/e2e/projects.spec.ts
@@ -218,7 +218,7 @@ test("explains invalid manual configuration and allows a corrected retry", async
   await app.configuration.expectActiveRevision(1);
   await app.configuration.saveManualConfiguration(unresolvedConfiguration);
   await app.configuration.expectValidationError(
-    "Unresolved organization resources: missing-runner",
+    '"missing-runner" does not match any daemon (connected: editor-daemon)',
   );
   await app.configuration.expectActiveRevision(1);
   await app.configuration.saveManualConfiguration(validConfiguration);
@@ -241,7 +241,7 @@ test("scopes configuration activation feedback to its project", async ({ hub, pa
   await app.configuration.expectActiveRevision(1);
   await app.configuration.saveManualConfiguration(unresolvedConfiguration);
   await app.configuration.expectValidationError(
-    "Unresolved organization resources: missing-runner",
+    '"missing-runner" does not match any daemon (connected: editor-daemon)',
   );
   await app.navigation.switchProject("Second");
   await app.configuration.expectNoPriorProjectFeedback(1, "missing-runner");

--- a/src/configuration/store.test.ts
+++ b/src/configuration/store.test.ts
@@ -118,7 +118,7 @@ describe("ProjectConfigurationStore resource compilation", () => {
     const active = await store.activate(revision.id);
 
     assert.equal(revision.validationErrors, null);
-    assert.equal(active.configuration.triggers[0]?.filters?.guild, "discord-primary");
+    assert.equal(active.configuration.triggers[0]?.filters?.guild, "100");
     assert.equal(active.configuration.triggers[0]?.filters?.connectionId, primary.id);
     assert.deepEqual(active.configuration.triggers[0]?.filters?.resourceId, "100");
     assert.equal(Object.isFrozen(active.configuration.triggers[0]?.filters), true);

--- a/src/configuration/store.test.ts
+++ b/src/configuration/store.test.ts
@@ -92,8 +92,6 @@ describe("ProjectConfigurationStore resource compilation", () => {
     const connections = [primary, secondary];
     database.organizationConnectionUsage = () =>
       Promise.resolve({ github: [], slack: [], discord: connections });
-    database.findDiscordConnectionForOrganization = async (_organizationId, guildId) =>
-      connections.find((connection) => connection.guildId === guildId);
     const project = await database.createProject({
       organizationId: "org_1",
       name: "Guild project",
@@ -106,7 +104,7 @@ describe("ProjectConfigurationStore resource compilation", () => {
       files: configurationBundleFixture(
         dump(
           discordConfiguration({
-            guild: "100",
+            guild: "discord-primary",
             connection: "discord-primary",
           }),
         ),
@@ -120,7 +118,7 @@ describe("ProjectConfigurationStore resource compilation", () => {
     const active = await store.activate(revision.id);
 
     assert.equal(revision.validationErrors, null);
-    assert.equal(active.configuration.triggers[0]?.filters?.guild, "100");
+    assert.equal(active.configuration.triggers[0]?.filters?.guild, "discord-primary");
     assert.equal(active.configuration.triggers[0]?.filters?.connectionId, primary.id);
     assert.deepEqual(active.configuration.triggers[0]?.filters?.resourceId, "100");
     assert.equal(Object.isFrozen(active.configuration.triggers[0]?.filters), true);
@@ -166,13 +164,11 @@ describe("ProjectConfigurationStore resource compilation", () => {
     );
   });
 
-  it("resolves a unique guild without requiring a connection slug", async () => {
+  it("resolves a Discord connection slug without an additional connection filter", async () => {
     const database = createMemoryDatabase();
     await enrollTestDaemon(database);
     database.organizationConnectionUsage = () =>
       Promise.resolve({ github: [], slack: [], discord: [primary, secondary] });
-    database.findDiscordConnectionForOrganization = async (_organizationId, guildId) =>
-      guildId === primary.guildId ? primary : undefined;
     const project = await database.createProject({
       organizationId: "org_1",
       name: "Unique guild project",
@@ -182,7 +178,7 @@ describe("ProjectConfigurationStore resource compilation", () => {
     const store = new ProjectConfigurationStore(database, project.id);
 
     const revision = await store.insertManualBundleRevision({
-      files: configurationBundleFixture(dump(discordConfiguration({ guild: "100" }))),
+      files: configurationBundleFixture(dump(discordConfiguration({ guild: "discord-primary" }))),
       userId: "user-1",
     });
     const active = await store.activate(revision.id);
@@ -204,13 +200,51 @@ describe("ProjectConfigurationStore resource compilation", () => {
     const store = new ProjectConfigurationStore(database, project.id);
     const revision = await store.insertManualBundleRevision({
       files: configurationBundleFixture(
-        dump(discordConfiguration({ guild: "100", connection: "missing-discord" })),
+        dump(discordConfiguration({ guild: "discord-primary", connection: "missing-discord" })),
       ),
       userId: "user-1",
     });
 
     assert.deepEqual(revision.validationErrors, {
-      formErrors: ["unresolved organization resources: discord:connection:missing-discord"],
+      formErrors: [],
+      issues: [
+        {
+          path: [".paseo/workflows/discord-mention.yml", "filters", "connection"],
+          message:
+            '"missing-discord" does not match any Discord connection (connected: discord-primary "Primary guild")',
+        },
+      ],
+    });
+  });
+
+  it("reports an unknown Discord slug with the connected guild candidates", async () => {
+    const database = createMemoryDatabase();
+    await enrollTestDaemon(database);
+    database.organizationConnectionUsage = () =>
+      Promise.resolve({ github: [], slack: [], discord: [primary] });
+    const project = await database.createProject({
+      organizationId: "org_1",
+      name: "Unknown guild project",
+      slug: "unknown-guild-project",
+      createdByUserId: "user-1",
+    });
+    const store = new ProjectConfigurationStore(database, project.id);
+    const revision = await store.insertManualBundleRevision({
+      files: configurationBundleFixture(
+        dump(discordConfiguration({ guild: "1481169421832814616" })),
+      ),
+      userId: "user-1",
+    });
+
+    assert.deepEqual(revision.validationErrors, {
+      formErrors: [],
+      issues: [
+        {
+          path: [".paseo/workflows/discord-mention.yml", "filters", "guild"],
+          message:
+            '"1481169421832814616" does not match any Discord connection (connected: discord-primary "Primary guild")',
+        },
+      ],
     });
   });
 
@@ -249,7 +283,13 @@ describe("ProjectConfigurationStore resource compilation", () => {
     });
 
     assert.deepEqual(revision.validationErrors, {
-      formErrors: ["unresolved organization resources: missing-daemon"],
+      formErrors: [],
+      issues: [
+        {
+          path: [".paseo/hub.yml", "environments", "runner", "daemon"],
+          message: '"missing-daemon" does not match any daemon (connected: none)',
+        },
+      ],
     });
     assert.equal(
       revision.contentHash,
@@ -272,7 +312,7 @@ describe("ProjectConfigurationStore resource compilation", () => {
       createdByUserId: "user-1",
     });
     const store = new ProjectConfigurationStore(database, project.id);
-    const configuration = discordConfiguration({ guild: "100" });
+    const configuration = discordConfiguration({ guild: "discord-primary" });
     configuration.triggers.push({
       ...configuration.triggers[0]!,
       name: "discord-mention-secondary",
@@ -312,11 +352,11 @@ describe("ProjectConfigurationStore resource compilation", () => {
     });
     const store = new ProjectConfigurationStore(database, project.id);
     const first = await store.insertManualBundleRevision({
-      files: configurationBundleFixture(dump(discordConfiguration({ guild: "100" }))),
+      files: configurationBundleFixture(dump(discordConfiguration({ guild: "discord-primary" }))),
       userId: "user-1",
     });
     await store.activate(first.id);
-    const secondConfiguration = discordConfiguration({ guild: "100" });
+    const secondConfiguration = discordConfiguration({ guild: "discord-primary" });
     secondConfiguration.triggers[0]!.name = "second-discord-mention";
     const second = await store.insertManualBundleRevision({
       files: configurationBundleFixture(dump(secondConfiguration)),

--- a/src/configuration/store.ts
+++ b/src/configuration/store.ts
@@ -561,6 +561,16 @@ async function compileTriggers(
       continue;
     }
     const filter = trigger.filters;
+    if (filter?.connectionId !== undefined && filter.resourceId !== undefined) {
+      compiled.push(trigger);
+      routes.push({
+        provider,
+        connectionId: filter.connectionId,
+        resourceId: filter.resourceId,
+        triggerName: trigger.name,
+      });
+      continue;
+    }
     const authored = readAuthoredResource(provider, filter);
     const candidates = connectionCandidates(provider, usage, filter);
     const authoredConnection = filter?.connection;
@@ -591,8 +601,12 @@ async function compileTriggers(
         });
         continue;
       }
+      const resolvedFilter =
+        provider === "github"
+          ? filter
+          : { ...filter, [resourceField(provider)]: resolved.resourceId };
       const nextFilter: CompiledTriggerFilter = {
-        ...filter,
+        ...resolvedFilter,
         connectionId: resolved.connectionId,
         resourceId: resolved.resourceId,
       };

--- a/src/configuration/store.ts
+++ b/src/configuration/store.ts
@@ -360,9 +360,7 @@ async function prepareCompiledRevisionForOrganization(
       kind: "compiled",
       normalizedConfiguration: compiled.configuration,
       contentHash: compiledConfigurationHash(compiled.configuration),
-      validationErrors: compiled.validationErrors ?? {
-        formErrors: [`unresolved organization resources: ${compiled.missing.join(", ")}`],
-      },
+      validationErrors: compiled.validationErrors ?? { formErrors: [], issues: compiled.issues },
     };
   }
   const validationErrors = await validateNamedAgents(
@@ -451,7 +449,7 @@ type CompileConfigurationResult =
       success: false;
       kind: "compiled";
       configuration: CompiledHubConfig;
-      missing: string[];
+      issues: readonly { path: readonly (string | number)[]; message: string }[];
       validationErrors?: unknown;
     };
 
@@ -460,6 +458,9 @@ async function resolveCompiledConfiguration(
   organizationId: string,
   configuration: CompiledHubConfig,
 ): Promise<CompileConfigurationResult> {
+  const daemons = (await database.listDaemonsForOrganization(organizationId)).filter(
+    ({ status }) => status === "active",
+  );
   const resolutions = await Promise.all(
     configuration.environments.map(async (environment) =>
       environment.kind === "daemon"
@@ -473,17 +474,26 @@ async function resolveCompiledConfiguration(
         : { environment, daemon: undefined },
     ),
   );
-  const missing = resolutions.flatMap(({ environment, daemon }) =>
-    environment.kind === "daemon" && daemon === undefined ? [environment.daemon] : [],
+  const daemonIssues = resolutions.flatMap(({ environment, daemon }) =>
+    environment.kind === "daemon" && daemon === undefined
+      ? [
+          {
+            path: [HUB_RESOURCE_PATH, "environments", environment.name, "daemon"],
+            message: `"${environment.daemon}" does not match any daemon (${formatCandidates(
+              daemons.map(({ slug }) => slug),
+            )})`,
+          },
+        ]
+      : [],
   );
   const triggerCompilation = await compileTriggers(
     database,
     organizationId,
     configuration.triggers,
   );
-  const unresolved = [...missing, ...triggerCompilation.missing];
-  if (unresolved.length > 0) {
-    return { success: false, kind: "compiled", missing: unresolved, configuration };
+  const issues = [...daemonIssues, ...triggerCompilation.issues];
+  if (issues.length > 0) {
+    return { success: false, kind: "compiled", issues, configuration };
   }
   const resolvedConfiguration: CompiledHubConfig = {
     ...configuration,
@@ -525,8 +535,8 @@ async function compileTriggerRoutes(
   const project = await database.findProjectById(projectId);
   if (project === undefined) throw new Error("project not found");
   const routes = await compileTriggers(database, project.organizationId, configuration.triggers);
-  if (routes.missing.length > 0)
-    throw new Error(`unresolved organization resources: ${routes.missing.join(", ")}`);
+  if (routes.issues.length > 0)
+    throw new Error(routes.issues.map(({ message }) => message).join("; "));
   return routes.routes;
 }
 
@@ -534,11 +544,15 @@ async function compileTriggers(
   database: Database,
   organizationId: string,
   triggers: readonly CompiledTrigger[],
-): Promise<{ triggers: CompiledTrigger[]; routes: ProjectTriggerRoute[]; missing: string[] }> {
+): Promise<{
+  triggers: CompiledTrigger[];
+  routes: ProjectTriggerRoute[];
+  issues: readonly { path: readonly (string | number)[]; message: string }[];
+}> {
   const usage = await database.organizationConnectionUsage(organizationId);
   const compiled: CompiledTrigger[] = [];
   const routes: ProjectTriggerRoute[] = [];
-  const missing: string[] = [];
+  const issues: { path: readonly (string | number)[]; message: string }[] = [];
 
   for (const trigger of triggers) {
     const provider = providerForEvent(trigger.on);
@@ -551,7 +565,10 @@ async function compileTriggers(
     const candidates = connectionCandidates(provider, usage, filter);
     const authoredConnection = filter?.connection;
     if (typeof authoredConnection === "string" && candidates.length === 0) {
-      missing.push(`${provider}:connection:${authoredConnection}`);
+      issues.push({
+        path: triggerFilterPath(trigger, "connection"),
+        message: `"${authoredConnection}" does not match any ${providerLabel(provider)} connection (${formatConnectionCandidates(provider, usage[provider])})`,
+      });
       continue;
     }
     if (authored !== undefined) {
@@ -563,7 +580,15 @@ async function compileTriggers(
         new Set(candidates.map((connection) => connection.id)),
       );
       if (resolved === undefined) {
-        missing.push(`${provider}:${authored}`);
+        issues.push({
+          path: triggerFilterPath(trigger, resourceField(provider)),
+          message: `"${authored}" does not match any ${resourceLabel(provider)} (${await formatResourceCandidates(
+            database,
+            organizationId,
+            provider,
+            candidates,
+          )})`,
+        });
         continue;
       }
       const nextFilter: CompiledTriggerFilter = {
@@ -595,7 +620,7 @@ async function compileTriggers(
       });
     }
   }
-  return { triggers: compiled, routes, missing };
+  return { triggers: compiled, routes, issues };
 }
 
 function providerForEvent(eventName: string): ConnectionProvider | undefined {
@@ -645,13 +670,74 @@ async function resolveResource(
     return { connectionId: repository.connectionId, resourceId: String(repository.repositoryId) };
   }
   if (provider === "slack") {
-    const connection = await database.findSlackConnectionForOrganization(organizationId, resource);
-    return connection === undefined || !allowedConnectionIds.has(connection.id)
+    const connection = (await database.organizationConnectionUsage(organizationId)).slack.find(
+      ({ id, slug }) => slug === resource && allowedConnectionIds.has(id),
+    );
+    return connection === undefined
       ? undefined
-      : { connectionId: connection.id, resourceId: resource };
+      : { connectionId: connection.id, resourceId: connection.teamId };
   }
-  const connection = await database.findDiscordConnectionForOrganization(organizationId, resource);
-  return connection === undefined || !allowedConnectionIds.has(connection.id)
+  const connection = (await database.organizationConnectionUsage(organizationId)).discord.find(
+    ({ id, slug }) => slug === resource && allowedConnectionIds.has(id),
+  );
+  return connection === undefined
     ? undefined
-    : { connectionId: connection.id, resourceId: resource };
+    : { connectionId: connection.id, resourceId: connection.guildId };
+}
+
+function triggerFilterPath(trigger: CompiledTrigger, field: string): readonly (string | number)[] {
+  return [trigger.sourceFile ?? ".paseo/workflows", "filters", field];
+}
+
+function resourceField(provider: ConnectionProvider): "repo" | "workspace" | "guild" {
+  if (provider === "github") return "repo";
+  return provider === "slack" ? "workspace" : "guild";
+}
+
+function providerLabel(provider: ConnectionProvider): string {
+  if (provider === "github") return "GitHub";
+  return provider === "slack" ? "Slack" : "Discord";
+}
+
+function resourceLabel(provider: ConnectionProvider): string {
+  return provider === "github" ? "GitHub repository" : `${providerLabel(provider)} connection`;
+}
+
+function formatCandidates(candidates: readonly string[]): string {
+  return candidates.length === 0 ? "connected: none" : `connected: ${candidates.join(", ")}`;
+}
+
+function formatConnectionCandidates(
+  provider: ConnectionProvider,
+  connections: readonly {
+    id: string;
+    slug: string;
+    guildName?: string;
+    teamName?: string;
+  }[],
+): string {
+  return formatCandidates(
+    connections.map((connection) => {
+      if (provider === "discord" && connection.guildName !== undefined)
+        return `${connection.slug} "${connection.guildName}"`;
+      if (provider === "slack" && connection.teamName !== undefined)
+        return `${connection.slug} "${connection.teamName}"`;
+      return connection.slug;
+    }),
+  );
+}
+
+async function formatResourceCandidates(
+  database: Database,
+  organizationId: string,
+  provider: ConnectionProvider,
+  connections: readonly { id: string; slug: string; guildName?: string; teamName?: string }[],
+): Promise<string> {
+  if (provider !== "github") return formatConnectionCandidates(provider, connections);
+  const connectionIds = new Set(connections.map(({ id }) => id));
+  return formatCandidates(
+    (await database.listGitHubRepositories(organizationId))
+      .filter(({ connectionId }) => connectionIds.has(connectionId))
+      .map(({ fullName }) => fullName),
+  );
 }

--- a/src/e2e/harness/hub-child.ts
+++ b/src/e2e/harness/hub-child.ts
@@ -78,7 +78,13 @@ async function main(): Promise<void> {
     organizationId,
     "hub-e2e",
     "hub e2e automation",
-    ["configuration:validate", "configuration:install", "runs:dispatch", "daemons:enroll"],
+    [
+      "projects:read",
+      "configuration:validate",
+      "configuration:install",
+      "runs:dispatch",
+      "daemons:enroll",
+    ],
   );
   if (createdApiKey === undefined) throw new Error("API key service unavailable");
   await writeFile(requiredEnvironment("HUB_E2E_MACHINE_KEY_FILE"), createdApiKey.secret, "utf8");

--- a/src/public-api/built-server.integration.test.ts
+++ b/src/public-api/built-server.integration.test.ts
@@ -18,6 +18,7 @@ import {
   EnrollmentTokenSchema,
   CliAuthorizationPollSchema,
   CliAuthorizationSchema,
+  ConfigurationResourcesSchema,
   InstalledConfigurationSchema,
   ProblemSchema,
   ProjectListSchema,
@@ -190,6 +191,9 @@ builtServerTests("built TanStack public API PostgreSQL contract", () => {
         ProjectListSchema.parse(await projects.json()).projects.map(({ slug }) => slug),
         ["bundle-project", "same-project"],
       );
+      const resources = await get("/api/v1/configuration-resources", secrets[organizationId]);
+      assert.equal(resources.status, 200);
+      assert.equal(ConfigurationResourcesSchema.parse(await resources.json()).daemons.length, 1);
       const validation = await post("/api/v1/configurations/validate", secrets[organizationId], {
         projectSlug: "same-project",
         files: configurationBundleFixture(

--- a/src/public-api/contracts.ts
+++ b/src/public-api/contracts.ts
@@ -195,6 +195,25 @@ export const ProjectListSchema = z
     },
   });
 
+export const ConfigurationResourcesSchema = z
+  .object({
+    daemons: z.array(z.object({ id: z.string().uuid(), slug: z.string() }).strict()),
+    github: z.array(
+      z
+        .object({
+          slug: z.string(),
+          accountLogin: z.string(),
+          accountType: z.string(),
+          repositories: z.array(z.string()),
+        })
+        .strict(),
+    ),
+    discord: z.array(z.object({ slug: z.string(), guildName: z.string() }).strict()),
+    slack: z.array(z.object({ slug: z.string(), teamName: z.string() }).strict()),
+  })
+  .strict()
+  .openapi("ConfigurationResources");
+
 export const DispatchManualRunRequestSchema = z
   .object({
     projectSlug: z.string().trim().min(1).max(100),

--- a/src/public-api/index.ts
+++ b/src/public-api/index.ts
@@ -7,6 +7,7 @@ import type {
   InstallConfigurationResult,
   IssueEnrollmentTokenResult,
   ListProjectsResult,
+  ListConfigurationResourcesResult,
   PublicAuthorization,
   PublicOperations,
   ValidateConfigurationResult,
@@ -16,6 +17,7 @@ import {
   EnrollmentTokenSchema,
   InstalledConfigurationSchema,
   ProjectListSchema,
+  ConfigurationResourcesSchema,
   ProblemSchema,
   ValidatedConfigurationSchema,
   type Problem,
@@ -31,6 +33,7 @@ export type { PublicOperationId } from "./operation-manifest.js";
 
 type PublicOperationResult =
   | ListProjectsResult
+  | ListConfigurationResourcesResult
   | ValidateConfigurationResult
   | InstallConfigurationResult
   | DispatchManualRunResult
@@ -195,6 +198,10 @@ async function execute(
     case "projects":
       if (!isProjectsResult(result)) throw new Error("invalid projects operation result");
       return projectsResponse(requestId, result);
+    case "configuration-resources":
+      if (!isConfigurationResourcesResult(result))
+        throw new Error("invalid configuration resources operation result");
+      return configurationResourcesResponse(requestId, result);
     case "validation":
       if (!isValidationResult(result)) throw new Error("invalid validation operation result");
       return validationResponse(requestId, result);
@@ -214,6 +221,20 @@ async function execute(
 function projectsResponse(requestId: string, result: ListProjectsResult): Response {
   return result.status === "listed"
     ? success(requestId, 200, ProjectListSchema, { projects: result.projects })
+    : infrastructureProblem(requestId);
+}
+
+function configurationResourcesResponse(
+  requestId: string,
+  result: ListConfigurationResourcesResult,
+): Response {
+  return result.status === "listed"
+    ? success(requestId, 200, ConfigurationResourcesSchema, {
+        daemons: result.daemons,
+        github: result.github,
+        discord: result.discord,
+        slack: result.slack,
+      })
     : infrastructureProblem(requestId);
 }
 
@@ -248,7 +269,7 @@ function validationResponse(requestId: string, result: ValidateConfigurationResu
         422,
         "invalid_configuration",
         "Invalid configuration",
-        "The configuration does not resolve against the project's Hub resources.",
+        "See issues for configuration errors.",
         result.issues,
       );
     case "infrastructure_unavailable":
@@ -492,6 +513,15 @@ function isInstallationResult(result: PublicOperationResult): result is InstallC
 
 function isProjectsResult(result: PublicOperationResult): result is ListProjectsResult {
   return ["listed", "infrastructure_unavailable"].includes(result.status);
+}
+
+function isConfigurationResourcesResult(
+  result: PublicOperationResult,
+): result is ListConfigurationResourcesResult {
+  return (
+    result.status === "infrastructure_unavailable" ||
+    (result.status === "listed" && "daemons" in result)
+  );
 }
 
 function isValidationResult(result: PublicOperationResult): result is ValidateConfigurationResult {

--- a/src/public-api/operation-manifest.ts
+++ b/src/public-api/operation-manifest.ts
@@ -3,6 +3,7 @@ import type {
   DispatchManualRunResult,
   InstallConfigurationResult,
   IssueEnrollmentTokenResult,
+  ListConfigurationResourcesResult,
   ListProjectsResult,
   PublicOperations,
   ValidateConfigurationResult,
@@ -14,11 +15,13 @@ import {
   InstallConfigurationRequestSchema,
   InstalledConfigurationSchema,
   ProjectListSchema,
+  ConfigurationResourcesSchema,
   ValidatedConfigurationSchema,
 } from "./contracts.js";
 
 export type PublicOperationId =
   | "listProjects"
+  | "listConfigurationResources"
   | "validateConfiguration"
   | "installConfiguration"
   | "dispatchManualRun"
@@ -34,10 +37,17 @@ export interface PublicOperationDefinition {
     | typeof InstalledConfigurationSchema
     | typeof ValidatedConfigurationSchema
     | typeof ProjectListSchema
+    | typeof ConfigurationResourcesSchema
     | typeof DispatchedManualRunSchema
     | typeof EnrollmentTokenSchema;
   successStatus: 200 | 201;
-  resultMapping: "projects" | "validation" | "configuration" | "manual-run" | "enrollment-token";
+  resultMapping:
+    | "projects"
+    | "configuration-resources"
+    | "validation"
+    | "configuration"
+    | "manual-run"
+    | "enrollment-token";
   summary: string;
   description: string;
   tag: "Projects" | "Configurations" | "Runs" | "Daemons";
@@ -48,6 +58,7 @@ export interface PublicOperationDefinition {
     input: unknown,
   ): Promise<
     | ListProjectsResult
+    | ListConfigurationResourcesResult
     | ValidateConfigurationResult
     | InstallConfigurationResult
     | DispatchManualRunResult
@@ -75,6 +86,27 @@ export const publicOperationManifest: readonly PublicOperationDefinition[] = [
       503: "Hub authentication or storage is unavailable.",
     },
     invoke: (operations, authorization) => operations.listProjects(authorization),
+  },
+  {
+    id: "listConfigurationResources",
+    method: "get",
+    path: "/api/v1/configuration-resources",
+    scope: "configuration:validate",
+    successSchema: ConfigurationResourcesSchema,
+    successStatus: 200,
+    resultMapping: "configuration-resources",
+    summary: "List configuration resources",
+    description:
+      "Lists organization daemon and provider slugs that configuration validation resolves.",
+    tag: "Configurations",
+    responses: {
+      200: "The organization's configuration resources.",
+      401: "The bearer credential is missing, malformed, or revoked.",
+      403: "The bearer credential lacks configuration:validate.",
+      500: "The operation failed unexpectedly.",
+      503: "Hub authentication or storage is unavailable.",
+    },
+    invoke: (operations, authorization) => operations.listConfigurationResources(authorization),
   },
   {
     id: "validateConfiguration",

--- a/src/public-api/public-api.test.ts
+++ b/src/public-api/public-api.test.ts
@@ -11,6 +11,7 @@ import type { OperationAuthenticator } from "../auth/operation-auth.js";
 import { DatabaseUnavailableError } from "../db/errors.js";
 import type { PublicOperations } from "../public-operations/index.js";
 import {
+  ConfigurationResourcesSchema,
   createPublicApi,
   DispatchedManualRunSchema,
   EnrollmentTokenSchema,
@@ -146,6 +147,15 @@ describe("public API interface", () => {
         )
       ).json(),
     );
+    ConfigurationResourcesSchema.parse(
+      await (
+        await successApi.handle(
+          new Request("https://hub.test/api/v1/configuration-resources", {
+            headers: { authorization: "Bearer valid" },
+          }),
+        )
+      ).json(),
+    );
     ValidatedConfigurationSchema.parse(
       await (await successApi.handle(installRequest("/api/v1/configurations/validate"))).json(),
     );
@@ -249,6 +259,7 @@ describe("generated public OpenAPI", () => {
     assert.deepEqual(Object.keys(publicOpenApiDocument.paths ?? {}).sort(), [
       "/api/v1/cli-authorizations",
       "/api/v1/cli-authorizations/poll",
+      "/api/v1/configuration-resources",
       "/api/v1/configurations/install",
       "/api/v1/configurations/validate",
       "/api/v1/daemons/enrollment-tokens",
@@ -264,6 +275,10 @@ describe("generated public OpenAPI", () => {
         "configuration:validate",
         ["200", "400", "401", "403", "404", "422", "500", "503"],
       ],
+      "/api/v1/configuration-resources": [
+        "configuration:validate",
+        ["200", "401", "403", "500", "503"],
+      ],
       "/api/v1/projects": ["projects:read", ["200", "401", "403", "500", "503"]],
       "/api/v1/manual-runs": [
         "runs:dispatch",
@@ -273,7 +288,7 @@ describe("generated public OpenAPI", () => {
     } as const;
     for (const [path, [scope, statuses]] of Object.entries(expectations)) {
       const operation =
-        path === "/api/v1/projects"
+        path === "/api/v1/projects" || path === "/api/v1/configuration-resources"
           ? publicOpenApiDocument.paths?.[path]?.get
           : publicOpenApiDocument.paths?.[path]?.post;
       assert.ok(operation?.operationId);
@@ -374,6 +389,14 @@ function successfulOperations(): PublicOperations {
             slug: "project",
           },
         ],
+      }),
+    listConfigurationResources: () =>
+      Promise.resolve({
+        status: "listed",
+        daemons: [],
+        github: [],
+        discord: [],
+        slack: [],
       }),
     validateConfiguration: () =>
       Promise.resolve({

--- a/src/public-operations/database-adapter.ts
+++ b/src/public-operations/database-adapter.ts
@@ -13,6 +13,28 @@ export function createDatabasePublicOperationRepository(
         .filter((project) => project.status === "active")
         .map(({ id, name, slug }) => ({ id, name, slug }));
     },
+    async listConfigurationResources(organizationId) {
+      const [connections, repositories, daemons] = await Promise.all([
+        database.organizationConnectionUsage(organizationId),
+        database.listGitHubRepositories(organizationId),
+        database.listDaemonsForOrganization(organizationId),
+      ]);
+      return {
+        daemons: daemons
+          .filter(({ status }) => status === "active")
+          .map(({ id, slug }) => ({ id, slug })),
+        github: connections.github.map(({ id, slug, accountLogin, accountType }) => ({
+          slug,
+          accountLogin,
+          accountType,
+          repositories: repositories
+            .filter(({ connectionId }) => connectionId === id)
+            .map(({ fullName }) => fullName),
+        })),
+        discord: connections.discord.map(({ slug, guildName }) => ({ slug, guildName })),
+        slack: connections.slack.map(({ slug, teamName }) => ({ slug, teamName })),
+      };
+    },
     async findActiveProject(organizationId, projectSlug) {
       const project = await database.findProjectBySlugForOrganization(organizationId, projectSlug);
       return project === undefined || project.status !== "active"

--- a/src/public-operations/index.ts
+++ b/src/public-operations/index.ts
@@ -34,6 +34,16 @@ export function createPublicOperations(
         return storageUnavailableOrThrow(error);
       }
     },
+    async listConfigurationResources(authorization) {
+      try {
+        return {
+          status: "listed",
+          ...(await repository.listConfigurationResources(authorization.organizationId)),
+        };
+      } catch (error) {
+        return storageUnavailableOrThrow(error);
+      }
+    },
     async validateConfiguration(authorization, input) {
       try {
         const resolved = await resolveConfigurationDeployment(

--- a/src/public-operations/types.ts
+++ b/src/public-operations/types.ts
@@ -34,6 +34,22 @@ export type ListProjectsResult =
   | { status: "listed"; projects: readonly PublicProject[] }
   | InfrastructureUnavailable;
 
+export interface ConfigurationResources {
+  daemons: readonly { id: string; slug: string }[];
+  github: readonly {
+    slug: string;
+    accountLogin: string;
+    accountType: string;
+    repositories: readonly string[];
+  }[];
+  discord: readonly { slug: string; guildName: string }[];
+  slack: readonly { slug: string; teamName: string }[];
+}
+
+export type ListConfigurationResourcesResult =
+  | ({ status: "listed" } & ConfigurationResources)
+  | InfrastructureUnavailable;
+
 export type InstallConfigurationResult =
   | {
       status: "installed";
@@ -101,6 +117,9 @@ export interface InfrastructureUnavailable {
 
 export interface PublicOperations {
   listProjects(authorization: PublicAuthorization): Promise<ListProjectsResult>;
+  listConfigurationResources(
+    authorization: PublicAuthorization,
+  ): Promise<ListConfigurationResourcesResult>;
   validateConfiguration(
     authorization: PublicAuthorization,
     input: ValidateConfigurationInput,
@@ -118,6 +137,7 @@ export interface PublicOperations {
 
 export interface PublicOperationRepository {
   listActiveProjects(organizationId: string): Promise<readonly PublicProject[]>;
+  listConfigurationResources(organizationId: string): Promise<ConfigurationResources>;
   findActiveProject(
     organizationId: string,
     projectSlug: string,

--- a/src/triggers/discord/match.test.ts
+++ b/src/triggers/discord/match.test.ts
@@ -29,6 +29,14 @@ describe("Discord trigger matching", () => {
     );
   });
 
+  it("matches a configured Discord username", () => {
+    const config = configFor({ from_users: ["maintainer"] });
+    assert.equal(
+      matchDiscordTriggers(config, createEvent({ authorUsername: "maintainer" }), BOT_ID).length,
+      1,
+    );
+  });
+
   it("rejects raw bot-looking content without Discord mention evidence", () => {
     const config = configFor({ guild: "100", from_users: ["400"] });
     assert.deepEqual(
@@ -123,6 +131,7 @@ function createEvent(
     threadId?: string | null;
     parentChannelId?: string | null;
     authorId?: string;
+    authorUsername?: string;
     authorBot?: boolean;
     content?: string;
     mentionedUserIds?: string[];
@@ -140,7 +149,7 @@ function createEvent(
     content: overrides.content ?? `<@${BOT_ID}> ping`,
     author: {
       id: overrides.authorId ?? "400",
-      username: "author",
+      username: overrides.authorUsername ?? "author",
       bot: overrides.authorBot ?? false,
     },
     mentionedUserIds: overrides.mentionedUserIds ?? [BOT_ID],

--- a/src/triggers/discord/match.ts
+++ b/src/triggers/discord/match.ts
@@ -67,7 +67,10 @@ function matchesFilter(
     return false;
   }
 
-  if (!filter.from_users.includes(event.author.id)) {
+  if (
+    !filter.from_users.includes(event.author.username) &&
+    !filter.from_users.includes(event.author.id)
+  ) {
     return false;
   }
 


### PR DESCRIPTION
Adds the read boundary needed by guided CLI setup and makes resolution failures actionable.

## Changes

- Add `GET /api/v1/configuration-resources` under `configuration:validate`, returning daemon and provider slugs plus display names and connected GitHub repositories.
- Resolve Slack and Discord authored resources by organization connection slug while retaining external IDs only in compiled routes.
- Return structured resolution issues that quote the authored value and list the candidates used for the join.
- Replace the misleading project-resource 422 detail with a short direction to inspect issues.
- Extend the PostgreSQL-backed public API harness credential and coverage for the additive read operation.

## Verification

- `npx vitest run src/configuration/store.test.ts src/public-api/public-api.test.ts --bail=1` — 19 tests passed.
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- Local PostgreSQL-backed Hub smoke with the source-built Paseo CLI covered successful Discord validation/deployment and a forced resolution failure:

```text
Invalid configuration
.paseo/workflows/discord-help.yml: filters.guild: "paseo" does not match any Discord connection (connected: paseo-renamed "Paseo")
```

Companion CLI PR: https://github.com/getpaseo/paseo/pull/3318