### PR TITLE
Make Hub runtime environment loading explicit

### DIFF
--- a/oxlint.json
+++ b/oxlint.json
@@ -83,7 +83,7 @@
     "import/no-unassigned-import": [
       "error",
       {
-        "allow": ["**/dotenv/config", "**/*.css", "**/styles.entry.js"]
+        "allow": ["**/*.css", "**/styles.entry.js"]
       }
     ],
 

--- a/src/command-line.test.ts
+++ b/src/command-line.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { describe, it } from "vitest";
+import { isCommandLineEntrypoint, readHubCommandLine } from "./command-line.js";
+
+describe("Hub command line", () => {
+  it("loads dotenv by default", () => {
+    assert.deepEqual(readHubCommandLine(["node", "/hub/index.js"]), {
+      environmentSource: "process-and-dotenv",
+    });
+  });
+
+  it("maps --no-env to process-only configuration", () => {
+    assert.deepEqual(readHubCommandLine(["node", "/hub/index.js", "--no-env"]), {
+      environmentSource: "process-only",
+    });
+  });
+
+  it("ignores arguments owned by the outer Vite command", () => {
+    assert.deepEqual(
+      readHubCommandLine(["node", "/hub/vite.js", "dev", "--port", "3000", "--no-env"]),
+      { environmentSource: "process-only" },
+    );
+  });
+
+  it("recognizes only the requested module as the executable entrypoint", () => {
+    assert.equal(isCommandLineEntrypoint("file:///hub/index.js", ["node", "/hub/index.js"]), true);
+    assert.equal(
+      isCommandLineEntrypoint("file:///hub/index.js", ["node", "/hub/another.js"]),
+      false,
+    );
+  });
+});

--- a/src/command-line.ts
+++ b/src/command-line.ts
@@ -1,0 +1,30 @@
+import { parseArgs } from "node:util";
+import { fileURLToPath } from "node:url";
+import type { RuntimeEnvironmentSource } from "./runtime-environment.js";
+
+export interface HubLaunch {
+  environmentSource: RuntimeEnvironmentSource;
+}
+
+export function readHubCommandLine(argv: readonly string[] = process.argv): HubLaunch {
+  const { values } = parseArgs({
+    args: argv.slice(2),
+    options: {
+      "no-env": { type: "boolean" },
+    },
+    strict: false,
+    allowPositionals: true,
+  });
+
+  return {
+    environmentSource: values["no-env"] === true ? "process-only" : "process-and-dotenv",
+  };
+}
+
+export function isCommandLineEntrypoint(
+  moduleUrl: string,
+  argv: readonly string[] = process.argv,
+): boolean {
+  const entrypoint = argv[1];
+  return entrypoint !== undefined && entrypoint === fileURLToPath(moduleUrl);
+}

--- a/src/db/migrate.ts
+++ b/src/db/migrate.ts
@@ -1,12 +1,18 @@
-import "dotenv/config";
 import { postgresDatabaseRuntime } from "./runtime/index.js";
+import { loadRuntimeEnvironment } from "../runtime-environment.js";
 
-const databaseUrl =
-  process.env["DATABASE_URL"] ?? "postgres://postgres:postgres@localhost:5432/paseo_hub";
-const { runtime } = await postgresDatabaseRuntime(databaseUrl);
+async function main(): Promise<void> {
+  loadRuntimeEnvironment("process-and-dotenv");
 
-try {
-  await runtime.migrate();
-} finally {
-  await runtime.close();
+  const databaseUrl =
+    process.env["DATABASE_URL"] ?? "postgres://postgres:postgres@localhost:5432/paseo_hub";
+  const { runtime } = await postgresDatabaseRuntime(databaseUrl);
+
+  try {
+    await runtime.migrate();
+  } finally {
+    await runtime.close();
+  }
 }
+
+await main();

--- a/src/index.bootstrap.test.ts
+++ b/src/index.bootstrap.test.ts
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, it } from "vitest";
 import { PostgreSqlContainer, type StartedPostgreSqlContainer } from "@testcontainers/postgresql";
 import { createPostgresQueryRuntime } from "./db/test-utils/runtime.js";
@@ -35,12 +38,16 @@ describe("production Hub runtime", () => {
 describe("production Hub cold start", () => {
   let postgres: StartedPostgreSqlContainer;
   let previousEnvironment: Map<string, string | undefined>;
+  let root: string;
+  const originalDirectory = process.cwd();
 
   beforeAll(async () => {
     postgres = await new PostgreSqlContainer("postgres:17-alpine").start();
   }, 120_000);
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "hub-production-postgres-"));
+    process.chdir(root);
     previousEnvironment = new Map(
       [
         "DATABASE_URL",
@@ -58,6 +65,8 @@ describe("production Hub cold start", () => {
   afterEach(async () => {
     await stopProductionRuntime();
     for (const [name, value] of previousEnvironment) restoreEnvironment(name, value);
+    process.chdir(originalDirectory);
+    await rm(root, { recursive: true, force: true });
   });
 
   afterAll(async () => {

--- a/src/index.embedded.integration.test.ts
+++ b/src/index.embedded.integration.test.ts
@@ -20,9 +20,11 @@ const ENVIRONMENT_NAMES = [
 
 let root: string;
 let previousEnvironment: Map<string, string | undefined>;
+const originalDirectory = process.cwd();
 
 beforeEach(async () => {
   root = await mkdtemp(join(tmpdir(), "hub-production-embedded-"));
+  process.chdir(root);
   previousEnvironment = new Map(ENVIRONMENT_NAMES.map((name) => [name, process.env[name]]));
   delete process.env["DATABASE_URL"];
   process.env["PASEO_HUB_DATA_DIR"] = join(root, "database");
@@ -38,6 +40,7 @@ beforeEach(async () => {
 afterEach(async () => {
   await stopProductionRuntime().catch(() => undefined);
   for (const [name, value] of previousEnvironment) restoreEnvironment(name, value);
+  process.chdir(originalDirectory);
   await rm(root, { recursive: true, force: true });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,6 @@
-import "dotenv/config";
 import { randomBytes } from "node:crypto";
 import { validateHeaderName, type IncomingMessage } from "node:http";
 import { join, resolve as resolvePath } from "node:path";
-import { fileURLToPath } from "node:url";
 import type { Duplex } from "node:stream";
 import type { RuntimeConfig } from "./config/index.js";
 import { DatabaseUnavailableError } from "./db/errors.js";
@@ -35,8 +33,17 @@ import { createSlackRegistration } from "./providers/slack/index.js";
 import { readInstanceAuthPolicy } from "./auth/instance-policy.js";
 import { createRuntimeConfiguration } from "./runtime-configuration/index.js";
 import { CompositionResources } from "./composition-resources.js";
+import { loadRuntimeEnvironment, type RuntimeEnvironmentSource } from "./runtime-environment.js";
+import { isCommandLineEntrypoint } from "./command-line.js";
 
-export function startProductionRuntime(): Promise<ApplicationRuntime> {
+export interface ProductionRuntimeOptions {
+  environmentSource: RuntimeEnvironmentSource;
+}
+
+export function startProductionRuntime(
+  options: ProductionRuntimeOptions = { environmentSource: "process-and-dotenv" },
+): Promise<ApplicationRuntime> {
+  loadRuntimeEnvironment(options.environmentSource);
   return startApplication(createProductionRuntime);
 }
 
@@ -48,8 +55,9 @@ export async function handleDaemonUpgrade(
   request: IncomingMessage,
   socket: Duplex,
   head: Buffer,
+  options: ProductionRuntimeOptions = { environmentSource: "process-and-dotenv" },
 ): Promise<void> {
-  const runtime = await startProductionRuntime();
+  const runtime = await startProductionRuntime(options);
   if (runtime.hub.handleUpgrade === null) {
     socket.destroy();
     return;
@@ -224,10 +232,10 @@ async function resolveHubIdentity(
 }
 
 async function main(): Promise<void> {
-  const config = loadRuntimeConfig();
-  const port = readPort();
   const build = await loadBuiltStartServer();
   await build.startProductionRuntime();
+  const config = loadRuntimeConfig();
+  const port = readPort();
   const server = createFetchServer(
     (request) => build.default.fetch(request),
     config.trustedClientIpHeader === undefined
@@ -270,7 +278,7 @@ function readPort(): number {
   return port;
 }
 
-if (process.argv[1] === fileURLToPath(import.meta.url)) {
+if (isCommandLineEntrypoint(import.meta.url)) {
   main().catch((error: unknown) => {
     logger.fatal(error);
     process.exit(1);

--- a/src/runtime-environment.test.ts
+++ b/src/runtime-environment.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, it } from "vitest";
+import { loadRuntimeEnvironment } from "./runtime-environment.js";
+
+const TEST_VARIABLE = "PASEO_HUB_RUNTIME_ENVIRONMENT_TEST";
+const originalDirectory = process.cwd();
+const originalValue = process.env[TEST_VARIABLE];
+let temporaryDirectory: string | undefined;
+
+afterEach(async () => {
+  process.chdir(originalDirectory);
+  if (originalValue === undefined) {
+    delete process.env[TEST_VARIABLE];
+  } else {
+    process.env[TEST_VARIABLE] = originalValue;
+  }
+  if (temporaryDirectory !== undefined) {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+    temporaryDirectory = undefined;
+  }
+});
+
+it("loads dotenv only when the runtime explicitly starts it", async () => {
+  temporaryDirectory = await mkdtemp(join(tmpdir(), "hub-runtime-environment-"));
+  await writeFile(join(temporaryDirectory, ".env"), `${TEST_VARIABLE}=loaded\n`);
+  process.chdir(temporaryDirectory);
+  delete process.env[TEST_VARIABLE];
+
+  assert.equal(process.env[TEST_VARIABLE], undefined);
+
+  loadRuntimeEnvironment("process-and-dotenv");
+
+  assert.equal(process.env[TEST_VARIABLE], "loaded");
+});
+
+it("preserves environment variables supplied by the process", async () => {
+  temporaryDirectory = await mkdtemp(join(tmpdir(), "hub-runtime-environment-"));
+  await writeFile(join(temporaryDirectory, ".env"), `${TEST_VARIABLE}=from-file\n`);
+  process.chdir(temporaryDirectory);
+  process.env[TEST_VARIABLE] = "from-process";
+
+  loadRuntimeEnvironment("process-and-dotenv");
+
+  assert.equal(process.env[TEST_VARIABLE], "from-process");
+});
+
+it("leaves dotenv untouched for process-only launches", async () => {
+  temporaryDirectory = await mkdtemp(join(tmpdir(), "hub-runtime-environment-"));
+  await writeFile(join(temporaryDirectory, ".env"), `${TEST_VARIABLE}=from-file\n`);
+  process.chdir(temporaryDirectory);
+  delete process.env[TEST_VARIABLE];
+
+  loadRuntimeEnvironment("process-only");
+
+  assert.equal(process.env[TEST_VARIABLE], undefined);
+});

--- a/src/runtime-environment.ts
+++ b/src/runtime-environment.ts
@@ -1,0 +1,8 @@
+import { config } from "dotenv";
+
+export type RuntimeEnvironmentSource = "process-and-dotenv" | "process-only";
+
+export function loadRuntimeEnvironment(source: RuntimeEnvironmentSource): void {
+  if (source === "process-only") return;
+  config();
+}

--- a/src/start-server.ts
+++ b/src/start-server.ts
@@ -1,10 +1,26 @@
 import { createStartHandler, defaultStreamHandler } from "@tanstack/react-start/server";
-import { startProductionRuntime } from "./index.js";
+import type { IncomingMessage } from "node:http";
+import type { Duplex } from "node:stream";
+import {
+  handleDaemonUpgrade as handleProductionDaemonUpgrade,
+  startProductionRuntime as startHubProductionRuntime,
+  stopProductionRuntime,
+} from "./index.js";
+import { readHubCommandLine } from "./command-line.js";
 import { hasApplication, startApplication } from "./server/runtime.js";
-export { handleDaemonUpgrade, startProductionRuntime, stopProductionRuntime } from "./index.js";
 export { startApplication } from "./server/runtime.js";
 
 const startFetch = createStartHandler(defaultStreamHandler);
+
+export function startProductionRuntime() {
+  return startHubProductionRuntime(readHubCommandLine());
+}
+
+export function handleDaemonUpgrade(request: IncomingMessage, socket: Duplex, head: Buffer) {
+  return handleProductionDaemonUpgrade(request, socket, head, readHubCommandLine());
+}
+
+export { stopProductionRuntime };
 
 const fetch = async (request: Request) => {
   if (!hasApplication()) await startProductionRuntime();

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,7 @@ import { tanstackStart } from "@tanstack/react-start/plugin/vite";
 
 export default defineConfig({
   build: { outDir: ".output" },
+  envDir: false,
   resolve: { alias: { "@": fileURLToPath(new URL("./src", import.meta.url)) } },
   plugins: [tanstackStart({ server: { entry: "./start-server.ts" } }), tailwindcss(), react()],
 });


### PR DESCRIPTION
Hub now owns environment loading at runtime startup, and `npm run dev -- --no-env` or `npm start -- --no-env` uses only the process environment. This makes dotenv behavior explicit across normal startup, daemon upgrades, and database migrations.

## Goals

- Load dotenv only through one runtime-environment owner.
- Disable implicit Vite/TanStack environment loading.
- Translate the Hub CLI flag into semantic runtime options at one boundary.
- Apply the same launch options to normal and daemon-upgrade startup.

## Non-goals

- Add wrappers, launchers, preloaders, or documentation.
- Change the held documentation aggregator.
- Change environment variable precedence beyond dotenv’s existing process-first behavior.

## Why

Hub owns the production executable and HTTP server while TanStack provides its Fetch handler. Making Hub the explicit environment owner prevents framework and module-import timing from deciding runtime configuration.

## Verification

- `npm exec vitest run src/command-line.test.ts src/runtime-environment.test.ts src/index.embedded.integration.test.ts src/index.bootstrap.test.ts` (14 passed)
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run build`

## Risk surface

Startup configuration is intentionally centralized; reviewers should check default dotenv startup, `--no-env` process-only startup, custom-server upgrades, and `npm run db:migrate`.