### PR TITLE
Keep local Hub data outside the working directory

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
-# Hub uses an embedded database under .dev/paseo-hub by default. Set DATABASE_URL to use PostgreSQL.
+# Hub uses an embedded database under $XDG_DATA_HOME/paseo-hub by default, falling back to
+# ~/.local/share/paseo-hub. Set DATABASE_URL to use PostgreSQL.
 # DATABASE_URL=postgres://postgres:postgres@localhost:5432/paseo_hub
-# PASEO_HUB_DATA_DIR=.dev/paseo-hub
+# PASEO_HUB_DATA_DIR=/path/to/paseo-hub-data
 PASEO_HUB_APP_URL=http://localhost:3000
 # Optional advanced override. Hub otherwise generates and stores a stable secret in its database.
 # PASEO_HUB_AUTH_SECRET=

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ npm install
 npm run dev
 ```
 
-Open <http://localhost:3000>. Hub stores the embedded database and its generated authentication secret in `.dev/paseo-hub` and keeps both across restarts. Set `PASEO_HUB_DATA_DIR` to use a different directory, or set `DATABASE_URL` to use PostgreSQL instead:
+Open <http://localhost:3000>. Hub stores the embedded database and its generated authentication secret under `$XDG_DATA_HOME/paseo-hub`, falling back to `~/.local/share/paseo-hub`, and keeps both across restarts. Set `PASEO_HUB_DATA_DIR` to use a different directory, or set `DATABASE_URL` to use PostgreSQL instead:
 
 ```sh
 DATABASE_URL=postgres://postgres:postgres@localhost:5432/paseo_hub npm run dev

--- a/src/data-directory.test.ts
+++ b/src/data-directory.test.ts
@@ -30,7 +30,7 @@ describe("Hub data directory", () => {
     }
   });
 
-  it("keeps PASEO_HUB_DATA_DIR as the explicit absolute or working-directory-relative override", () => {
+  it("keeps every defined PASEO_HUB_DATA_DIR as an explicit override", () => {
     const explicitDirectory = resolve("fixtures", "explicit-data");
     const workingDirectory = resolve("fixtures", "work");
     assert.equal(
@@ -54,6 +54,17 @@ describe("Hub data directory", () => {
         workingDirectory,
       }),
       join(workingDirectory, "var", "paseo-hub"),
+    );
+    assert.equal(
+      resolveHubDataDirectory({
+        environment: {
+          PASEO_HUB_DATA_DIR: "",
+          XDG_DATA_HOME: resolve("fixtures", "xdg-data"),
+        },
+        homeDirectory: resolve("fixtures", "home"),
+        workingDirectory,
+      }),
+      workingDirectory,
     );
   });
 });

--- a/src/data-directory.test.ts
+++ b/src/data-directory.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { join, resolve } from "node:path";
+import { describe, it } from "vitest";
+import { resolveHubDataDirectory } from "./data-directory.js";
+
+describe("Hub data directory", () => {
+  it("stores Hub data under XDG_DATA_HOME", () => {
+    const dataHome = resolve("fixtures", "xdg-data");
+    assert.equal(
+      resolveHubDataDirectory({
+        environment: { XDG_DATA_HOME: dataHome },
+        homeDirectory: resolve("fixtures", "home"),
+        workingDirectory: resolve("fixtures", "work"),
+      }),
+      join(dataHome, "paseo-hub"),
+    );
+  });
+
+  it("uses the XDG default when XDG_DATA_HOME is absent, empty, or relative", () => {
+    const homeDirectory = resolve("fixtures", "home");
+    for (const xdgDataHome of [undefined, "", "relative/data"]) {
+      assert.equal(
+        resolveHubDataDirectory({
+          environment: { XDG_DATA_HOME: xdgDataHome },
+          homeDirectory,
+          workingDirectory: resolve("fixtures", "work"),
+        }),
+        join(homeDirectory, ".local", "share", "paseo-hub"),
+      );
+    }
+  });
+
+  it("keeps PASEO_HUB_DATA_DIR as the explicit absolute or working-directory-relative override", () => {
+    const explicitDirectory = resolve("fixtures", "explicit-data");
+    const workingDirectory = resolve("fixtures", "work");
+    assert.equal(
+      resolveHubDataDirectory({
+        environment: {
+          PASEO_HUB_DATA_DIR: explicitDirectory,
+          XDG_DATA_HOME: resolve("fixtures", "xdg-data"),
+        },
+        homeDirectory: resolve("fixtures", "home"),
+        workingDirectory,
+      }),
+      explicitDirectory,
+    );
+    assert.equal(
+      resolveHubDataDirectory({
+        environment: {
+          PASEO_HUB_DATA_DIR: "var/paseo-hub",
+          XDG_DATA_HOME: resolve("fixtures", "xdg-data"),
+        },
+        homeDirectory: resolve("fixtures", "home"),
+        workingDirectory,
+      }),
+      join(workingDirectory, "var", "paseo-hub"),
+    );
+  });
+});

--- a/src/data-directory.ts
+++ b/src/data-directory.ts
@@ -1,0 +1,30 @@
+import { homedir } from "node:os";
+import { isAbsolute, join, resolve } from "node:path";
+
+const APPLICATION_DATA_DIRECTORY = "paseo-hub";
+
+interface HubDataDirectoryOptions {
+  environment?: Record<string, string | undefined>;
+  homeDirectory?: string;
+  workingDirectory?: string;
+}
+
+/** Resolves the one durable home for the embedded database and generated runtime secrets. */
+export function resolveHubDataDirectory(options: HubDataDirectoryOptions = {}): string {
+  const environment = options.environment ?? process.env;
+  const workingDirectory = options.workingDirectory ?? process.cwd();
+  const override = nonEmpty(environment["PASEO_HUB_DATA_DIR"]);
+  if (override !== undefined) return resolve(workingDirectory, override);
+
+  const configuredDataHome = nonEmpty(environment["XDG_DATA_HOME"]);
+  const dataHome =
+    configuredDataHome !== undefined && isAbsolute(configuredDataHome)
+      ? configuredDataHome
+      : join(options.homeDirectory ?? homedir(), ".local", "share");
+  return join(dataHome, APPLICATION_DATA_DIRECTORY);
+}
+
+function nonEmpty(value: string | undefined): string | undefined {
+  if (value === undefined || value.trim().length === 0) return undefined;
+  return value;
+}

--- a/src/data-directory.ts
+++ b/src/data-directory.ts
@@ -13,7 +13,7 @@ interface HubDataDirectoryOptions {
 export function resolveHubDataDirectory(options: HubDataDirectoryOptions = {}): string {
   const environment = options.environment ?? process.env;
   const workingDirectory = options.workingDirectory ?? process.cwd();
-  const override = nonEmpty(environment["PASEO_HUB_DATA_DIR"]);
+  const override = environment["PASEO_HUB_DATA_DIR"];
   if (override !== undefined) return resolve(workingDirectory, override);
 
   const configuredDataHome = nonEmpty(environment["XDG_DATA_HOME"]);

--- a/src/index.embedded.integration.test.ts
+++ b/src/index.embedded.integration.test.ts
@@ -12,6 +12,7 @@ import { assertOneFailure, FailureLogStream } from "./test-utils/failure-logs.js
 const ENVIRONMENT_NAMES = [
   "DATABASE_URL",
   "PASEO_HUB_DATA_DIR",
+  "XDG_DATA_HOME",
   "PASEO_HUB_AUTH_SECRET",
   "PASEO_HUB_APP_URL",
   "PASEO_REGISTRATION_MODE",
@@ -167,6 +168,23 @@ it("selects embedded storage without DATABASE_URL and preserves it across restar
     runtime_configurations: 1,
     auth_secret: firstSecret,
   });
+});
+
+it("selects the XDG data directory when no explicit data directory is configured", async () => {
+  const dataHome = join(root, "xdg-data");
+  delete process.env["PASEO_HUB_DATA_DIR"];
+  process.env["XDG_DATA_HOME"] = dataHome;
+
+  await startProductionRuntime();
+  await stopProductionRuntime();
+
+  const bundle = await embeddedDatabaseRuntime(join(dataHome, "paseo-hub"));
+  const result = await bundle.runtime.query<{ runtime_configurations: number }>(
+    `select count(*)::integer as runtime_configurations from runtime_configuration`,
+  );
+  await bundle.runtime.close();
+
+  assert.deepEqual(result.rows, [{ runtime_configurations: 1 }]);
 });
 
 async function storedAuthSecret(): Promise<string> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 import { randomBytes } from "node:crypto";
 import { validateHeaderName, type IncomingMessage } from "node:http";
-import { join, resolve as resolvePath } from "node:path";
 import type { Duplex } from "node:stream";
 import type { Logger } from "pino";
 import type { RuntimeConfig } from "./config/index.js";
@@ -45,6 +44,7 @@ import {
   resolveCallbackOrigin,
 } from "./provider-applications/index.js";
 import { createSlackSocketInstallationVerifier } from "./providers/slack/installation.js";
+import { resolveHubDataDirectory } from "./data-directory.js";
 
 export interface ProductionRuntimeOptions {
   environmentSource: RuntimeEnvironmentSource;
@@ -216,9 +216,7 @@ async function createDatabaseHandle(): Promise<DatabaseRuntimeBundle & { databas
     );
   }
 
-  const dataDirectory = resolvePath(
-    process.env["PASEO_HUB_DATA_DIR"] ?? join(process.cwd(), ".dev", "paseo-hub"),
-  );
+  const dataDirectory = resolveHubDataDirectory();
   return initializeDatabaseRuntime(
     () => embeddedDatabaseRuntime(dataDirectory),
     `database runtime ready: embedded (${dataDirectory})`,


### PR DESCRIPTION
## What changed

The zero-configuration Hub now keeps its embedded database and generated runtime secrets in the user's XDG data directory instead of the directory where Hub happened to be launched.

- use `$XDG_DATA_HOME/paseo-hub` when `XDG_DATA_HOME` is an absolute path
- fall back to `~/.local/share/paseo-hub`
- keep `PASEO_HUB_DATA_DIR` as the explicit override, including its existing relative-path behavior
- document the default in the README and environment example

## Why

The embedded database contains durable user data: the operator account, provider configuration, runtime secrets, and execution history. Putting it under `.dev` in the current working directory made that state depend on the launch directory and could leave it inside an unrelated project checkout.

## Scope

This does not migrate existing `.dev/paseo-hub` directories, change PostgreSQL or Docker deployments, or address npm packaging. The cwd-based embedded default has not shipped yet.

No linked issue or superseded PR.

## Verification

- `npm test` — 935 passed, 15 skipped
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- focused data-directory and embedded-production tests — 10 passed

## Risk surface

Only launches without both `DATABASE_URL` and `PASEO_HUB_DATA_DIR` change location. Relative `XDG_DATA_HOME` values are ignored as required by the XDG base-directory specification; explicit relative `PASEO_HUB_DATA_DIR` values remain relative to the working directory.
