### PR TITLE
Start Hub without a preconfigured auth secret

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,8 +2,8 @@
 # DATABASE_URL=postgres://postgres:postgres@localhost:5432/paseo_hub
 # PASEO_HUB_DATA_DIR=.dev/paseo-hub
 PASEO_HUB_APP_URL=http://localhost:3000
-# Generate once per deployment and persist it across Hub restarts.
-PASEO_HUB_AUTH_SECRET=
+# Optional advanced override. Hub otherwise generates and stores a stable secret in its database.
+# PASEO_HUB_AUTH_SECRET=
 # Admission and organization provisioning policy. These defaults keep a new instance closed
 # until its owner is bootstrapped and members are invited.
 PASEO_REGISTRATION_MODE=invite_only

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ npm install
 npm run dev
 ```
 
-Open <http://localhost:3000>. Hub stores the embedded database in `.dev/paseo-hub` and keeps it across restarts. Set `PASEO_HUB_DATA_DIR` to use a different directory, or set `DATABASE_URL` to use PostgreSQL instead:
+Open <http://localhost:3000>. Hub stores the embedded database and its generated authentication secret in `.dev/paseo-hub` and keeps both across restarts. Set `PASEO_HUB_DATA_DIR` to use a different directory, or set `DATABASE_URL` to use PostgreSQL instead:
 
 ```sh
 DATABASE_URL=postgres://postgres:postgres@localhost:5432/paseo_hub npm run dev
@@ -59,11 +59,13 @@ Set these values in `.env`:
 
 ```dotenv
 PASEO_HUB_APP_URL=https://hub.example.com
-PASEO_HUB_AUTH_SECRET=replace-with-the-output-of-openssl-rand-hex-32
 PASEO_BOOTSTRAP_ORGANIZATION=My organization
 PASEO_BOOTSTRAP_OWNER_EMAIL=me@example.com
 PASEO_BOOTSTRAP_OWNER_PASSWORD=replace-with-a-temporary-password
 ```
+
+Hub generates and stores its authentication secret in the database. Advanced deployments may set
+`PASEO_HUB_AUTH_SECRET` to override it without replacing the stored secret.
 
 Billing is optional: leave `STRIPE_SECRET_KEY` unset and Hub runs with no billing surface at all. See [docs/billing.md](docs/billing.md).
 

--- a/drizzle/0034_wandering_roxanne_simpson.sql
+++ b/drizzle/0034_wandering_roxanne_simpson.sql
@@ -1,0 +1,6 @@
+CREATE TABLE "runtime_configuration" (
+	"singleton" boolean PRIMARY KEY DEFAULT true NOT NULL,
+	"auth_secret" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "runtime_configuration_singleton_check" CHECK ("runtime_configuration"."singleton")
+);

--- a/drizzle/meta/0034_snapshot.json
+++ b/drizzle/meta/0034_snapshot.json
@@ -1,0 +1,5030 @@
+{
+  "id": "4f16e247-192e-4fa9-834a-db4f24759893",
+  "prevId": "a3e663d2-f414-44b5-ae30-f9b1b43f484d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_executions": {
+      "name": "agent_executions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "machine_id": {
+          "name": "machine_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_execution_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_by_agent_at": {
+          "name": "completed_by_agent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deadline_at": {
+          "name": "deadline_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idle_deadline_at": {
+          "name": "idle_deadline_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_context": {
+          "name": "trigger_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_context": {
+          "name": "output_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reaction_state": {
+          "name": "reaction_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "configuration_revision_id": {
+          "name": "configuration_revision_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completion_token_hash": {
+          "name": "completion_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_claimed_at": {
+          "name": "reply_claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_claim_count": {
+          "name": "reply_claim_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_emissions": {
+          "name": "output_emissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "output_delivery_attempts": {
+          "name": "output_delivery_attempts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "launch_intent": {
+          "name": "launch_intent",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daemon_id": {
+          "name": "daemon_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daemon_agent_id": {
+          "name": "daemon_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_step_run_id": {
+          "name": "workflow_step_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hub_action": {
+          "name": "hub_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hub_action_completed_at": {
+          "name": "hub_action_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hub_action_ready_at": {
+          "name": "hub_action_ready_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hub_action_acknowledgements": {
+          "name": "hub_action_acknowledgements",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"terminal_at\":null,\"idle_at\":null,\"finish_execution_call\":null}'::jsonb"
+        }
+      },
+      "indexes": {
+        "agent_executions_machine_id_idx": {
+          "name": "agent_executions_machine_id_idx",
+          "columns": [
+            {
+              "expression": "machine_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_executions_project_started_at_idx": {
+          "name": "agent_executions_project_started_at_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_executions_status_idx": {
+          "name": "agent_executions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_executions_project_organization_fk": {
+          "name": "agent_executions_project_organization_fk",
+          "tableFrom": "agent_executions",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id", "organization_id"],
+          "columnsTo": ["id", "organization_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agent_executions_revision_project_organization_fk": {
+          "name": "agent_executions_revision_project_organization_fk",
+          "tableFrom": "agent_executions",
+          "tableTo": "project_configuration_revisions",
+          "columnsFrom": ["configuration_revision_id", "project_id", "organization_id"],
+          "columnsTo": ["id", "project_id", "organization_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agent_executions_machine_organization_fk": {
+          "name": "agent_executions_machine_organization_fk",
+          "tableFrom": "agent_executions",
+          "tableTo": "machines",
+          "columnsFrom": ["machine_id", "organization_id"],
+          "columnsTo": ["id", "org_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agent_executions_daemon_organization_fk": {
+          "name": "agent_executions_daemon_organization_fk",
+          "tableFrom": "agent_executions",
+          "tableTo": "daemons",
+          "columnsFrom": ["daemon_id", "organization_id"],
+          "columnsTo": ["id", "organization_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agent_executions_workflow_step_run_fk": {
+          "name": "agent_executions_workflow_step_run_fk",
+          "tableFrom": "agent_executions",
+          "tableTo": "workflow_step_runs",
+          "columnsFrom": ["workflow_step_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agent_executions_hub_action_check": {
+          "name": "agent_executions_hub_action_check",
+          "value": "\"agent_executions\".\"hub_action\" is null or \"agent_executions\".\"hub_action\" in ('interrupt', 'archive')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.attachment_capabilities": {
+      "name": "attachment_capabilities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider_event_receipt_id": {
+          "name": "provider_event_receipt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locator": {
+          "name": "locator",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "attachment_capabilities_receipt_provider_source_unique": {
+          "name": "attachment_capabilities_receipt_provider_source_unique",
+          "columns": [
+            {
+              "expression": "provider_event_receipt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attachment_capabilities_receipt_idx": {
+          "name": "attachment_capabilities_receipt_idx",
+          "columns": [
+            {
+              "expression": "provider_event_receipt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "attachment_capabilities_organization_id_organization_id_fk": {
+          "name": "attachment_capabilities_organization_id_organization_id_fk",
+          "tableFrom": "attachment_capabilities",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attachment_capabilities_receipt_organization_fk": {
+          "name": "attachment_capabilities_receipt_organization_fk",
+          "tableFrom": "attachment_capabilities",
+          "tableTo": "provider_event_receipts",
+          "columnsFrom": ["provider_event_receipt_id", "organization_id"],
+          "columnsTo": ["id", "organization_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "attachment_capabilities_provider_check": {
+          "name": "attachment_capabilities_provider_check",
+          "value": "\"attachment_capabilities\".\"provider\" in ('slack', 'discord')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_kind": {
+          "name": "actor_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_identity": {
+          "name": "actor_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_events_organization_created_idx": {
+          "name": "audit_events_organization_created_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_events_project_created_idx": {
+          "name": "audit_events_project_created_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_events_organization_id_organization_id_fk": {
+          "name": "audit_events_organization_id_organization_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audit_events_project_id_projects_id_fk": {
+          "name": "audit_events_project_id_projects_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audit_events_project_organization_fk": {
+          "name": "audit_events_project_organization_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id", "organization_id"],
+          "columnsTo": ["id", "organization_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "audit_events_actor_kind_check": {
+          "name": "audit_events_actor_kind_check",
+          "value": "\"audit_events\".\"actor_kind\" in ('user', 'github', 'system')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.billing_plan_prices": {
+      "name": "billing_plan_prices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lookup_key": {
+          "name": "lookup_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interval": {
+          "name": "interval",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_amount": {
+          "name": "unit_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "billing_plan_prices_plan_id_idx": {
+          "name": "billing_plan_prices_plan_id_idx",
+          "columns": [
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "billing_plan_prices_plan_id_billing_plans_id_fk": {
+          "name": "billing_plan_prices_plan_id_billing_plans_id_fk",
+          "tableFrom": "billing_plan_prices",
+          "tableTo": "billing_plans",
+          "columnsFrom": ["plan_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "billing_plan_prices_interval_check": {
+          "name": "billing_plan_prices_interval_check",
+          "value": "\"billing_plan_prices\".\"interval\" in ('monthly', 'annual')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.billing_plans": {
+      "name": "billing_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template": {
+          "name": "template",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_hash": {
+          "name": "template_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "marketing": {
+          "name": "marketing",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "billing_plans_slug_unique": {
+          "name": "billing_plans_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cli_authorizations": {
+      "name": "cli_authorizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_verifier": {
+          "name": "device_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code_verifier": {
+          "name": "user_code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint_verifier": {
+          "name": "fingerprint_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "poll_interval_seconds": {
+          "name": "poll_interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_poll_at": {
+          "name": "next_poll_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_organization_id": {
+          "name": "approved_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by_user_id": {
+          "name": "approved_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "cli_authorizations_fingerprint_idx": {
+          "name": "cli_authorizations_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "fingerprint_verifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cli_authorizations_status_expiry_idx": {
+          "name": "cli_authorizations_status_expiry_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cli_authorizations_device_verifier_unique": {
+          "name": "cli_authorizations_device_verifier_unique",
+          "nullsNotDistinct": false,
+          "columns": ["device_verifier"]
+        },
+        "cli_authorizations_user_code_verifier_unique": {
+          "name": "cli_authorizations_user_code_verifier_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_code_verifier"]
+        },
+        "cli_authorizations_credential_id_unique": {
+          "name": "cli_authorizations_credential_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["credential_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "cli_authorizations_status_check": {
+          "name": "cli_authorizations_status_check",
+          "value": "\"cli_authorizations\".\"status\" in ('pending', 'approved', 'denied', 'expired', 'disclosed')"
+        },
+        "cli_authorizations_poll_interval_check": {
+          "name": "cli_authorizations_poll_interval_check",
+          "value": "\"cli_authorizations\".\"poll_interval_seconds\" >= 5"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.configuration_sync_attempts": {
+      "name": "configuration_sync_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_connection_id": {
+          "name": "github_connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_repository_id": {
+          "name": "github_repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_delivery_id": {
+          "name": "webhook_delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "configuration_sync_attempts_project_created_idx": {
+          "name": "configuration_sync_attempts_project_created_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "configuration_sync_attempts_project_organization_fk": {
+          "name": "configuration_sync_attempts_project_organization_fk",
+          "tableFrom": "configuration_sync_attempts",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id", "organization_id"],
+          "columnsTo": ["id", "organization_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "configuration_sync_attempts_github_connection_organization_fk": {
+          "name": "configuration_sync_attempts_github_connection_organization_fk",
+          "tableFrom": "configuration_sync_attempts",
+          "tableTo": "github_connections",
+          "columnsFrom": ["github_connection_id", "organization_id"],
+          "columnsTo": ["id", "organization_id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daemon_enrollment_tokens": {
+      "name": "daemon_enrollment_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "verifier": {
+          "name": "verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_by_api_key_id": {
+          "name": "issued_by_api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_by_cli_credential_id": {
+          "name": "issued_by_cli_credential_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "daemon_enrollment_tokens_issued_by_cli_credential_id_organization_cli_credentials_id_fk": {
+          "name": "daemon_enrollment_tokens_issued_by_cli_credential_id_organization_cli_credentials_id_fk",
+          "tableFrom": "daemon_enrollment_tokens",
+          "tableTo": "organization_cli_credentials",
+          "columnsFrom": ["issued_by_cli_credential_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "daemon_enrollment_tokens_verifier_unique": {
+          "name": "daemon_enrollment_tokens_verifier_unique",
+          "nullsNotDistinct": false,
+          "columns": ["verifier"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daemons": {
+      "name": "daemons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enrollment_verifier": {
+          "name": "enrollment_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "machine_id": {
+          "name": "machine_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "daemon_public_key": {
+          "name": "daemon_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_verifier": {
+          "name": "credential_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registered_by_api_key_id": {
+          "name": "registered_by_api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registered_by_cli_credential_id": {
+          "name": "registered_by_cli_credential_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "presence": {
+          "name": "presence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'offline'"
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disconnected_at": {
+          "name": "disconnected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "daemons_machine_id_unique": {
+          "name": "daemons_machine_id_unique",
+          "columns": [
+            {
+              "expression": "machine_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "daemons_id_organization_unique": {
+          "name": "daemons_id_organization_unique",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "daemons_organization_slug_unique": {
+          "name": "daemons_organization_slug_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daemons_registered_by_cli_credential_id_organization_cli_credentials_id_fk": {
+          "name": "daemons_registered_by_cli_credential_id_organization_cli_credentials_id_fk",
+          "tableFrom": "daemons",
+          "tableTo": "organization_cli_credentials",
+          "columnsFrom": ["registered_by_cli_credential_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "daemons_machine_organization_fk": {
+          "name": "daemons_machine_organization_fk",
+          "tableFrom": "daemons",
+          "tableTo": "machines",
+          "columnsFrom": ["machine_id", "organization_id"],
+          "columnsTo": ["id", "org_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "daemons_idempotency_key_unique": {
+          "name": "daemons_idempotency_key_unique",
+          "nullsNotDistinct": false,
+          "columns": ["idempotency_key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "daemons_status_check": {
+          "name": "daemons_status_check",
+          "value": "\"daemons\".\"status\" in ('active', 'revoked')"
+        },
+        "daemons_presence_check": {
+          "name": "daemons_presence_check",
+          "value": "\"daemons\".\"presence\" in ('offline', 'connected')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.discord_connections": {
+      "name": "discord_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guild_name": {
+          "name": "guild_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connected_by_user_id": {
+          "name": "connected_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discord_connections_id_organization_unique": {
+          "name": "discord_connections_id_organization_unique",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discord_connections_organization_slug_unique": {
+          "name": "discord_connections_organization_slug_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_connections_organization_id_organization_id_fk": {
+          "name": "discord_connections_organization_id_organization_id_fk",
+          "tableFrom": "discord_connections",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "discord_connections_connected_by_user_id_user_id_fk": {
+          "name": "discord_connections_connected_by_user_id_user_id_fk",
+          "tableFrom": "discord_connections",
+          "tableTo": "user",
+          "columnsFrom": ["connected_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discord_connections_guild_id_unique": {
+          "name": "discord_connections_guild_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["guild_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entitlement_changes": {
+      "name": "entitlement_changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "before": {
+          "name": "before",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after": {
+          "name": "after",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "entitlement_changes_organization_created_idx": {
+          "name": "entitlement_changes_organization_created_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entitlement_changes_organization_id_organization_id_fk": {
+          "name": "entitlement_changes_organization_id_organization_id_fk",
+          "tableFrom": "entitlement_changes",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "entitlement_changes_source_check": {
+          "name": "entitlement_changes_source_check",
+          "value": "\"entitlement_changes\".\"source\" in ('provisioning', 'plan_stamp', 'override')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.github_connections": {
+      "name": "github_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connected_by_user_id": {
+          "name": "connected_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "github_connections_installation_unique": {
+          "name": "github_connections_installation_unique",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_connections_organization_slug_unique": {
+          "name": "github_connections_organization_slug_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_connections_id_organization_unique": {
+          "name": "github_connections_id_organization_unique",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_connections_organization_idx": {
+          "name": "github_connections_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_connections_organization_id_organization_id_fk": {
+          "name": "github_connections_organization_id_organization_id_fk",
+          "tableFrom": "github_connections",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_connections_connected_by_user_id_user_id_fk": {
+          "name": "github_connections_connected_by_user_id_user_id_fk",
+          "tableFrom": "github_connections",
+          "tableTo": "user",
+          "columnsFrom": ["connected_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "github_connections_installation_id_unique": {
+          "name": "github_connections_installation_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["installation_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "github_connections_status_check": {
+          "name": "github_connections_status_check",
+          "value": "\"github_connections\".\"status\" in ('active', 'suspended')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.github_repositories": {
+      "name": "github_repositories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discovered_at": {
+          "name": "discovered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_repositories_connection_repository_unique": {
+          "name": "github_repositories_connection_repository_unique",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_repositories_organization_idx": {
+          "name": "github_repositories_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_repositories_connection_organization_fk": {
+          "name": "github_repositories_connection_organization_fk",
+          "tableFrom": "github_repositories",
+          "tableTo": "github_connections",
+          "columnsFrom": ["connection_id", "organization_id"],
+          "columnsTo": ["id", "organization_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instance_bootstrap": {
+      "name": "instance_bootstrap",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "instance_bootstrap_organization_id_organization_id_fk": {
+          "name": "instance_bootstrap_organization_id_organization_id_fk",
+          "tableFrom": "instance_bootstrap",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "instance_bootstrap_owner_user_id_user_id_fk": {
+          "name": "instance_bootstrap_owner_user_id_user_id_fk",
+          "tableFrom": "instance_bootstrap",
+          "tableTo": "user",
+          "columnsFrom": ["owner_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "instance_bootstrap_completion_check": {
+          "name": "instance_bootstrap_completion_check",
+          "value": "\"instance_bootstrap\".\"completed_at\" is null or (\"instance_bootstrap\".\"organization_id\" is not null and \"instance_bootstrap\".\"owner_user_id\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitations_organization_status_idx": {
+          "name": "invitations_organization_status_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitations_pending_organization_email_unique": {
+          "name": "invitations_pending_organization_email_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invitation\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": ["inviter_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "invitations_role_check": {
+          "name": "invitations_role_check",
+          "value": "\"invitation\".\"role\" in ('admin', 'member')"
+        },
+        "invitations_status_check": {
+          "name": "invitations_status_check",
+          "value": "\"invitation\".\"status\" in ('pending', 'accepted', 'rejected', 'canceled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.machines": {
+      "name": "machines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "machine_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "terminated_at": {
+          "name": "terminated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shutdown_reason": {
+          "name": "shutdown_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_name": {
+          "name": "trigger_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_context": {
+          "name": "trigger_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "specs": {
+          "name": "specs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "machines_id_org_id_unique": {
+          "name": "machines_id_org_id_unique",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "machines_org_id_idx": {
+          "name": "machines_org_id_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "machines_status_idx": {
+          "name": "machines_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "members_organization_user_unique": {
+          "name": "members_organization_user_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "members_user_id_idx": {
+          "name": "members_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "members_organization_id_idx": {
+          "name": "members_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "members_role_check": {
+          "name": "members_role_check",
+          "value": "\"member\".\"role\" in ('owner', 'admin', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_api_keys": {
+      "name": "organization_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verifier": {
+          "name": "verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "organization_api_keys_prefix_unique": {
+          "name": "organization_api_keys_prefix_unique",
+          "columns": [
+            {
+              "expression": "prefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organization_api_keys_organization_created_idx": {
+          "name": "organization_api_keys_organization_created_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_api_keys_organization_id_organization_id_fk": {
+          "name": "organization_api_keys_organization_id_organization_id_fk",
+          "tableFrom": "organization_api_keys",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_api_keys_created_by_user_id_user_id_fk": {
+          "name": "organization_api_keys_created_by_user_id_user_id_fk",
+          "tableFrom": "organization_api_keys",
+          "tableTo": "user",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "organization_api_keys_scopes_check": {
+          "name": "organization_api_keys_scopes_check",
+          "value": "\"organization_api_keys\".\"scopes\" <@ ARRAY['projects:read', 'configuration:validate', 'configuration:install', 'runs:dispatch', 'daemons:enroll']::text[] and cardinality(\"organization_api_keys\".\"scopes\") > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_cli_credentials": {
+      "name": "organization_cli_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verifier": {
+          "name": "verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "organization_cli_credentials_prefix_unique": {
+          "name": "organization_cli_credentials_prefix_unique",
+          "columns": [
+            {
+              "expression": "prefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organization_cli_credentials_organization_created_idx": {
+          "name": "organization_cli_credentials_organization_created_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_cli_credentials_organization_id_organization_id_fk": {
+          "name": "organization_cli_credentials_organization_id_organization_id_fk",
+          "tableFrom": "organization_cli_credentials",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_cli_credentials_created_by_user_id_user_id_fk": {
+          "name": "organization_cli_credentials_created_by_user_id_user_id_fk",
+          "tableFrom": "organization_cli_credentials",
+          "tableTo": "user",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_connection_attempts": {
+      "name": "organization_connection_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_verifier": {
+          "name": "state_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "return_route": {
+          "name": "return_route",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_external_id": {
+          "name": "candidate_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pkce_verifier": {
+          "name": "pkce_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "organization_connection_attempts_expiry_idx": {
+          "name": "organization_connection_attempts_expiry_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_connection_attempts_organization_id_organization_id_fk": {
+          "name": "organization_connection_attempts_organization_id_organization_id_fk",
+          "tableFrom": "organization_connection_attempts",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_connection_attempts_user_id_user_id_fk": {
+          "name": "organization_connection_attempts_user_id_user_id_fk",
+          "tableFrom": "organization_connection_attempts",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_connection_attempts_session_id_session_id_fk": {
+          "name": "organization_connection_attempts_session_id_session_id_fk",
+          "tableFrom": "organization_connection_attempts",
+          "tableTo": "session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_connection_attempts_state_verifier_unique": {
+          "name": "organization_connection_attempts_state_verifier_unique",
+          "nullsNotDistinct": false,
+          "columns": ["state_verifier"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "organization_connection_attempts_provider_check": {
+          "name": "organization_connection_attempts_provider_check",
+          "value": "\"organization_connection_attempts\".\"provider\" in ('github', 'discord', 'slack')"
+        },
+        "organization_connection_attempts_phase_check": {
+          "name": "organization_connection_attempts_phase_check",
+          "value": "\"organization_connection_attempts\".\"phase\" in ('github_setup', 'github_user_authorization', 'discord_authorization', 'slack_authorization')"
+        },
+        "organization_connection_attempts_shape_check": {
+          "name": "organization_connection_attempts_shape_check",
+          "value": "(\"organization_connection_attempts\".\"phase\" = 'github_setup' and \"organization_connection_attempts\".\"provider\" = 'github' and \"organization_connection_attempts\".\"candidate_external_id\" is null and \"organization_connection_attempts\".\"pkce_verifier\" is null)\n        or (\"organization_connection_attempts\".\"phase\" = 'github_user_authorization' and \"organization_connection_attempts\".\"provider\" = 'github' and \"organization_connection_attempts\".\"candidate_external_id\" is not null and (\"organization_connection_attempts\".\"pkce_verifier\" is not null or \"organization_connection_attempts\".\"consumed_at\" is not null))\n        or (\"organization_connection_attempts\".\"phase\" = 'discord_authorization' and \"organization_connection_attempts\".\"provider\" = 'discord' and \"organization_connection_attempts\".\"candidate_external_id\" is null and \"organization_connection_attempts\".\"pkce_verifier\" is null)\n        or (\"organization_connection_attempts\".\"phase\" = 'slack_authorization' and \"organization_connection_attempts\".\"provider\" = 'slack' and \"organization_connection_attempts\".\"candidate_external_id\" is null and \"organization_connection_attempts\".\"pkce_verifier\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_entitlements": {
+      "name": "organization_entitlements",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "granted": {
+          "name": "granted",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overrides": {
+          "name": "overrides",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_version": {
+          "name": "plan_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stamped_at": {
+          "name": "stamped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_entitlements_organization_id_organization_id_fk": {
+          "name": "organization_entitlements_organization_id_organization_id_fk",
+          "tableFrom": "organization_entitlements",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_subscriptions": {
+      "name": "organization_subscriptions",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_subscriptions_organization_id_organization_id_fk": {
+          "name": "organization_subscriptions_organization_id_organization_id_fk",
+          "tableFrom": "organization_subscriptions",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_subscriptions_stripe_subscription_id_unique": {
+          "name": "organization_subscriptions_stripe_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["stripe_subscription_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_usage": {
+      "name": "organization_usage",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meter": {
+          "name": "meter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used": {
+          "name": "used",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "organization_usage_organization_meter_idx": {
+          "name": "organization_usage_organization_meter_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "meter",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_usage_organization_id_organization_id_fk": {
+          "name": "organization_usage_organization_id_organization_id_fk",
+          "tableFrom": "organization_usage",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "organization_usage_organization_id_meter_period_start_pk": {
+          "name": "organization_usage_organization_id_meter_period_start_pk",
+          "columns": ["organization_id", "meter", "period_start"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "organization_usage_used_non_negative": {
+          "name": "organization_usage_used_non_negative",
+          "value": "\"organization_usage\".\"used\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_configuration_revisions": {
+      "name": "project_configuration_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_evidence": {
+          "name": "source_evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_yaml": {
+          "name": "raw_yaml",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "normalized_configuration": {
+          "name": "normalized_configuration",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "validation_errors": {
+          "name": "validation_errors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_repository_id": {
+          "name": "github_repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_repository_full_name": {
+          "name": "github_repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_commit_sha": {
+          "name": "github_commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_commit_url": {
+          "name": "github_commit_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_ref": {
+          "name": "github_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_webhook_delivery_id": {
+          "name": "github_webhook_delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_sender": {
+          "name": "github_sender",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_author": {
+          "name": "github_author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_committer": {
+          "name": "github_committer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "validated_at": {
+          "name": "validated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "project_configuration_revisions_project_version_unique": {
+          "name": "project_configuration_revisions_project_version_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_configuration_revisions_id_project_organization_unique": {
+          "name": "project_configuration_revisions_id_project_organization_unique",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_configuration_revisions_project_created_idx": {
+          "name": "project_configuration_revisions_project_created_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_configuration_revisions_created_by_user_id_user_id_fk": {
+          "name": "project_configuration_revisions_created_by_user_id_user_id_fk",
+          "tableFrom": "project_configuration_revisions",
+          "tableTo": "user",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "project_configuration_revisions_project_organization_fk": {
+          "name": "project_configuration_revisions_project_organization_fk",
+          "tableFrom": "project_configuration_revisions",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id", "organization_id"],
+          "columnsTo": ["id", "organization_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "project_configuration_revisions_source_kind_check": {
+          "name": "project_configuration_revisions_source_kind_check",
+          "value": "\"project_configuration_revisions\".\"source_kind\" in ('github', 'manual')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_configuration_sources": {
+      "name": "project_configuration_sources",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_connection_id": {
+          "name": "github_connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_repository_id": {
+          "name": "github_repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_repository_full_name": {
+          "name": "github_repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_default_branch": {
+          "name": "github_default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "automatic_deployment_enabled": {
+          "name": "automatic_deployment_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "selected_by_user_id": {
+          "name": "selected_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_configuration_sources_selected_by_user_id_user_id_fk": {
+          "name": "project_configuration_sources_selected_by_user_id_user_id_fk",
+          "tableFrom": "project_configuration_sources",
+          "tableTo": "user",
+          "columnsFrom": ["selected_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "project_configuration_sources_project_organization_fk": {
+          "name": "project_configuration_sources_project_organization_fk",
+          "tableFrom": "project_configuration_sources",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id", "organization_id"],
+          "columnsTo": ["id", "organization_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_configuration_sources_github_connection_organization_fk": {
+          "name": "project_configuration_sources_github_connection_organization_fk",
+          "tableFrom": "project_configuration_sources",
+          "tableTo": "github_connections",
+          "columnsFrom": ["github_connection_id", "organization_id"],
+          "columnsTo": ["id", "organization_id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "project_configuration_sources_authority_shape_check": {
+          "name": "project_configuration_sources_authority_shape_check",
+          "value": "(\"project_configuration_sources\".\"kind\" = 'manual' and \"project_configuration_sources\".\"github_connection_id\" is null and \"project_configuration_sources\".\"github_repository_id\" is null and not \"project_configuration_sources\".\"automatic_deployment_enabled\") or (\"project_configuration_sources\".\"kind\" = 'github' and \"project_configuration_sources\".\"github_connection_id\" is not null and \"project_configuration_sources\".\"github_repository_id\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_trigger_routes": {
+      "name": "project_trigger_routes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configuration_revision_id": {
+          "name": "configuration_revision_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_name": {
+          "name": "trigger_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "project_trigger_routes_shape_unique": {
+          "name": "project_trigger_routes_shape_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "configuration_revision_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trigger_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_trigger_routes_resource_idx": {
+          "name": "project_trigger_routes_resource_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_trigger_routes_project_organization_fk": {
+          "name": "project_trigger_routes_project_organization_fk",
+          "tableFrom": "project_trigger_routes",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id", "organization_id"],
+          "columnsTo": ["id", "organization_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_trigger_routes_revision_project_organization_fk": {
+          "name": "project_trigger_routes_revision_project_organization_fk",
+          "tableFrom": "project_trigger_routes",
+          "tableTo": "project_configuration_revisions",
+          "columnsFrom": ["configuration_revision_id", "project_id", "organization_id"],
+          "columnsTo": ["id", "project_id", "organization_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "project_trigger_routes_provider_check": {
+          "name": "project_trigger_routes_provider_check",
+          "value": "\"project_trigger_routes\".\"provider\" in ('github', 'slack', 'discord')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_configuration_revision_id": {
+          "name": "active_configuration_revision_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "projects_organization_slug_unique": {
+          "name": "projects_organization_slug_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_id_organization_unique": {
+          "name": "projects_id_organization_unique",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_organization_status_idx": {
+          "name": "projects_organization_status_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_organization_id_organization_id_fk": {
+          "name": "projects_organization_id_organization_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "projects_created_by_user_id_user_id_fk": {
+          "name": "projects_created_by_user_id_user_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "user",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "projects_active_configuration_revision_id_project_configuration_revisions_id_fk": {
+          "name": "projects_active_configuration_revision_id_project_configuration_revisions_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "project_configuration_revisions",
+          "columnsFrom": ["active_configuration_revision_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "projects_status_check": {
+          "name": "projects_status_check",
+          "value": "\"projects\".\"status\" in ('active', 'archived')"
+        },
+        "projects_archive_shape_check": {
+          "name": "projects_archive_shape_check",
+          "value": "(\"projects\".\"status\" = 'active' and \"projects\".\"archived_at\" is null) or (\"projects\".\"status\" = 'archived' and \"projects\".\"archived_at\" is not null and \"projects\".\"active_configuration_revision_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.provider_event_receipts": {
+      "name": "provider_event_receipts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signature_hash": {
+          "name": "signature_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "dropped_reason": {
+          "name": "dropped_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_routes": {
+          "name": "accepted_routes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "provider_event_receipts_id_organization_unique": {
+          "name": "provider_event_receipts_id_organization_unique",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "provider_event_receipts_organization_delivery_unique": {
+          "name": "provider_event_receipts_organization_delivery_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "delivery_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "provider_event_receipts_signature_unique": {
+          "name": "provider_event_receipts_signature_unique",
+          "columns": [
+            {
+              "expression": "signature_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"provider_event_receipts\".\"signature_hash\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "provider_event_receipts_organization_received_idx": {
+          "name": "provider_event_receipts_organization_received_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "provider_event_receipts_resource_idx": {
+          "name": "provider_event_receipts_resource_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provider_event_receipts_organization_id_organization_id_fk": {
+          "name": "provider_event_receipts_organization_id_organization_id_fk",
+          "tableFrom": "provider_event_receipts",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "provider_event_receipts_provider_check": {
+          "name": "provider_event_receipts_provider_check",
+          "value": "\"provider_event_receipts\".\"provider\" in ('github', 'slack', 'discord', 'manual')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.runtime_configuration": {
+      "name": "runtime_configuration",
+      "schema": "",
+      "columns": {
+        "singleton": {
+          "name": "singleton",
+          "type": "boolean",
+          "primaryKey": true,
+          "notNull": true,
+          "default": true
+        },
+        "auth_secret": {
+          "name": "auth_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "runtime_configuration_singleton_check": {
+          "name": "runtime_configuration_singleton_check",
+          "value": "\"runtime_configuration\".\"singleton\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sessions_active_organization_id_idx": {
+          "name": "sessions_active_organization_id_idx",
+          "columns": [
+            {
+              "expression": "active_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_connections": {
+      "name": "slack_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_name": {
+          "name": "team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_access_token": {
+          "name": "bot_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "connected_by_user_id": {
+          "name": "connected_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "slack_connections_id_organization_unique": {
+          "name": "slack_connections_id_organization_unique",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "slack_connections_organization_slug_unique": {
+          "name": "slack_connections_organization_slug_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_connections_organization_id_organization_id_fk": {
+          "name": "slack_connections_organization_id_organization_id_fk",
+          "tableFrom": "slack_connections",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slack_connections_connected_by_user_id_user_id_fk": {
+          "name": "slack_connections_connected_by_user_id_user_id_fk",
+          "tableFrom": "slack_connections",
+          "tableTo": "user",
+          "columnsFrom": ["connected_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "slack_connections_team_id_unique": {
+          "name": "slack_connections_team_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["team_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trigger_runs": {
+      "name": "trigger_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configuration_revision_id": {
+          "name": "configuration_revision_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_event_receipt_id": {
+          "name": "provider_event_receipt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configured_trigger_name": {
+          "name": "configured_trigger_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'accepted'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_prompt": {
+          "name": "raw_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inputs": {
+          "name": "inputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "values": {
+          "name": "values",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "trigger_context": {
+          "name": "trigger_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "output_context": {
+          "name": "output_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "deadline_at": {
+          "name": "deadline_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deadline_kind": {
+          "name": "deadline_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reaction_state": {
+          "name": "reaction_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_notification_pending_at": {
+          "name": "terminal_notification_pending_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_notification_delivered_at": {
+          "name": "terminal_notification_delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_notification_lease_expires_at": {
+          "name": "terminal_notification_lease_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection": {
+          "name": "rejection",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "trigger_runs_receipt_project_configured_unique": {
+          "name": "trigger_runs_receipt_project_configured_unique",
+          "columns": [
+            {
+              "expression": "provider_event_receipt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "configured_trigger_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trigger_runs_status_deadline_idx": {
+          "name": "trigger_runs_status_deadline_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deadline_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trigger_runs_project_created_idx": {
+          "name": "trigger_runs_project_created_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trigger_runs_terminal_notification_idx": {
+          "name": "trigger_runs_terminal_notification_idx",
+          "columns": [
+            {
+              "expression": "terminal_notification_delivered_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "terminal_notification_lease_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trigger_runs_organization_fk": {
+          "name": "trigger_runs_organization_fk",
+          "tableFrom": "trigger_runs",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trigger_runs_project_organization_fk": {
+          "name": "trigger_runs_project_organization_fk",
+          "tableFrom": "trigger_runs",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id", "organization_id"],
+          "columnsTo": ["id", "organization_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trigger_runs_revision_project_organization_fk": {
+          "name": "trigger_runs_revision_project_organization_fk",
+          "tableFrom": "trigger_runs",
+          "tableTo": "project_configuration_revisions",
+          "columnsFrom": ["configuration_revision_id", "project_id", "organization_id"],
+          "columnsTo": ["id", "project_id", "organization_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "trigger_runs_receipt_organization_fk": {
+          "name": "trigger_runs_receipt_organization_fk",
+          "tableFrom": "trigger_runs",
+          "tableTo": "provider_event_receipts",
+          "columnsFrom": ["provider_event_receipt_id", "organization_id"],
+          "columnsTo": ["id", "organization_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "trigger_runs_status_check": {
+          "name": "trigger_runs_status_check",
+          "value": "\"trigger_runs\".\"status\" in ('running', 'succeeded', 'failed', 'timed_out', 'rejected')"
+        },
+        "trigger_runs_outcome_check": {
+          "name": "trigger_runs_outcome_check",
+          "value": "(\"trigger_runs\".\"outcome\" = 'accepted' and \"trigger_runs\".\"status\" <> 'rejected' and \"trigger_runs\".\"rejection\" is null)\n        or (\"trigger_runs\".\"outcome\" = 'rejected' and \"trigger_runs\".\"status\" = 'rejected' and \"trigger_runs\".\"rejection\" is not null)"
+        },
+        "trigger_runs_deadline_kind_check": {
+          "name": "trigger_runs_deadline_kind_check",
+          "value": "\"trigger_runs\".\"deadline_kind\" is null or \"trigger_runs\".\"deadline_kind\" in ('step_hard', 'step_idle', 'whole_run')"
+        },
+        "trigger_runs_deadline_shape_check": {
+          "name": "trigger_runs_deadline_shape_check",
+          "value": "(\"trigger_runs\".\"outcome\" = 'accepted' and \"trigger_runs\".\"deadline_at\" is not null)\n        or (\"trigger_runs\".\"outcome\" = 'rejected' and \"trigger_runs\".\"deadline_at\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "must_change_password": {
+          "name": "must_change_password",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_instance_operator": {
+          "name": "is_instance_operator",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_step_runs": {
+      "name": "workflow_step_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trigger_run_id": {
+          "name": "trigger_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_id": {
+          "name": "step_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_execution_id": {
+          "name": "agent_execution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deadline_kind": {
+          "name": "deadline_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deadline_at": {
+          "name": "deadline_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idle_deadline_at": {
+          "name": "idle_deadline_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatch_intent": {
+          "name": "dispatch_intent",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflow_step_runs_trigger_ordinal_unique": {
+          "name": "workflow_step_runs_trigger_ordinal_unique",
+          "columns": [
+            {
+              "expression": "trigger_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ordinal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_step_runs_trigger_step_unique": {
+          "name": "workflow_step_runs_trigger_step_unique",
+          "columns": [
+            {
+              "expression": "trigger_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "step_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_step_runs_agent_execution_unique": {
+          "name": "workflow_step_runs_agent_execution_unique",
+          "columns": [
+            {
+              "expression": "agent_execution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workflow_step_runs\".\"agent_execution_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_step_runs_trigger_status_idx": {
+          "name": "workflow_step_runs_trigger_status_idx",
+          "columns": [
+            {
+              "expression": "trigger_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_step_runs_trigger_run_fk": {
+          "name": "workflow_step_runs_trigger_run_fk",
+          "tableFrom": "workflow_step_runs",
+          "tableTo": "trigger_runs",
+          "columnsFrom": ["trigger_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_step_runs_status_check": {
+          "name": "workflow_step_runs_status_check",
+          "value": "\"workflow_step_runs\".\"status\" in ('pending', 'running', 'succeeded', 'skipped', 'failed', 'timed_out')"
+        },
+        "workflow_step_runs_deadline_kind_check": {
+          "name": "workflow_step_runs_deadline_kind_check",
+          "value": "\"workflow_step_runs\".\"deadline_kind\" is null or \"workflow_step_runs\".\"deadline_kind\" in ('step_hard', 'step_idle', 'whole_run')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_wakeups": {
+      "name": "workflow_wakeups",
+      "schema": "",
+      "columns": {
+        "trigger_run_id": {
+          "name": "trigger_run_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "available_at": {
+          "name": "available_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflow_wakeups_available_lease_idx": {
+          "name": "workflow_wakeups_available_lease_idx",
+          "columns": [
+            {
+              "expression": "available_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lease_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_wakeups_trigger_run_fk": {
+          "name": "workflow_wakeups_trigger_run_fk",
+          "tableFrom": "workflow_wakeups",
+          "tableTo": "trigger_runs",
+          "columnsFrom": ["trigger_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.agent_execution_status": {
+      "name": "agent_execution_status",
+      "schema": "public",
+      "values": ["spawning", "running", "succeeded", "failed"]
+    },
+    "public.machine_status": {
+      "name": "machine_status",
+      "schema": "public",
+      "values": ["spawning", "alive", "terminated"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -239,6 +239,13 @@
       "when": 1786372632385,
       "tag": "0033_tense_joseph",
       "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "7",
+      "when": 1786649830424,
+      "tag": "0034_wandering_roxanne_simpson",
+      "breakpoints": true
     }
   ]
 }

--- a/fly.example.toml
+++ b/fly.example.toml
@@ -12,7 +12,8 @@ PASEO_HUB_APP_URL = 'https://your-paseo-hub.fly.dev'
 PASEO_HUB_TRUSTED_CLIENT_IP_HEADER = 'fly-client-ip'
 PASEO_REGISTRATION_MODE = 'invite_only'
 PASEO_ORGANIZATION_CREATION = 'disabled'
-# PASEO_HUB_AUTH_SECRET must be installed in the app's secret store.
+# Hub generates and durably stores its authentication secret on first start.
+# Advanced deployments may override it with the PASEO_HUB_AUTH_SECRET app secret.
 
 [http_service]
 internal_port = 3000

--- a/src/application-runtime.test.ts
+++ b/src/application-runtime.test.ts
@@ -98,11 +98,14 @@ describe("application runtime provider composition", () => {
   });
 
   it("rejects duplicate provider request registrations", async () => {
+    const events: string[] = [];
     const first = fakeRegistration();
     first.connection = { ...first.connection, name: "first" };
+    first.sources = [trackedSource("first", events)];
     first.requests = [{ name: "events", handle: () => Promise.resolve(new Response()) }];
     const second = fakeRegistration();
     second.connection = { ...second.connection, name: "second" };
+    second.sources = [trackedSource("second", events)];
     second.requests = [{ name: "events", handle: () => Promise.resolve(new Response()) }];
 
     const database = createMemoryDatabase();
@@ -114,10 +117,19 @@ describe("application runtime provider composition", () => {
           entitlements: entitlementsForTest(database),
           billing: null,
           registrations: [first, second],
-          close: () => Promise.resolve(),
+          close: async () => {
+            events.push("upstream:close");
+          },
         }),
       /provider request registrations must have unique names: events/u,
     );
+    assert.deepEqual(events, [
+      "first:start",
+      "second:start",
+      "first:stop",
+      "second:stop",
+      "upstream:close",
+    ]);
   });
 
   it("reports member connection status as read-only", async () => {
@@ -278,6 +290,17 @@ function fakeRegistration(name = "fake"): ProviderRegistration {
     sources: [],
     outputs: [],
     requests: [],
+  };
+}
+
+function trackedSource(name: string, events: string[]) {
+  return {
+    start: async () => {
+      events.push(`${name}:start`);
+    },
+    stop: async () => {
+      events.push(`${name}:stop`);
+    },
   };
 }
 

--- a/src/application-runtime.ts
+++ b/src/application-runtime.ts
@@ -27,6 +27,7 @@ import {
   type PublicBillingPlan,
 } from "./server/runtime.js";
 import { ProjectDashboard } from "./projects/dashboard.js";
+import { CompositionResources } from "./composition-resources.js";
 
 export interface ApplicationCompositionOptions {
   database: Database | null;
@@ -45,6 +46,20 @@ export interface ApplicationCompositionOptions {
 
 export async function createApplicationRuntime(
   options: ApplicationCompositionOptions,
+): Promise<ApplicationRuntime> {
+  const resources = new CompositionResources();
+  resources.own(() => options.close());
+  try {
+    return await createOwnedApplicationRuntime(options, resources);
+  } catch (error) {
+    await resources.close();
+    throw error;
+  }
+}
+
+async function createOwnedApplicationRuntime(
+  options: ApplicationCompositionOptions,
+  ownership: CompositionResources,
 ): Promise<ApplicationRuntime> {
   const registrations = options.registrations ?? [];
   const connections = new Map(
@@ -97,6 +112,7 @@ export async function createApplicationRuntime(
       ? {}
       : { daemonConnectionForId: options.daemonConnectionForId }),
   });
+  ownership.own(() => application.hub.stop());
   await application.hub.start(registrations.flatMap((registration) => registration.sources));
 
   const resources = options.database === null ? null : new OrganizationResources(options.database);
@@ -107,7 +123,6 @@ export async function createApplicationRuntime(
     }
     requests.set(request.name, (incoming) => request.handle(incoming));
   }
-  const activeHub = application.hub;
   const githubConfigurations = registrations.flatMap((registration) =>
     registration.githubConfiguration === undefined ? [] : [registration.githubConfiguration],
   );
@@ -115,7 +130,7 @@ export async function createApplicationRuntime(
     throw new Error("GitHub configuration registrations must be unique");
   }
   return {
-    hub: activeHub,
+    hub: application.hub,
     operations: application.operations,
     publicApi: application.publicApi,
     resources,
@@ -298,10 +313,7 @@ export async function createApplicationRuntime(
     },
     providerRequest: (name, request) =>
       requests.get(name)?.(request) ?? Promise.resolve(new Response("Not Found", { status: 404 })),
-    async stop() {
-      await activeHub.stop();
-      await options.close();
-    },
+    stop: () => ownership.close(),
   };
 }
 

--- a/src/composition-resources.ts
+++ b/src/composition-resources.ts
@@ -1,0 +1,32 @@
+export type CloseResource = () => Promise<void>;
+
+/** Owns composed runtime resources and closes every one in reverse acquisition order. */
+export class CompositionResources {
+  private resources: CloseResource[] = [];
+  private closing: Promise<void> | undefined;
+
+  own(close: CloseResource): void {
+    if (this.closing !== undefined) throw new Error("composition resources are already closing");
+    this.resources.push(close);
+  }
+
+  close(): Promise<void> {
+    this.closing ??= this.closeOwnedResources();
+    return this.closing;
+  }
+
+  private async closeOwnedResources(): Promise<void> {
+    const errors: unknown[] = [];
+    for (const close of this.resources.toReversed()) {
+      try {
+        await close();
+      } catch (error) {
+        errors.push(error);
+      }
+    }
+    this.resources = [];
+    if (errors.length === 1) throw errors[0];
+    if (errors.length > 1)
+      throw new AggregateError(errors, "multiple composition resources failed to close");
+  }
+}

--- a/src/db/migrations.integration.test.ts
+++ b/src/db/migrations.integration.test.ts
@@ -305,7 +305,7 @@ describe("database migration application", () => {
     assert.deepEqual(after, before);
     assert.deepEqual(await historicalShape(fixture.url), {
       authTables: 7,
-      drizzleMigrations: 34,
+      drizzleMigrations: 35,
       legacyArtifacts: null,
       legacyOperatorPrincipals: null,
       bootstrapOrganizationId: fixture.organizationId,

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1007,6 +1007,16 @@ export const instanceBootstrap = pgTable(
   ],
 );
 
+export const runtimeConfiguration = pgTable(
+  "runtime_configuration",
+  {
+    singleton: boolean().primaryKey().default(true),
+    authSecret: text("auth_secret").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [check("runtime_configuration_singleton_check", sql`${table.singleton}`)],
+);
+
 export const organizationApiKeys = pgTable(
   "organization_api_keys",
   {

--- a/src/index.bootstrap.test.ts
+++ b/src/index.bootstrap.test.ts
@@ -77,6 +77,8 @@ describe("production Hub cold start", () => {
     await client.close();
 
     process.env["DATABASE_URL"] = databaseUrl;
+    delete process.env["PASEO_HUB_AUTH_SECRET"];
+    delete process.env["PASEO_HUB_APP_URL"];
     process.env["PASEO_REGISTRATION_MODE"] = "disabled";
     delete process.env["PASEO_BOOTSTRAP_ORGANIZATION"];
     delete process.env["PASEO_BOOTSTRAP_OWNER_EMAIL"];
@@ -85,12 +87,22 @@ describe("production Hub cold start", () => {
     const runtime = await startProductionRuntime();
     const verification = await createPostgresQueryRuntime(databaseUrl);
 
-    const result = await verification.query<{ count: number }>(
-      `select count(*)::integer as count from instance_bootstrap`,
-    );
+    const result = await verification.query<{
+      bootstraps: number;
+      runtimeConfigurations: number;
+      authSecret: string;
+    }>(`select
+          (select count(*)::integer from instance_bootstrap) as "bootstraps",
+          (select count(*)::integer from runtime_configuration) as "runtimeConfigurations",
+          (select auth_secret from runtime_configuration) as "authSecret"`);
     await verification.close();
-    assert.equal(result.rows[0]?.count, 0);
-    assert.ok(runtime);
+    assert.equal(result.rows[0]?.bootstraps, 0);
+    assert.equal(result.rows[0]?.runtimeConfigurations, 1);
+    assert.match(result.rows[0]?.authSecret ?? "", /^[a-f0-9]{64}$/u);
+    assert.notEqual(
+      (await runtime.auth(new Request("http://localhost:3000/api/auth/get-session"))).status,
+      503,
+    );
   }, 120_000);
 
   it("runs configured bootstrap before exposing the production runtime", async () => {

--- a/src/index.embedded.integration.test.ts
+++ b/src/index.embedded.integration.test.ts
@@ -26,8 +26,8 @@ beforeEach(async () => {
   previousEnvironment = new Map(ENVIRONMENT_NAMES.map((name) => [name, process.env[name]]));
   delete process.env["DATABASE_URL"];
   process.env["PASEO_HUB_DATA_DIR"] = join(root, "database");
-  process.env["PASEO_HUB_AUTH_SECRET"] = "embedded-production-secret-at-least-32-characters";
-  process.env["PASEO_HUB_APP_URL"] = "http://localhost:3000";
+  delete process.env["PASEO_HUB_AUTH_SECRET"];
+  delete process.env["PASEO_HUB_APP_URL"];
   process.env["PASEO_REGISTRATION_MODE"] = "invite_only";
   process.env["PASEO_ORGANIZATION_CREATION"] = "disabled";
   process.env["PASEO_BOOTSTRAP_ORGANIZATION"] = "Embedded owner";
@@ -36,27 +36,87 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
-  await stopProductionRuntime();
+  await stopProductionRuntime().catch(() => undefined);
   for (const [name, value] of previousEnvironment) restoreEnvironment(name, value);
   await rm(root, { recursive: true, force: true });
 });
 
+it("releases embedded storage when runtime configuration is invalid", async () => {
+  process.env["PASEO_HUB_APP_URL"] = "not a URL";
+
+  await assert.rejects(() => startProductionRuntime(), TypeError);
+
+  await reopenEmbeddedStorage();
+});
+
+it("releases embedded storage when auth initialization fails", async () => {
+  const bundle = await embeddedDatabaseRuntime(process.env["PASEO_HUB_DATA_DIR"]!);
+  await bundle.runtime.migrate();
+  await bundle.runtime.query(
+    `insert into "user" (id, name, email, email_verified)
+     values ('existing-user', 'Existing user', $1, true)`,
+    [process.env["PASEO_BOOTSTRAP_OWNER_EMAIL"]!],
+  );
+  await bundle.runtime.close();
+
+  await assert.rejects(() => startProductionRuntime(), /already belongs/u);
+
+  await reopenEmbeddedStorage();
+});
+
 it("selects embedded storage without DATABASE_URL and preserves it across restarts", async () => {
-  await startProductionRuntime();
+  const firstRuntime = await startProductionRuntime();
+  const authResponse = await firstRuntime.auth(
+    new Request("http://localhost:3000/api/auth/get-session"),
+  );
+  assert.notEqual(authResponse.status, 503);
+  const authBody = await authResponse.text();
   await stopProductionRuntime();
+
+  const firstSecret = await storedAuthSecret();
+  assert.doesNotMatch(authBody, new RegExp(firstSecret, "u"));
   await startProductionRuntime();
   await stopProductionRuntime();
 
   const bundle = await embeddedDatabaseRuntime(process.env["PASEO_HUB_DATA_DIR"]!);
-  const result = await bundle.runtime.query<{ organizations: number; bootstraps: number }>(`
+  const result = await bundle.runtime.query<{
+    organizations: number;
+    bootstraps: number;
+    runtime_configurations: number;
+    auth_secret: string;
+  }>(`
     select
       (select count(*)::integer from organization) as organizations,
-      (select count(*)::integer from instance_bootstrap) as bootstraps
+      (select count(*)::integer from instance_bootstrap) as bootstraps,
+      (select count(*)::integer from runtime_configuration) as runtime_configurations,
+      (select auth_secret from runtime_configuration) as auth_secret
   `);
   await bundle.runtime.close();
 
-  assert.deepEqual(result.rows[0], { organizations: 1, bootstraps: 1 });
+  assert.deepEqual(result.rows[0], {
+    organizations: 1,
+    bootstraps: 1,
+    runtime_configurations: 1,
+    auth_secret: firstSecret,
+  });
 });
+
+async function storedAuthSecret(): Promise<string> {
+  const bundle = await embeddedDatabaseRuntime(process.env["PASEO_HUB_DATA_DIR"]!);
+  const result = await bundle.runtime.query<{ auth_secret: string }>(
+    `select auth_secret from runtime_configuration`,
+  );
+  await bundle.runtime.close();
+  const secret = result.rows[0]?.auth_secret;
+  assert.ok(secret);
+  return secret;
+}
+
+async function reopenEmbeddedStorage(): Promise<void> {
+  const bundle = await embeddedDatabaseRuntime(process.env["PASEO_HUB_DATA_DIR"]!);
+  await bundle.runtime.migrate();
+  await bundle.runtime.close();
+}
 
 function restoreEnvironment(name: string, value: string | undefined): void {
   if (value === undefined) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import "dotenv/config";
+import { randomBytes } from "node:crypto";
 import { validateHeaderName, type IncomingMessage } from "node:http";
 import { join, resolve as resolvePath } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -32,6 +33,8 @@ import { createDiscordRegistration } from "./providers/discord/index.js";
 import { createGitHubRegistration } from "./providers/github/index.js";
 import { createSlackRegistration } from "./providers/slack/index.js";
 import { readInstanceAuthPolicy } from "./auth/instance-policy.js";
+import { createRuntimeConfiguration } from "./runtime-configuration/index.js";
+import { CompositionResources } from "./composition-resources.js";
 
 export function startProductionRuntime(): Promise<ApplicationRuntime> {
   return startApplication(createProductionRuntime);
@@ -55,64 +58,66 @@ export async function handleDaemonUpgrade(
 }
 
 async function createProductionRuntime(): Promise<ApplicationRuntime> {
-  const config = loadRuntimeConfig();
-  const identity = readHubIdentity();
-  const { database, runtime, locks } = await createDatabaseHandle();
-  const entitlements = composeEntitlements(database, runtime);
-  const billingConfig = readBillingConfig();
-  const billing =
-    billingConfig === undefined
-      ? null
-      : composeBilling({
-          config: billingConfig,
-          database,
-          catalogSource: createStripeCatalogSource(billingConfig.stripeSecretKey),
-          billingClient: createStripeBillingClient(billingConfig.stripeSecretKey),
-          seatUsage: entitlements.seatUsage,
-        });
-  // Sync on boot, per the plan. A Stripe outage here must not block the whole instance from
-  // starting — only the marketing catalog goes stale until the next webhook or restart.
-  await billing?.syncCatalog().catch((error: unknown) => {
-    logger.error({ err: error }, "billing catalog sync failed at boot");
-  });
-  const auth = createProductionAuthServer(
-    entitlements,
-    runtime,
-    locks,
-    config.authPolicy,
-    identity,
-    config.trustedClientIpHeader,
-    billing,
-  );
-  if (config.authPolicy.bootstrap !== undefined && auth === null) {
-    throw new Error("PASEO_HUB_AUTH_SECRET is required when instance bootstrap is configured");
+  const resources = new CompositionResources();
+  try {
+    const config = loadRuntimeConfig();
+    const { database, runtime, locks } = await createDatabaseHandle();
+    resources.own(() => database.close());
+    const identity = await resolveHubIdentity(runtime, readPort());
+    const entitlements = composeEntitlements(database, runtime);
+    resources.own(() => entitlements.close());
+    const billingConfig = readBillingConfig();
+    const billing =
+      billingConfig === undefined
+        ? null
+        : composeBilling({
+            config: billingConfig,
+            database,
+            catalogSource: createStripeCatalogSource(billingConfig.stripeSecretKey),
+            billingClient: createStripeBillingClient(billingConfig.stripeSecretKey),
+            seatUsage: entitlements.seatUsage,
+          });
+    // Sync on boot, per the plan. A Stripe outage here must not block the whole instance from
+    // starting — only the marketing catalog goes stale until the next webhook or restart.
+    await billing?.syncCatalog().catch((error: unknown) => {
+      logger.error({ err: error }, "billing catalog sync failed at boot");
+    });
+    const auth = createProductionAuthServer(
+      entitlements,
+      runtime,
+      locks,
+      config.authPolicy,
+      identity,
+      config.trustedClientIpHeader,
+      billing,
+    );
+    resources.own(() => auth.close());
+    await auth.initialize?.();
+    const providerOptions = {
+      database,
+      auth,
+      applicationBaseUrl: identity.appUrl,
+      publicBaseUrl: identity.appUrl,
+    };
+    const registrations = [
+      createGitHubRegistration(providerOptions),
+      createDiscordRegistration(providerOptions),
+      createSlackRegistration(providerOptions),
+    ];
+    return await createApplicationRuntime({
+      database,
+      auth,
+      entitlements: entitlements.service,
+      billing,
+      registrations,
+      publicBaseUrl: identity.appUrl,
+      completionTokenSecret: identity.authSecret,
+      close: () => resources.close(),
+    });
+  } catch (error) {
+    await resources.close();
+    throw error;
   }
-  await auth?.initialize?.();
-  const providerOptions = {
-    database,
-    auth,
-    applicationBaseUrl: identity.appUrl,
-    publicBaseUrl: identity.appUrl,
-  };
-  const registrations = [
-    createGitHubRegistration(providerOptions),
-    createDiscordRegistration(providerOptions),
-    createSlackRegistration(providerOptions),
-  ];
-  return createApplicationRuntime({
-    database,
-    auth,
-    entitlements: entitlements.service,
-    billing,
-    registrations,
-    publicBaseUrl: identity.appUrl,
-    ...(identity.authSecret === undefined ? {} : { completionTokenSecret: identity.authSecret }),
-    async close() {
-      await auth?.close();
-      await entitlements.close();
-      await database?.close();
-    },
-  });
 }
 
 function createProductionAuthServer(
@@ -124,10 +129,6 @@ function createProductionAuthServer(
   trustedClientIpHeader: string | undefined,
   billing: BillingRuntime | null,
 ) {
-  if (identity.authSecret === undefined) {
-    logger.warn("PASEO_HUB_AUTH_SECRET is unset; browser auth routes are closed");
-    return null;
-  }
   return createAuthServer({
     database,
     locks,
@@ -198,17 +199,27 @@ function loadRuntimeConfig(): RuntimeConfig {
 
 interface HubIdentity {
   appUrl: string;
-  authSecret?: string;
+  authSecret: string;
 }
 
-function readHubIdentity(): HubIdentity {
+async function resolveHubIdentity(
+  database: DatabaseRuntime,
+  effectivePort: number,
+): Promise<HubIdentity> {
   const configuredAppUrl = process.env["PASEO_HUB_APP_URL"];
   const configuredAuthSecret = process.env["PASEO_HUB_AUTH_SECRET"];
+  const configuration = createRuntimeConfiguration({
+    database,
+    environment: {
+      ...(configuredAppUrl === undefined ? {} : { appUrl: configuredAppUrl }),
+      ...(configuredAuthSecret === undefined ? {} : { authSecret: configuredAuthSecret }),
+    },
+    effectivePort,
+    randomBytes,
+  });
   return {
-    appUrl: new URL(configuredAppUrl ?? "http://localhost:3000").toString(),
-    ...(configuredAuthSecret === undefined || configuredAuthSecret.length === 0
-      ? {}
-      : { authSecret: configuredAuthSecret }),
+    appUrl: await configuration.publicUrl(),
+    authSecret: await configuration.authSecret(),
   };
 }
 

--- a/src/runtime-configuration/index.ts
+++ b/src/runtime-configuration/index.ts
@@ -1,0 +1,43 @@
+import type { DatabaseRuntime } from "../db/runtime/index.js";
+import { RuntimeConfigurationStore } from "./internal/store.js";
+
+export interface RuntimeConfiguration {
+  authSecret(): Promise<string>;
+  publicUrl(): Promise<string>;
+}
+
+interface RuntimeConfigurationEnvironment {
+  authSecret?: string;
+  appUrl?: string;
+}
+
+export function createRuntimeConfiguration(options: {
+  database: DatabaseRuntime;
+  environment: RuntimeConfigurationEnvironment;
+  effectivePort: number;
+  randomBytes(size: number): Uint8Array;
+}): RuntimeConfiguration {
+  const store = new RuntimeConfigurationStore(options.database);
+  return {
+    authSecret: () => {
+      const override = nonEmpty(options.environment.authSecret);
+      return override === undefined
+        ? store.resolveAuthSecret(() => encodeSecret(options.randomBytes(32)))
+        : Promise.resolve(override);
+    },
+    publicUrl: () =>
+      Promise.resolve(
+        new URL(
+          options.environment.appUrl ?? `http://localhost:${options.effectivePort}`,
+        ).toString(),
+      ),
+  };
+}
+
+function nonEmpty(value: string | undefined): string | undefined {
+  return value === undefined || value.length === 0 ? undefined : value;
+}
+
+function encodeSecret(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString("hex");
+}

--- a/src/runtime-configuration/internal/store.ts
+++ b/src/runtime-configuration/internal/store.ts
@@ -1,0 +1,24 @@
+import type { DatabaseRuntime, QueryRow } from "../../db/runtime/index.js";
+
+interface StoredSecretRow extends QueryRow {
+  auth_secret: string;
+}
+
+/** @package */
+export class RuntimeConfigurationStore {
+  constructor(private readonly database: DatabaseRuntime) {}
+
+  async resolveAuthSecret(generate: () => string): Promise<string> {
+    const result = await this.database.query<StoredSecretRow>(
+      `insert into runtime_configuration (singleton, auth_secret)
+       values (true, $1)
+       on conflict (singleton) do update
+       set auth_secret = runtime_configuration.auth_secret
+       returning auth_secret`,
+      [generate()],
+    );
+    const stored = result.rows[0]?.auth_secret;
+    if (stored === undefined) throw new Error("runtime auth secret resolution returned no value");
+    return stored;
+  }
+}

--- a/src/runtime-configuration/runtime-configuration.integration.test.ts
+++ b/src/runtime-configuration/runtime-configuration.integration.test.ts
@@ -1,0 +1,134 @@
+import assert from "node:assert/strict";
+import { randomBytes } from "node:crypto";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, it } from "vitest";
+import { PostgreSqlContainer } from "@testcontainers/postgresql";
+import { embeddedDatabaseRuntime, postgresDatabaseRuntime } from "../db/runtime/index.js";
+import { createRuntimeConfiguration } from "./index.js";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("runtime configuration", () => {
+  it("atomically persists one high-entropy secret for concurrent first resolution", async () => {
+    const { runtime } = await freshRuntime();
+    const configuration = createConfiguration(runtime);
+
+    const secrets = await Promise.all(Array.from({ length: 20 }, () => configuration.authSecret()));
+
+    assert.equal(new Set(secrets).size, 1);
+    assert.match(secrets[0]!, /^[a-f0-9]{64}$/u);
+    const persisted = await runtime.query<{ count: number; auth_secret: string }>(
+      `select count(*)::integer as count, min(auth_secret) as auth_secret
+       from runtime_configuration`,
+    );
+    assert.deepEqual(persisted.rows[0], { count: 1, auth_secret: secrets[0] });
+    await runtime.close();
+  });
+
+  it("atomically persists one secret across independent PostgreSQL runtime owners", async () => {
+    const postgres = await new PostgreSqlContainer("postgres:17-alpine").start();
+    const databaseUrl = postgres.getConnectionUri();
+    const migrationOwner = await postgresDatabaseRuntime(databaseUrl);
+    await migrationOwner.runtime.migrate();
+    await migrationOwner.runtime.close();
+
+    const owners = await Promise.all(
+      Array.from({ length: 20 }, () => postgresDatabaseRuntime(databaseUrl)),
+    );
+    try {
+      const secrets = await Promise.all(
+        owners.map(({ runtime }) => createConfiguration(runtime).authSecret()),
+      );
+
+      assert.equal(new Set(secrets).size, 1);
+      assert.match(secrets[0]!, /^[a-f0-9]{64}$/u);
+      const persisted = await owners[0]!.runtime.query<{ count: number; auth_secret: string }>(
+        `select count(*)::integer as count, min(auth_secret) as auth_secret
+         from runtime_configuration`,
+      );
+      assert.deepEqual(persisted.rows[0], { count: 1, auth_secret: secrets[0] });
+    } finally {
+      await Promise.all(owners.map(({ runtime }) => runtime.close()));
+      await postgres.stop();
+    }
+  });
+
+  it("reuses a secret after restart and isolates fresh data directories", async () => {
+    const first = await freshRuntime();
+    const firstSecret = await createConfiguration(first.runtime).authSecret();
+    await first.runtime.close();
+
+    const reopenedBundle = await embeddedDatabaseRuntime(first.root);
+    await reopenedBundle.runtime.migrate();
+    const reopenedSecret = await createConfiguration(reopenedBundle.runtime).authSecret();
+    await reopenedBundle.runtime.close();
+
+    const second = await freshRuntime();
+    const secondSecret = await createConfiguration(second.runtime).authSecret();
+    await second.runtime.close();
+
+    assert.equal(reopenedSecret, firstSecret);
+    assert.notEqual(secondSecret, firstSecret);
+  });
+
+  it("uses an environment override without replacing the stored generated secret", async () => {
+    const { runtime } = await freshRuntime();
+    const stored = await createConfiguration(runtime).authSecret();
+    const override = "advanced-deployment-secret";
+
+    assert.equal(
+      await createConfiguration(runtime, { authSecret: override }).authSecret(),
+      override,
+    );
+    assert.equal(await createConfiguration(runtime).authSecret(), stored);
+    const persisted = await runtime.query<{ auth_secret: string }>(
+      `select auth_secret from runtime_configuration`,
+    );
+    assert.equal(persisted.rows[0]?.auth_secret, stored);
+    await runtime.close();
+  });
+
+  it("resolves the public URL from the effective port unless explicitly overridden", async () => {
+    const { runtime } = await freshRuntime();
+
+    assert.equal(
+      await createConfiguration(runtime, {}, 4317).publicUrl(),
+      "http://localhost:4317/",
+    );
+    assert.equal(
+      await createConfiguration(
+        runtime,
+        { appUrl: "https://hub.example.test/base" },
+        4317,
+      ).publicUrl(),
+      "https://hub.example.test/base",
+    );
+    await assert.rejects(
+      async () => createConfiguration(runtime, { appUrl: "" }, 4317).publicUrl(),
+      TypeError,
+    );
+    await runtime.close();
+  });
+});
+
+async function freshRuntime() {
+  const root = await mkdtemp(join(tmpdir(), "hub-runtime-configuration-"));
+  roots.push(root);
+  const bundle = await embeddedDatabaseRuntime(root);
+  await bundle.runtime.migrate();
+  return { runtime: bundle.runtime, root };
+}
+
+function createConfiguration(
+  database: Awaited<ReturnType<typeof freshRuntime>>["runtime"],
+  environment: { authSecret?: string; appUrl?: string } = {},
+  effectivePort = 3000,
+) {
+  return createRuntimeConfiguration({ database, environment, effectivePort, randomBytes });
+}


### PR DESCRIPTION
Ordinary self-hosted Hub startup now creates and reuses one durable authentication and execution-authority secret. Operators can start with the embedded default or PostgreSQL without first manufacturing `PASEO_HUB_AUTH_SECRET`; advanced deployments retain an explicit environment override.

## Goals

- Generate one 64-hex authentication secret on first startup and persist it through the existing database-runtime seam.
- Reuse the stored secret across restarts for both browser authentication and execution capabilities.
- Give `PASEO_HUB_AUTH_SECRET` precedence without overwriting the stored generated value, so removing the override returns to the durable secret.
- Derive the zero-environment public URL from the effective `PORT`, while preserving an explicit `PASEO_HUB_APP_URL` exactly.
- Unwind every acquired startup resource in reverse order when runtime configuration, authentication initialization, provider startup, or later application composition fails.
- Keep deployment examples and Hub-owned setup documentation aligned with automatic durable generation.

## Non-goals

- Owner welcome or first-owner UI flows.
- Provider setup or credential onboarding.
- NPX packaging or a new distribution entry point.

## Why

Embedded storage removed the external database requirement from ordinary local startup, but Hub still required operators to generate and preserve a separate secret before browser authentication and execution capabilities were available. Runtime identity now has one storage-backed owner, while the environment remains an explicit deployment override rather than a second source of durable state.

## Related work

- [PR #45 — Add a driver-neutral database runtime seam](https://github.com/getpaseo/hub/pull/45) established the shared PostgreSQL/PGlite ownership boundary used for durable runtime configuration.
- [PR #46 — Make embedded storage the local Hub default](https://github.com/getpaseo/hub/pull/46) established zero-service startup; this PR removes the remaining mandatory secret from that ordinary startup path.

No open Hub issue or pull request covers this behavior, so this PR does not supersede or close another thread.

## Verification

Exact accepted-head evidence:

- Focused runtime configuration, embedded startup cleanup, and application composition regressions: 12/12 passed.
- Full test suite: 763 passed, 15 source-gated tests skipped.
- Independent PostgreSQL first-write race: 20 runtime/pool owners received one durable 64-hex winner.
- `npm run typecheck`: passed.
- `npm run lint`: passed with 0 warnings and 0 errors.
- `npm run format:check`: passed.
- `npm run db:check`: passed with no schema drift.
- `npm run build`: passed.
- `npm run docker:smoke`: passed.
- Built browser suite against the exact pinned Paseo source commit: 74/74 passed.
- Source-built Hub contract suite against the same pinned source: 6/6 passed with leak-free shutdown evidence.
- `git diff --check`: passed.

## Risk surface

The meaningful risks are first-start secret races, migration compatibility, override precedence, and resource ownership when startup rejects. PostgreSQL coverage uses independent pool owners to exercise database-level atomicity; embedded coverage proves persistence, override restoration, secret non-disclosure, and same-directory reopen after invalid URL and authentication initialization failures. Application composition coverage proves started sources stop before upstream storage closes. The existing single secret remains the authority for both browser authentication and execution capabilities; this PR adds no rotation, encryption, provider, billing, or onboarding behavior.
