### PR TITLE
Keep pending authentication E2E focused on request locking

### DIFF
--- a/e2e/dashboard-desktop.spec.ts
+++ b/e2e/dashboard-desktop.spec.ts
@@ -20,7 +20,7 @@ test("locks authentication mode while a request is pending", async ({ hub }) => 
   await hub.signUpAs("owner", owner);
   await hub.createOrganization("owner", "Acme");
   await hub.signOut("owner");
-  await hub.proveAuthenticationPendingLocksMode("owner", owner, "Acme");
+  await hub.proveAuthenticationPendingLocksMode("owner", owner);
 });
 
 test("keeps authentication locked until the signed-in account installs", async ({ hub }) => {

--- a/e2e/helpers/hub.ts
+++ b/e2e/helpers/hub.ts
@@ -500,12 +500,8 @@ export class PaseoHub {
     await this.requireUser(alias).expectDesktopSidebarAndOrganizationMenu();
   }
 
-  async proveAuthenticationPendingLocksMode(
-    alias: string,
-    account: Account,
-    organization: string,
-  ): Promise<void> {
-    await this.requireUser(alias).proveAuthenticationPendingLocksMode(account, organization);
+  async proveAuthenticationPendingLocksMode(alias: string, account: Account): Promise<void> {
+    await this.requireUser(alias).proveAuthenticationPendingLocksMode(account);
   }
 
   async proveAuthenticationSettlementLocksMode(
@@ -2781,7 +2777,7 @@ class HubUser {
     await form.getByRole("button", { name: "Create account" }).click();
   }
 
-  async proveAuthenticationPendingLocksMode(account: Account, organization: string): Promise<void> {
+  async proveAuthenticationPendingLocksMode(account: Account): Promise<void> {
     const serverFunctions = "**/_serverFn/**";
     let authRequests = 0;
     let responseCompleted = () => {};
@@ -2831,11 +2827,6 @@ class HubUser {
       await delivered;
       await this.page.unroute(serverFunctions);
     }
-    await expect(
-      this.page
-        .getByRole("heading", { name: "Choose an organization" })
-        .or(this.page.locator("header").first().getByText(organization, { exact: true })),
-    ).toBeVisible();
   }
 
   async proveAuthenticationSettlementLocksMode(


### PR DESCRIPTION
The pending-authentication browser test now ends after proving that authentication controls remain locked and duplicate submissions are prevented. Signed-in account installation and landing remain covered by the adjacent settlement test, avoiding a race on an unrelated render transition after the pending response is released.

## Goals

- Keep the pending-request test scoped to request-locking behavior.
- Preserve explicit coverage of account installation and signed-in landing.
- Remove the CI race without increasing timeouts or adding retries.

## Non-goals

- Change authentication product behavior.
- Change application readiness or query timing.
- Mask database/container startup failures.

## Why

The failed main build timed out after all pending-authentication assertions had passed. Releasing the intercepted response made it available to the browser but did not own the later React Query refetch and signed-in render; that separate lifecycle already has a dedicated test.

## Verification

- Production build passed.
- Typecheck passed.
- Formatting and diff checks passed.
- Pending-authentication scenario passed 10/10 serial repetitions.
- Two-worker stress reached the application successfully 18 times; the two other repetitions failed before app startup on PostgreSQL migration/query timeouts, not in the changed scenario.

## Risk surface

Test-only change. The adjacent settlement test continues to assert the final signed-in organization state.
