### PR TITLE
Fix Slack username allowlists

### DIFF
--- a/e2e/helpers/hub.ts
+++ b/e2e/helpers/hub.ts
@@ -468,7 +468,7 @@ export class PaseoHub {
          (organization_id, team_id, slug, team_name, bot_user_id, bot_access_token, scopes, connected_by_user_id)
        values ($1, 'T-drop-reason', 'drop-reason-slack', 'Drop Reason Slack', 'UBOT',
                'PRIVATE-SLACK-TOKEN',
-               '["app_mentions:read","channels:history","chat:write","files:read","groups:history","reactions:write"]'::jsonb, $2)`,
+               '["app_mentions:read","channels:history","chat:write","files:read","groups:history","reactions:write","users:read"]'::jsonb, $2)`,
       [target.organization_id, target.user_id],
     );
     const database = await createDatabase(this.primary.databaseUrl);

--- a/slack-app-manifest.yml
+++ b/slack-app-manifest.yml
@@ -15,6 +15,7 @@ oauth_config:
       - files:read
       - groups:history
       - reactions:write
+      - users:read
 settings:
   event_subscriptions:
     request_url: https://hub.example.com/api/integrations/slack/events

--- a/src/providers/slack/client.test.ts
+++ b/src/providers/slack/client.test.ts
@@ -18,7 +18,7 @@ describe("Slack connection client", () => {
           access_token: "xoxb-token",
           bot_user_id: "UBOT",
           scope:
-            "app_mentions:read,channels:history,chat:write,files:read,groups:history,reactions:write",
+            "app_mentions:read,channels:history,chat:write,files:read,groups:history,reactions:write,users:read",
           team: { id: "T1", name: "Acme" },
         });
       },
@@ -29,7 +29,7 @@ describe("Slack connection client", () => {
     assert.equal(authorization.searchParams.get("state"), "random-state");
     assert.equal(
       authorization.searchParams.get("scope"),
-      "app_mentions:read,channels:history,chat:write,files:read,groups:history,reactions:write",
+      "app_mentions:read,channels:history,chat:write,files:read,groups:history,reactions:write,users:read",
     );
     assert.equal(
       authorization.searchParams.get("redirect_uri"),
@@ -47,6 +47,7 @@ describe("Slack connection client", () => {
         "files:read",
         "groups:history",
         "reactions:write",
+        "users:read",
       ],
     });
     assert.equal(exchangeBody?.get("client_secret"), "secret-1");

--- a/src/providers/slack/client.ts
+++ b/src/providers/slack/client.ts
@@ -7,6 +7,7 @@ export const SLACK_REQUIRED_BOT_SCOPES = [
   "files:read",
   "groups:history",
   "reactions:write",
+  "users:read",
 ] as const;
 
 const SlackOAuthResponseSchema = z

--- a/src/providers/slack/registration.test.ts
+++ b/src/providers/slack/registration.test.ts
@@ -124,6 +124,7 @@ describe("Slack registration", () => {
           "files:read",
           "groups:history",
           "reactions:write",
+          "users:read",
         ],
       });
     const requests: string[] = [];

--- a/src/triggers/slack/client.test.ts
+++ b/src/triggers/slack/client.test.ts
@@ -3,6 +3,26 @@ import { describe, it } from "vitest";
 import { createSlackBotClient } from "./client.js";
 
 describe("Slack Web API client", () => {
+  it("looks up an authored username with the workspace bot token", async () => {
+    let request: { url: string; method: string | undefined } | undefined;
+    const client = createSlackBotClient({
+      tokenForWorkspace: () => Promise.resolve("xoxb-secret"),
+      fetch: async (input, init) => {
+        request = { url: requestUrl(input), method: init?.method };
+        return Response.json({ ok: true, user: { name: "operator" } });
+      },
+    });
+
+    assert.equal(
+      await client.lookupUserName?.({ organizationId: "org-1", teamId: "T1", userId: "U1" }),
+      "operator",
+    );
+    assert.deepEqual(request, {
+      url: "https://slack.com/api/users.info",
+      method: "POST",
+    });
+  });
+
   it("resolves the workspace token internally and checks Slack's ok field", async () => {
     const requests: Array<{ url: string; authorization: string | null; body: unknown }> = [];
     const authorities: Array<[string, string]> = [];

--- a/src/triggers/slack/client.ts
+++ b/src/triggers/slack/client.ts
@@ -34,6 +34,9 @@ const SlackFileInfoSchema = SlackApiResponseSchema.extend({
     })
     .optional(),
 });
+const SlackUserInfoSchema = SlackApiResponseSchema.extend({
+  user: z.object({ name: z.string().min(1).max(255) }).optional(),
+});
 const SLACK_API_TIMEOUT_MS = 10_000;
 const SLACK_THREAD_REPLIES_MAX_PAGES = 10;
 
@@ -86,6 +89,11 @@ export interface SlackBotClient {
     threadTs: string;
     beforeTs: string;
   }): Promise<SlackThreadReadResult>;
+  lookupUserName?(input: {
+    organizationId: string;
+    teamId: string;
+    userId: string;
+  }): Promise<string | undefined>;
   downloadAttachment?(input: {
     organizationId: string;
     teamId: string;
@@ -255,6 +263,18 @@ export function createSlackBotClient(options: {
     });
   }
 
+  async function lookupUserName(input: {
+    organizationId: string;
+    teamId: string;
+    userId: string;
+  }): Promise<string | undefined> {
+    const result = SlackUserInfoSchema.parse(
+      await callJson(input.organizationId, input.teamId, "users.info", { user: input.userId }),
+    );
+    if (!result.ok) throw new Error(`Slack API ${result.error ?? "unknown_error"}`);
+    return result.user?.name;
+  }
+
   return {
     sendMessage: (input) =>
       call(input.organizationId, input.teamId, "chat.postMessage", {
@@ -275,6 +295,7 @@ export function createSlackBotClient(options: {
         name: input.name,
       }),
     readThreadMessages,
+    lookupUserName,
     downloadAttachment,
   };
 }

--- a/src/triggers/slack/events.ts
+++ b/src/triggers/slack/events.ts
@@ -65,7 +65,7 @@ export const NormalizedSlackMentionEventSchema = z.object({
   eventTs: SlackTimestampSchema,
   eventTime: z.number().int().nonnegative(),
   content: z.string(),
-  author: z.object({ id: SlackIdSchema }),
+  author: z.object({ id: SlackIdSchema, username: z.string().min(1).max(255).optional() }),
   createdAt: z.string(),
   attachments: z.array(SlackAttachmentMetadataSchema).default([]),
 });

--- a/src/triggers/slack/match.test.ts
+++ b/src/triggers/slack/match.test.ts
@@ -5,6 +5,14 @@ import type { NormalizedSlackMentionEvent } from "./events.js";
 import { matchSlackTriggers, readSlackPromptBody } from "./match.js";
 
 describe("Slack trigger matching", () => {
+  it("allows exact, case-sensitive Slack usernames as well as user IDs", () => {
+    const config = configForUsers(["operator", "U2"]);
+
+    assert.equal(matchSlackTriggers(config, mention({ username: "operator" }), "UBOT").length, 1);
+    assert.equal(matchSlackTriggers(config, mention({ username: "Operator" }), "UBOT").length, 0);
+    assert.equal(matchSlackTriggers(config, mention({ authorId: "U2" }), "UBOT").length, 1);
+  });
+
   it("requires the compiled trigger filters and bot mention", () => {
     const config = compileHubConfig({
       environments: [{ name: "runner", kind: "daemon", daemon: "runner", cwd: "/repo" }],
@@ -50,7 +58,33 @@ describe("Slack trigger matching", () => {
   });
 });
 
-function mention(): NormalizedSlackMentionEvent {
+function configForUsers(fromUsers: string[]) {
+  return compileHubConfig({
+    environments: [{ name: "runner", kind: "daemon", daemon: "runner", cwd: "/repo" }],
+    triggers: [
+      {
+        name: "slack-run",
+        on: "slack.mention",
+        max_runtime: "2h",
+        filters: { workspace: "T1", channels: ["C1"], from_users: fromUsers },
+        steps: [
+          {
+            id: "run",
+            environment: "runner",
+            max_runtime: "1h",
+            idle_timeout: "5m",
+            agent: { provider: "opencode", mode: "default" },
+            prompt: [{ text: "Run the request" }],
+          },
+        ],
+      },
+    ],
+  });
+}
+
+function mention(
+  overrides: { authorId?: string; username?: string } = {},
+): NormalizedSlackMentionEvent {
   return {
     type: "mention",
     id: "Ev1",
@@ -62,7 +96,10 @@ function mention(): NormalizedSlackMentionEvent {
     eventTs: "1700000000.000001",
     eventTime: 1_700_000_001,
     content: "hello <@UBOT> run tests",
-    author: { id: "U1" },
+    author: {
+      id: overrides.authorId ?? "U1",
+      ...(overrides.username === undefined ? {} : { username: overrides.username }),
+    },
     createdAt: new Date(1_700_000_000_000).toISOString(),
     attachments: [],
   };

--- a/src/triggers/slack/match.ts
+++ b/src/triggers/slack/match.ts
@@ -33,7 +33,11 @@ function matchesFilters(
   connectionId?: string | null,
 ): boolean {
   if (filters === undefined || !event.content.includes(`<@${botUserId}>`)) return false;
-  if (filters.from_users === undefined || !filters.from_users.includes(event.author.id))
+  if (
+    filters.from_users === undefined ||
+    (!filters.from_users.includes(event.author.id) &&
+      (event.author.username === undefined || !filters.from_users.includes(event.author.username)))
+  )
     return false;
   if (filters.connectionId !== undefined && filters.connectionId !== connectionId) return false;
   const workspace = readString(filters, "workspace");

--- a/src/triggers/slack/provider.test.ts
+++ b/src/triggers/slack/provider.test.ts
@@ -13,6 +13,32 @@ import { createSlackTriggerProvider } from "./provider.js";
 import { isAcceptedTriggerProviderMatch } from "../index.js";
 
 describe("Slack Phase 1 trigger provider", () => {
+  it("resolves the authored Slack username once before matching", async () => {
+    const database = createMemoryDatabase();
+    const { project, revision, store } = await createActiveProjectConfiguration(
+      database,
+      usernameConfiguration(),
+      { organizationId: "org-1" },
+    );
+    const client = new RecordingSlackClient({ username: "operator" });
+    const provider = createSlackTriggerProvider({
+      configurationStoreForProject: () => store,
+      botUserIdForWorkspace: () => Promise.resolve("UBOT"),
+      client,
+    });
+
+    const matched = await provider.match(external(project.id, revision.id));
+    assert.notEqual(typeof matched, "string");
+    assert.deepEqual(client.userLookups, ["U1"]);
+
+    const rejected = await createSlackTriggerProvider({
+      configurationStoreForProject: () => store,
+      botUserIdForWorkspace: () => Promise.resolve("UBOT"),
+      client: new RecordingSlackClient({ username: "someone-else" }),
+    }).match(external(project.id, revision.id));
+    assert.equal(rejected, "trigger_filters_rejected");
+  });
+
   it("normalizes typed inputs identically at the provider boundary", async () => {
     const database = createMemoryDatabase();
     const { project, revision, store } = await createActiveProjectConfiguration(
@@ -637,6 +663,19 @@ function configuration() {
   };
 }
 
+function usernameConfiguration() {
+  const base = configuration();
+  return {
+    ...base,
+    triggers: [
+      {
+        ...base.triggers[0]!,
+        filters: { ...base.triggers[0]!.filters, from_users: ["operator"] },
+      },
+    ],
+  };
+}
+
 function inputConfiguration() {
   const base = configuration();
   const trigger = base.triggers[0]!;
@@ -734,6 +773,7 @@ class RecordingSlackClient implements SlackBotClient {
     content: string;
   }> = [];
   threadReads: string[] = [];
+  userLookups: string[] = [];
   private readonly threadMessages: SlackThreadMessage[];
 
   constructor(
@@ -743,6 +783,7 @@ class RecordingSlackClient implements SlackBotClient {
       failMessages?: boolean;
       failThreadRead?: boolean;
       threadComplete?: boolean;
+      username?: string;
     } = {},
   ) {
     this.threadMessages = options.threadMessages ?? [];
@@ -765,6 +806,10 @@ class RecordingSlackClient implements SlackBotClient {
   removeReaction(input: { organizationId: string; teamId: string; name: string }): Promise<void> {
     this.reactions.push(`${input.organizationId}:${input.teamId}:remove:${input.name}`);
     return Promise.resolve();
+  }
+  lookupUserName(input: { userId: string }): Promise<string | undefined> {
+    this.userLookups.push(input.userId);
+    return Promise.resolve(this.options.username);
   }
   readThreadMessages(input: {
     organizationId: string;

--- a/src/triggers/slack/provider.ts
+++ b/src/triggers/slack/provider.ts
@@ -1,4 +1,5 @@
 import type { ProjectConfigurationStore } from "../../configuration/store.js";
+import type { CompiledTriggerConfig } from "../../config/index.js";
 import type {
   AttachmentCapabilityRegistry,
   AttachmentDescriptor,
@@ -118,9 +119,12 @@ export function createSlackTriggerProvider(options: {
       if (stored === undefined) return "configuration_unavailable";
       if (!stored.configuration.triggers.some((candidate) => candidate.on === trigger.source))
         return "no_trigger_for_source";
+      const event = needsSlackUsername(stored.configuration.triggers, rawEvent.author.id)
+        ? await enrichSlackAuthor(rawEvent, trigger.organizationId, options.client)
+        : rawEvent;
       const matchedTriggers = matchSlackTriggers(
         stored.configuration,
-        rawEvent,
+        event,
         botUserId,
         trigger.connectionId,
       );
@@ -258,6 +262,40 @@ export function createSlackTriggerProvider(options: {
       return reactionState;
     },
   };
+}
+
+async function enrichSlackAuthor(
+  event: NormalizedSlackMentionEvent,
+  organizationId: string,
+  client: SlackBotClient,
+): Promise<NormalizedSlackMentionEvent> {
+  if (client.lookupUserName === undefined) return event;
+  try {
+    const username = await client.lookupUserName({
+      organizationId,
+      teamId: event.teamId,
+      userId: event.author.id,
+    });
+    return username === undefined ? event : { ...event, author: { ...event.author, username } };
+  } catch (error) {
+    logger.warn(
+      { err: error, teamId: event.teamId, userId: event.author.id },
+      "Slack author username lookup failed",
+    );
+    return event;
+  }
+}
+
+function needsSlackUsername(
+  triggers: readonly Pick<CompiledTriggerConfig, "on" | "filters">[],
+  authorId: string,
+): boolean {
+  return triggers.some(
+    (candidate) =>
+      candidate.on === "slack.mention" &&
+      candidate.filters?.from_users !== undefined &&
+      !candidate.filters.from_users.includes(authorId),
+  );
 }
 
 async function removeReactionForPhase(


### PR DESCRIPTION
Slack `from_users` filters now accept the authored Slack username as well as the existing Slack user ID. Username comparison is exact and case-sensitive.

## Goals

- Make the CLI-authored Slack username allowlist trigger correctly.
- Preserve existing Slack user-ID allowlists and fail closed when username lookup is unavailable.
- Bound identity hydration to one `users.info` request per matching attempt, outside pure filter matching.

## Non-goals

- Change Slack mention parsing or user-ID semantics.
- Add display-name matching or case folding.

## Why

Slack `app_mention` events contain an author user ID, not a username, so matching only the event payload could not honor a username configured by the CLI. Hub now requests the Slack account `name` through `users.info` when an ID allowlist cannot decide the match. This adds the `users:read` bot scope; existing installations need to reconnect to grant it.

## Verification

- `npx vitest run src/triggers/slack/match.test.ts src/triggers/slack/provider.test.ts src/triggers/slack/client.test.ts src/providers/slack/client.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run format`

## Risk surface

Slack connections without the new `users:read` scope are intentionally marked as needing reconnection. If a username lookup fails after a valid grant, only ID allowlists can match, preserving fail-closed authorization.