### PR TITLE
Add explicit GitHub workflow triggers

### DIFF
--- a/e2e/apps.spec.ts
+++ b/e2e/apps.spec.ts
@@ -170,6 +170,7 @@ test("on HTTPS GitHub event triggers are set up beside repository access", async
     expect(await github.subscribedEvents()).toEqual([
       "Issue comment",
       "Issues",
+      "Pull requests",
       "Pull request review",
       "Pull request review comment",
       "Push",

--- a/src/auth/github-events.ts
+++ b/src/auth/github-events.ts
@@ -7,6 +7,7 @@ const UserSchema = z
   .passthrough()
   .optional()
   .catch(undefined);
+const LabelSchema = z.object({ name: OptionalStringSchema }).passthrough();
 
 export const WebhookPayloadSchema = z
   .object({
@@ -107,6 +108,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 export const IssueCommentPayloadSchema = z
   .object({
+    action: OptionalStringSchema,
     issue: z
       .object({
         number: OptionalNumberSchema,
@@ -114,6 +116,7 @@ export const IssueCommentPayloadSchema = z
         body: OptionalStringSchema,
         html_url: OptionalStringSchema,
         user: UserSchema,
+        labels: z.array(LabelSchema).optional().catch(undefined),
         pull_request: z.object({}).passthrough().optional().catch(undefined),
       })
       .optional()
@@ -132,6 +135,7 @@ export const IssueCommentPayloadSchema = z
 
 export const IssuesPayloadSchema = z
   .object({
+    action: OptionalStringSchema,
     issue: z
       .object({
         number: OptionalNumberSchema,
@@ -139,15 +143,18 @@ export const IssuesPayloadSchema = z
         body: OptionalStringSchema,
         html_url: OptionalStringSchema,
         user: UserSchema,
+        labels: z.array(LabelSchema).optional().catch(undefined),
       })
       .optional()
       .catch(undefined),
     sender: UserSchema,
+    label: LabelSchema.optional().catch(undefined),
   })
   .passthrough();
 
 export const PullRequestPayloadSchema = z
   .object({
+    action: OptionalStringSchema,
     pull_request: z
       .object({
         number: OptionalNumberSchema,
@@ -155,6 +162,7 @@ export const PullRequestPayloadSchema = z
         body: OptionalStringSchema,
         html_url: OptionalStringSchema,
         user: UserSchema,
+        labels: z.array(LabelSchema).optional().catch(undefined),
         head: z
           .object({
             ref: OptionalStringSchema,
@@ -165,6 +173,7 @@ export const PullRequestPayloadSchema = z
       .optional()
       .catch(undefined),
     sender: UserSchema,
+    label: LabelSchema.optional().catch(undefined),
   })
   .passthrough();
 

--- a/src/config/compiler.ts
+++ b/src/config/compiler.ts
@@ -84,6 +84,8 @@ const AuthoredTriggerFilterSchema = z
   .object({
     pattern: z.string().optional(),
     contains: z.string().optional(),
+    label: z.string().min(1).optional(),
+    labels: z.array(z.string().min(1)).min(1).optional(),
     repo: z.string().min(1).optional(),
     guild: z.string().min(1).optional(),
     workspace: z.string().min(1).optional(),

--- a/src/projects/activity-summary.test.ts
+++ b/src/projects/activity-summary.test.ts
@@ -50,6 +50,33 @@ describe("summarizeTrigger", () => {
     });
   });
 
+  it("summarizes a created pull request with its number and title", () => {
+    const summary = summarizeTrigger("github.pull_request_created", {
+      id: "1",
+      type: "pull_request",
+      repo: "acme/widgets",
+      repositoryId: 1,
+      installationId: 1,
+      createdAt: new Date().toISOString(),
+      payload: {
+        action: "opened",
+        pull_request: {
+          number: 42,
+          title: "Ship semantic events",
+          html_url: "https://github.com/acme/widgets/pull/42",
+        },
+        sender: { login: "alice" },
+      },
+    });
+
+    assert.deepEqual(summary, {
+      provider: "github",
+      headline: "Pull request #42 created: Ship semantic events",
+      actor: "alice",
+      externalUrl: "https://github.com/acme/widgets/pull/42",
+    });
+  });
+
   it("falls back to a generic headline when a valid envelope carries a malformed event payload", () => {
     const summary = summarizeTrigger("github.push", {
       id: "1",

--- a/src/projects/activity-summary.ts
+++ b/src/projects/activity-summary.ts
@@ -11,6 +11,7 @@ import {
 } from "../auth/github-events.js";
 import { NormalizedDiscordMessageEventSchema } from "../triggers/discord/events.js";
 import { NormalizedSlackMentionEventSchema } from "../triggers/slack/events.js";
+import { classifyGitHubEvent } from "../triggers/github/classification.js";
 
 export interface TriggerSummary {
   provider: "github" | "slack" | "discord" | "manual";
@@ -55,6 +56,18 @@ function summarizeGitHub(payload: unknown): TriggerSummary {
     return { provider: "github", headline: "GitHub event", actor: null, externalUrl: null };
   }
   const externalUrl = readGitHubTriggerUrl(event.data.payload) ?? null;
+  const classified = classifyGitHubEvent(event.data);
+  if (classified.semanticEvent === "github.pull_request_created") {
+    return {
+      provider: "github",
+      headline:
+        classified.item?.number === null || classified.item === null
+          ? "Pull request created"
+          : `Pull request #${String(classified.item.number)} created${classified.item.title === null ? "" : `: ${classified.item.title}`}`,
+      actor: classified.actor.length === 0 ? null : classified.actor,
+      externalUrl,
+    };
+  }
   const { headline, actor } = summarizeGitHubEvent(event.data.type, event.data.payload);
   return { provider: "github", headline, actor, externalUrl };
 }

--- a/src/provider-applications/guides.test.ts
+++ b/src/provider-applications/guides.test.ts
@@ -205,7 +205,14 @@ test("GitHub renders permissions as a mapping and events as a list, never as pro
   ]);
   assert.deepEqual(
     steps.flatMap((step) => step.events ?? []),
-    ["Issue comment", "Issues", "Pull request review", "Pull request review comment", "Push"],
+    [
+      "Issue comment",
+      "Issues",
+      "Pull requests",
+      "Pull request review",
+      "Pull request review comment",
+      "Push",
+    ],
   );
   const prose = steps.map(stepText).join(" ");
   assert.ok(

--- a/src/provider-applications/guides.ts
+++ b/src/provider-applications/guides.ts
@@ -260,6 +260,7 @@ export const GITHUB_GUIDE: ProviderGuide = {
           events: [
             "Issue comment",
             "Issues",
+            "Pull requests",
             "Pull request review",
             "Pull request review comment",
             "Push",

--- a/src/provider-applications/internal/runtime-owner.test.ts
+++ b/src/provider-applications/internal/runtime-owner.test.ts
@@ -14,6 +14,47 @@ import type {
 import { DynamicProviderRuntime } from "./runtime-owner.js";
 
 describe("dynamic provider runtime", () => {
+  it.each([
+    "github.issue_created",
+    "github.pull_request_created",
+    "github.issue_comment_created",
+    "github.pull_request_comment_created",
+    "github.issue_label_added",
+    "github.pull_request_label_added",
+  ] as const)("publishes %s through the activated GitHub runtime registry", async (eventName) => {
+    const runtime = new DynamicProviderRuntime({
+      database: createMemoryDatabase(),
+      auth: testAuth(),
+      applicationBaseUrl: "https://hub.test",
+      registrationFactory: ({ configuration }) =>
+        downstreamRegistration(providerConfigurationId(configuration), [], []),
+    });
+    const stable = runtime
+      .registrations()
+      .find((registration) => registration.connection.name === "github")!;
+    await stable.sources[0]!.start(() => Promise.resolve());
+    const trigger = stable.triggerProviders[0]!({
+      configurationStoreForProject: () => {
+        throw new Error("unused");
+      },
+      connectionsForProject: () => {
+        throw new Error("unused");
+      },
+    })!;
+
+    const candidate = await runtime.prepare(
+      "github",
+      providerConfiguration("github", "A1"),
+      "https://hub.test",
+      providerIdentity("github", "A1"),
+      1,
+    );
+    await candidate.start();
+    candidate.publish();
+
+    assert.ok(trigger.eventNames.includes(eventName));
+  });
+
   it("publishes a started replacement, retires old resources, and retains in-flight snapshots", async () => {
     const started: string[] = [];
     const stopped: string[] = [];

--- a/src/provider-applications/internal/runtime-owner.test.ts
+++ b/src/provider-applications/internal/runtime-owner.test.ts
@@ -15,6 +15,11 @@ import { DynamicProviderRuntime } from "./runtime-owner.js";
 
 describe("dynamic provider runtime", () => {
   it.each([
+    "github.issues",
+    "github.issue_comment",
+    "github.pull_request_review",
+    "github.pull_request_review_comment",
+    "github.push",
     "github.issue_created",
     "github.pull_request_created",
     "github.issue_comment_created",

--- a/src/provider-applications/internal/runtime-owner.ts
+++ b/src/provider-applications/internal/runtime-owner.ts
@@ -22,6 +22,7 @@ import type {
 } from "../index.js";
 import { parseProviderApplicationConfiguration } from "./store.js";
 import type { SlackDeliveryStatus } from "../../triggers/slack/source/index.js";
+import { GITHUB_TRIGGER_EVENT_NAMES } from "../../triggers/github/classification.js";
 
 interface Slot {
   active: ActiveRegistration | undefined;
@@ -707,13 +708,7 @@ function actionNames(provider: Provider): readonly string[] {
 function eventNames(provider: Provider): TriggerProvider["eventNames"] {
   if (provider === "slack") return ["slack.mention"];
   if (provider === "discord") return ["discord.mention"];
-  return [
-    "github.issue_comment",
-    "github.issues",
-    "github.pull_request_review",
-    "github.pull_request_review_comment",
-    "github.push",
-  ];
+  return GITHUB_TRIGGER_EVENT_NAMES;
 }
 
 async function startSources(active: ActiveRegistration, handler: TriggerHandler): Promise<void> {

--- a/src/triggers/github/classification.ts
+++ b/src/triggers/github/classification.ts
@@ -1,0 +1,182 @@
+import {
+  IssueCommentPayloadSchema,
+  IssuesPayloadSchema,
+  PullRequestPayloadSchema,
+  PullRequestReviewCommentPayloadSchema,
+  PullRequestReviewPayloadSchema,
+} from "../../auth/github-events.js";
+import type { NormalizedGitHubEvent } from "../../auth/github-events.js";
+
+export const GITHUB_SEMANTIC_TRIGGER_EVENT_NAMES = [
+  "github.issue_created",
+  "github.pull_request_created",
+  "github.issue_comment_created",
+  "github.pull_request_comment_created",
+  "github.issue_label_added",
+  "github.pull_request_label_added",
+] as const;
+
+export type GitHubSemanticEvent = (typeof GITHUB_SEMANTIC_TRIGGER_EVENT_NAMES)[number];
+
+export const GITHUB_TRIGGER_EVENT_NAMES = [
+  "github.issue_comment",
+  "github.issues",
+  "github.pull_request_review",
+  "github.pull_request_review_comment",
+  "github.push",
+  ...GITHUB_SEMANTIC_TRIGGER_EVENT_NAMES,
+] as const;
+
+export interface GitHubClassifiedEvent {
+  readonly semanticEvent: GitHubSemanticEvent | undefined;
+  readonly actor: string;
+  readonly text: string;
+  readonly labels: readonly string[];
+  readonly changedLabel: string | undefined;
+  readonly item: GitHubClassifiedItem | null;
+}
+
+export interface GitHubClassifiedItem {
+  readonly type: "issue" | "pull_request";
+  readonly number: number | null;
+  readonly title: string | null;
+  readonly body: string | null;
+  readonly url: string | null;
+  readonly author: { readonly login: string } | null;
+}
+
+/** The sole owner of GitHub webhook action and item interpretation. */
+export function classifyGitHubEvent(event: NormalizedGitHubEvent): GitHubClassifiedEvent {
+  if (event.type === "issues") return classifyIssue(event);
+  if (event.type === "pull_request") return classifyPullRequest(event);
+  if (event.type === "issue_comment") return classifyIssueComment(event);
+  if (event.type === "pull_request_review") return classifyReview(event);
+  if (event.type === "pull_request_review_comment") return classifyReviewComment(event);
+  return emptyClassification();
+}
+
+function classifyIssue(event: NormalizedGitHubEvent): GitHubClassifiedEvent {
+  const payload = IssuesPayloadSchema.parse(event.payload);
+  const item = payload.issue === undefined ? null : itemFor("issue", payload.issue);
+  return {
+    semanticEvent: issueSemanticEvent(payload.action),
+    actor: payload.sender?.login ?? "",
+    text: textFor(item),
+    labels: labelsFor(payload.issue?.labels),
+    changedLabel: payload.action === "labeled" ? payload.label?.name : undefined,
+    item,
+  };
+}
+
+function classifyPullRequest(event: NormalizedGitHubEvent): GitHubClassifiedEvent {
+  const payload = PullRequestPayloadSchema.parse(event.payload);
+  const item =
+    payload.pull_request === undefined ? null : itemFor("pull_request", payload.pull_request);
+  return {
+    semanticEvent: pullRequestSemanticEvent(payload.action),
+    actor: payload.sender?.login ?? "",
+    text: textFor(item),
+    labels: labelsFor(payload.pull_request?.labels),
+    changedLabel: payload.action === "labeled" ? payload.label?.name : undefined,
+    item,
+  };
+}
+
+function classifyIssueComment(event: NormalizedGitHubEvent): GitHubClassifiedEvent {
+  const payload = IssueCommentPayloadSchema.parse(event.payload);
+  const isPullRequest = payload.issue?.pull_request !== undefined;
+  return {
+    semanticEvent: commentSemanticEvent(payload.action, isPullRequest),
+    actor: payload.sender?.login ?? payload.comment?.user?.login ?? "",
+    text: payload.comment?.body ?? "",
+    labels: labelsFor(payload.issue?.labels),
+    changedLabel: undefined,
+    item:
+      payload.issue === undefined
+        ? null
+        : itemFor(isPullRequest ? "pull_request" : "issue", payload.issue),
+  };
+}
+
+function classifyReview(event: NormalizedGitHubEvent): GitHubClassifiedEvent {
+  const payload = PullRequestReviewPayloadSchema.parse(event.payload);
+  return {
+    ...emptyClassification(),
+    actor: payload.sender?.login ?? payload.review?.user?.login ?? "",
+    text: payload.review?.body ?? "",
+    labels: labelsFor(payload.pull_request?.labels),
+    item: payload.pull_request === undefined ? null : itemFor("pull_request", payload.pull_request),
+  };
+}
+
+function classifyReviewComment(event: NormalizedGitHubEvent): GitHubClassifiedEvent {
+  const payload = PullRequestReviewCommentPayloadSchema.parse(event.payload);
+  return {
+    ...emptyClassification(),
+    actor: payload.sender?.login ?? payload.comment?.user?.login ?? "",
+    text: payload.comment?.body ?? "",
+    labels: labelsFor(payload.pull_request?.labels),
+    item: payload.pull_request === undefined ? null : itemFor("pull_request", payload.pull_request),
+  };
+}
+
+function emptyClassification(): GitHubClassifiedEvent {
+  return {
+    semanticEvent: undefined,
+    actor: "",
+    text: "",
+    labels: [],
+    changedLabel: undefined,
+    item: null,
+  };
+}
+
+function issueSemanticEvent(action: string | undefined): GitHubSemanticEvent | undefined {
+  if (action === "opened") return "github.issue_created";
+  if (action === "labeled") return "github.issue_label_added";
+  return undefined;
+}
+
+function pullRequestSemanticEvent(action: string | undefined): GitHubSemanticEvent | undefined {
+  if (action === "opened") return "github.pull_request_created";
+  if (action === "labeled") return "github.pull_request_label_added";
+  return undefined;
+}
+
+function commentSemanticEvent(
+  action: string | undefined,
+  isPullRequest: boolean,
+): GitHubSemanticEvent | undefined {
+  if (action !== "created") return undefined;
+  return isPullRequest ? "github.pull_request_comment_created" : "github.issue_comment_created";
+}
+
+function itemFor(
+  type: GitHubClassifiedItem["type"],
+  item: {
+    number?: number | undefined;
+    title?: string | undefined;
+    body?: string | undefined;
+    html_url?: string | undefined;
+    user?: { login?: string | undefined } | undefined;
+  },
+): GitHubClassifiedItem {
+  return {
+    type,
+    number: item.number ?? null,
+    title: item.title ?? null,
+    body: item.body ?? null,
+    url: item.html_url ?? null,
+    author: item.user?.login === undefined ? null : { login: item.user.login },
+  };
+}
+
+function textFor(item: GitHubClassifiedItem | null): string {
+  return [item?.title ?? "", item?.body ?? ""].filter((value) => value.length > 0).join("\n");
+}
+
+function labelsFor(
+  labels: readonly { name?: string | undefined }[] | undefined,
+): readonly string[] {
+  return labels?.flatMap((label) => (label.name === undefined ? [] : [label.name])) ?? [];
+}

--- a/src/triggers/github/match.test.ts
+++ b/src/triggers/github/match.test.ts
@@ -5,6 +5,176 @@ import type { NormalizedGitHubEvent } from "../../auth/github-events.js";
 import { matchTriggers } from "./match.js";
 
 describe("GitHub trigger matching", () => {
+  it.each([
+    ["actions", ["opened"]],
+    ["item_types", ["issue"]],
+    ["labels", []],
+  ])("does not accept the unsupported or empty %s filter", (key, value) => {
+    assert.throws(() => configFor({ from_users: ["boudra"], [key]: value }));
+  });
+
+  it.each([
+    {
+      acceptance: "1: issue_created accepts only opened issues",
+      on: "github.issue_created",
+      event: eventFor("issues", { action: "opened", issue: issue() }),
+      expected: 1,
+    },
+    {
+      acceptance: "1: issue_created rejects non-opened issues",
+      on: "github.issue_created",
+      event: eventFor("issues", { action: "closed", issue: issue() }),
+      expected: 0,
+    },
+    {
+      acceptance: "2: pull_request_created accepts only opened pull requests",
+      on: "github.pull_request_created",
+      event: eventFor("pull_request", { action: "opened", pull_request: pullRequest() }),
+      expected: 1,
+    },
+    {
+      acceptance: "2: pull_request_created rejects non-opened pull requests",
+      on: "github.pull_request_created",
+      event: eventFor("pull_request", { action: "closed", pull_request: pullRequest() }),
+      expected: 0,
+    },
+    {
+      acceptance: "3: created issue comments are separate from pull-request comments",
+      on: "github.issue_comment_created",
+      event: eventFor("issue_comment", { action: "created", issue: issue(), comment: comment() }),
+      expected: 1,
+    },
+    {
+      acceptance: "3: created pull-request comments are separate from issue comments",
+      on: "github.pull_request_comment_created",
+      event: eventFor("issue_comment", {
+        action: "created",
+        issue: { ...issue(), pull_request: {} },
+        comment: comment(),
+      }),
+      expected: 1,
+    },
+    {
+      acceptance: "3: semantic comments reject actions other than created",
+      on: "github.issue_comment_created",
+      event: eventFor("issue_comment", { action: "edited", issue: issue(), comment: comment() }),
+      expected: 0,
+    },
+    {
+      acceptance: "4: issue label_added matches its changed label case-insensitively",
+      on: "github.issue_label_added",
+      filters: { label: "READY-FOR-AGENT" },
+      event: eventFor("issues", {
+        action: "labeled",
+        issue: issue(),
+        label: { name: "ready-for-agent" },
+      }),
+      expected: 1,
+    },
+    {
+      acceptance: "4: pull-request label_added matches its changed label",
+      on: "github.pull_request_label_added",
+      filters: { label: "ready-for-agent" },
+      event: eventFor("pull_request", {
+        action: "labeled",
+        pull_request: pullRequest(),
+        label: { name: "ready-for-agent" },
+      }),
+      expected: 1,
+    },
+    {
+      acceptance: "5: labels requires every current issue label",
+      on: "github.issue_created",
+      filters: { labels: ["bug", "BACKEND"] },
+      event: eventFor("issues", {
+        action: "opened",
+        issue: issue({ labels: [{ name: "Bug" }, { name: "backend" }] }),
+      }),
+      expected: 1,
+    },
+    {
+      acceptance: "5: labels rejects a missing current pull-request label",
+      on: "github.pull_request_created",
+      filters: { labels: ["bug", "backend"] },
+      event: eventFor("pull_request", {
+        action: "opened",
+        pull_request: pullRequest({ labels: [{ name: "bug" }] }),
+      }),
+      expected: 0,
+    },
+    {
+      acceptance: "5: labels applies to issue comments",
+      on: "github.issue_comment_created",
+      filters: { labels: ["bug", "backend"] },
+      event: eventFor("issue_comment", {
+        action: "created",
+        issue: issue({ labels: [{ name: "bug" }, { name: "backend" }] }),
+        comment: comment(),
+      }),
+      expected: 1,
+    },
+    {
+      acceptance: "6: repository, connection, sender, content, and label filters compose with AND",
+      on: "github.issue_label_added",
+      filters: {
+        repo: "boudra/faro",
+        connection: "github-main",
+        contains: "body",
+        from_users: ["boudra"],
+        label: "ready-for-agent",
+        labels: ["bug"],
+      },
+      connectionId: "11111111-1111-4111-8111-111111111111",
+      event: eventFor("issues", {
+        action: "labeled",
+        issue: issue({ body: "body", labels: [{ name: "bug" }] }),
+        label: { name: "ready-for-agent" },
+      }),
+      expected: 1,
+    },
+    {
+      acceptance: "6: any failed composed filter rejects",
+      on: "github.issue_label_added",
+      filters: { contains: "different", label: "ready-for-agent" },
+      event: eventFor("issues", {
+        action: "labeled",
+        issue: issue({ body: "body" }),
+        label: { name: "ready-for-agent" },
+      }),
+      expected: 0,
+    },
+    {
+      acceptance: "7: legacy issues retains its action-agnostic behavior",
+      on: "github.issues",
+      event: eventFor("issues", { action: "closed", issue: issue() }),
+      expected: 1,
+    },
+    {
+      acceptance: "7: legacy issue_comment retains its action-agnostic behavior",
+      on: "github.issue_comment",
+      event: eventFor("issue_comment", { action: "edited", issue: issue(), comment: comment() }),
+      expected: 1,
+    },
+  ])("$acceptance", ({ on, filters, event, expected, connectionId }) => {
+    const config = configFor({
+      from_users: ["boudra"],
+      ...filters,
+      ...(connectionId === undefined ? {} : { connection: "github-main" }),
+    });
+    const trigger = config.triggers[0]!;
+    const configured = {
+      ...config,
+      triggers: [
+        {
+          ...trigger,
+          on,
+          filters: { ...trigger.filters, ...(connectionId === undefined ? {} : { connectionId }) },
+        },
+      ],
+    };
+    assert.equal(matchTriggers(configured, event, connectionId).length, expected);
+  });
+
   it("matches the compiled one-step trigger by repository, text, and actor", () => {
     const config = configFor({ repo: "boudra/faro", contains: "@paseo", from_users: ["boudra"] });
     const matches = matchTriggers(config, createEvent());
@@ -127,6 +297,29 @@ function configFor(filters: Record<string, unknown>) {
       },
     ],
   });
+}
+
+function issue(overrides: Record<string, unknown> = {}) {
+  return { number: 12, title: "Title", body: "body", user: { login: "author" }, ...overrides };
+}
+
+function pullRequest(overrides: Record<string, unknown> = {}) {
+  return {
+    number: 12,
+    title: "Title",
+    body: "body",
+    user: { login: "author" },
+    head: { ref: "topic" },
+    ...overrides,
+  };
+}
+
+function comment() {
+  return { id: 123, body: "comment body", user: { login: "boudra" } };
+}
+
+function eventFor(type: string, payload: Record<string, unknown>): NormalizedGitHubEvent {
+  return { ...createEvent(), type, payload: { ...payload, sender: { login: "boudra" } } };
 }
 
 function createEvent(

--- a/src/triggers/github/match.test.ts
+++ b/src/triggers/github/match.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "vitest";
 import { compileHubConfig } from "../../config/index.js";
 import type { NormalizedGitHubEvent } from "../../auth/github-events.js";
-import { matchTriggers } from "./match.js";
+import { matchTriggers, readGitHubInvocationMessage } from "./match.js";
 
 describe("GitHub trigger matching", () => {
   it.each([
@@ -175,6 +175,72 @@ describe("GitHub trigger matching", () => {
     assert.equal(matchTriggers(configured, event, connectionId).length, expected);
   });
 
+  it.each([
+    {
+      name: "issues",
+      event: eventFor("issues", {
+        action: "closed",
+        issue: issue({ title: "Issue title", body: "Issue body" }),
+      }),
+      text: "Issue title\nIssue body",
+      anotherAction: "reopened",
+    },
+    {
+      name: "issue comments",
+      event: eventFor("issue_comment", {
+        action: "edited",
+        issue: issue(),
+        comment: comment({ body: "Issue comment" }),
+      }),
+      text: "Issue comment",
+      anotherAction: "deleted",
+    },
+    {
+      name: "pull-request reviews",
+      event: eventFor("pull_request_review", {
+        action: "submitted",
+        pull_request: pullRequest(),
+        review: { body: "Review body", user: { login: "reviewer" } },
+      }),
+      text: "Review body",
+      anotherAction: "edited",
+    },
+    {
+      name: "pull-request review comments",
+      event: eventFor("pull_request_review_comment", {
+        action: "created",
+        pull_request: pullRequest(),
+        comment: comment({ body: "Review comment" }),
+      }),
+      text: "Review comment",
+      anotherAction: "deleted",
+    },
+  ])(
+    "keeps legacy $name actor, text, and action-agnostic matching",
+    ({ event, text, anotherAction }) => {
+      const config = configFor({ contains: text, from_users: ["boudra"] });
+      const trigger = config.triggers[0]!;
+      const configured = { ...config, triggers: [{ ...trigger, on: `github.${event.type}` }] };
+
+      assert.equal(readGitHubInvocationMessage(event), text);
+      assert.equal(matchTriggers(configured, event).length, 1);
+      assert.equal(
+        matchTriggers(configured, {
+          ...event,
+          payload: { ...event.payload, sender: { login: "someone-else" } },
+        }).length,
+        0,
+      );
+      assert.equal(
+        matchTriggers(configured, {
+          ...event,
+          payload: { ...event.payload, action: anotherAction },
+        }).length,
+        1,
+      );
+    },
+  );
+
   it("matches the compiled one-step trigger by repository, text, and actor", () => {
     const config = configFor({ repo: "boudra/faro", contains: "@paseo", from_users: ["boudra"] });
     const matches = matchTriggers(config, createEvent());
@@ -314,8 +380,8 @@ function pullRequest(overrides: Record<string, unknown> = {}) {
   };
 }
 
-function comment() {
-  return { id: 123, body: "comment body", user: { login: "boudra" } };
+function comment(overrides: Record<string, unknown> = {}) {
+  return { id: 123, body: "comment body", user: { login: "boudra" }, ...overrides };
 }
 
 function eventFor(type: string, payload: Record<string, unknown>): NormalizedGitHubEvent {

--- a/src/triggers/github/match.ts
+++ b/src/triggers/github/match.ts
@@ -2,13 +2,8 @@ import type {
   CompiledTriggerConfig as CompiledTrigger,
   TriggerFilter,
 } from "../../config/index.js";
-import {
-  IssueCommentPayloadSchema,
-  IssuesPayloadSchema,
-  PullRequestReviewCommentPayloadSchema,
-  PullRequestReviewPayloadSchema,
-} from "../../auth/github-events.js";
 import type { NormalizedGitHubEvent } from "../../auth/github-events.js";
+import { classifyGitHubEvent } from "./classification.js";
 
 type MatchedTriggerDefinition = Pick<CompiledTrigger, "name" | "on" | "filters">;
 
@@ -18,7 +13,7 @@ export interface MatchedTriggerEvent {
 }
 
 export function readGitHubInvocationMessage(event: NormalizedGitHubEvent): string {
-  return getFilterText(event);
+  return classifyGitHubEvent(event).text;
 }
 
 export function readGitHubInvocationParserMessage(
@@ -47,11 +42,15 @@ export function matchTriggers(
   event: NormalizedGitHubEvent,
   connectionId?: string | null,
 ): MatchedTriggerEvent[] {
-  const on = `github.${event.type}`;
+  const classified = classifyGitHubEvent(event);
+  const eventNames = new Set([`github.${event.type}`, classified.semanticEvent]);
   const matches: MatchedTriggerEvent[] = [];
 
   for (const trigger of config.triggers) {
-    if (trigger.on !== on || !matchesFilter(event, trigger.filters, connectionId)) {
+    if (
+      !eventNames.has(trigger.on) ||
+      !matchesFilter(classified, trigger.filters, event, connectionId)
+    ) {
       continue;
     }
 
@@ -62,8 +61,9 @@ export function matchTriggers(
 }
 
 function matchesFilter(
-  event: NormalizedGitHubEvent,
+  classified: ReturnType<typeof classifyGitHubEvent>,
   filter: TriggerFilter | undefined,
+  event: NormalizedGitHubEvent,
   connectionId?: string | null,
 ): boolean {
   if (filter === undefined) {
@@ -89,84 +89,46 @@ function matchesFilter(
   }
 
   const pattern = readStringFilter(filter, "pattern");
-  if (pattern !== undefined && !getFilterText(event).startsWith(pattern)) {
+  if (pattern !== undefined && !classified.text.startsWith(pattern)) {
     return false;
   }
 
   const contains = readStringFilter(filter, "contains");
-  if (contains !== undefined && !getFilterText(event).includes(contains)) {
+  if (contains !== undefined && !classified.text.includes(contains)) {
     return false;
   }
 
-  const actor = getEventActor(event);
-  if (!filter.from_users.includes(actor)) {
+  if (!filter.from_users.includes(classified.actor)) {
+    return false;
+  }
+
+  const label = readStringFilter(filter, "label");
+  if (label !== undefined && !sameLabel(label, classified.changedLabel)) {
+    return false;
+  }
+
+  const labels = filter.labels;
+  if (
+    labels !== undefined &&
+    !labels.every((labelName) => classified.labels.some((current) => sameLabel(labelName, current)))
+  ) {
     return false;
   }
 
   return true;
 }
 
-function readStringFilter(filter: TriggerFilter, key: "pattern" | "contains"): string | undefined {
+function readStringFilter(
+  filter: TriggerFilter,
+  key: "pattern" | "contains" | "label",
+): string | undefined {
   const value = filter[key];
   return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 
-function getFilterText(event: NormalizedGitHubEvent): string {
-  switch (event.type) {
-    case "issue_comment": {
-      const payload = IssueCommentPayloadSchema.parse(event.payload);
-      return payload.comment?.body ?? "";
-    }
-    case "issues": {
-      const payload = IssuesPayloadSchema.parse(event.payload);
-      return [payload.issue?.title ?? "", payload.issue?.body ?? ""]
-        .filter((value) => value.length > 0)
-        .join("\n");
-    }
-    case "pull_request_review": {
-      const payload = PullRequestReviewPayloadSchema.parse(event.payload);
-      return payload.review?.body ?? "";
-    }
-    case "pull_request_review_comment": {
-      const payload = PullRequestReviewCommentPayloadSchema.parse(event.payload);
-      return payload.comment?.body ?? "";
-    }
-    default:
-      return "";
-  }
-}
-
-function getEventActor(event: NormalizedGitHubEvent): string {
-  switch (event.type) {
-    case "issue_comment":
-      return getIssueCommentActor(event.payload);
-    case "issues":
-      return getIssuesActor(event.payload);
-    case "pull_request_review":
-      return getPullRequestReviewActor(event.payload);
-    case "pull_request_review_comment":
-      return getPullRequestReviewCommentActor(event.payload);
-    default:
-      return "";
-  }
-}
-
-function getIssueCommentActor(payload: unknown): string {
-  const parsed = IssueCommentPayloadSchema.parse(payload);
-  return parsed.sender?.login ?? parsed.comment?.user?.login ?? "";
-}
-
-function getIssuesActor(payload: unknown): string {
-  const parsed = IssuesPayloadSchema.parse(payload);
-  return parsed.sender?.login ?? "";
-}
-
-function getPullRequestReviewActor(payload: unknown): string {
-  const parsed = PullRequestReviewPayloadSchema.parse(payload);
-  return parsed.sender?.login ?? parsed.review?.user?.login ?? "";
-}
-
-function getPullRequestReviewCommentActor(payload: unknown): string {
-  const parsed = PullRequestReviewCommentPayloadSchema.parse(payload);
-  return parsed.sender?.login ?? parsed.comment?.user?.login ?? "";
+function sameLabel(expected: string, actual: string | undefined): boolean {
+  return (
+    actual !== undefined &&
+    expected.localeCompare(actual, undefined, { sensitivity: "accent" }) === 0
+  );
 }

--- a/src/triggers/github/provider.test.ts
+++ b/src/triggers/github/provider.test.ts
@@ -73,6 +73,36 @@ describe("GitHub Phase 1 trigger provider", () => {
     assert.equal(wrongActor, "trigger_filters_rejected");
   });
 
+  it("routes a semantic trigger from the legacy GitHub webhook source", async () => {
+    const configuration = githubConfiguration();
+    const trigger = configuration.triggers[0]!;
+    configuration.triggers = [
+      {
+        ...trigger,
+        on: "github.issue_created",
+      },
+    ];
+    const { project, revision, store } = await activeConfiguration(configuration);
+    const provider = createProvider(store, new TestReactions());
+    const event: NormalizedGitHubEvent = {
+      ...createEvent(),
+      type: "issues",
+      payload: {
+        action: "opened",
+        issue: {
+          number: 211,
+          title: "smoke",
+          body: "issue body @paseo",
+          user: { login: "issue-author" },
+        },
+        sender: { login: "boudra" },
+      },
+    };
+
+    const matches = await provider.match(external(project.id, revision.id, event));
+    assert.equal(typeof matches === "string" ? 0 : matches.length, 1);
+  });
+
   it("exposes safe issue and pull-request item context without the raw webhook", async () => {
     const { project, revision, store } = await activeConfiguration();
     const provider = createProvider(store, new TestReactions());

--- a/src/triggers/github/provider.ts
+++ b/src/triggers/github/provider.ts
@@ -16,16 +16,12 @@ import {
 import { matchesInputFilters, parseInvocation } from "../invocation.js";
 import {
   IssueCommentPayloadSchema,
-  IssuesPayloadSchema,
   NormalizedGitHubEventSchema,
-  PullRequestPayloadSchema,
-  PullRequestReviewPayloadSchema,
   PullRequestReviewCommentPayloadSchema,
 } from "../../auth/github-events.js";
 import type { NormalizedGitHubEvent } from "../../auth/github-events.js";
-import { z } from "zod";
+import { classifyGitHubEvent, GITHUB_TRIGGER_EVENT_NAMES } from "./classification.js";
 
-const SafeRecordSchema = z.record(z.string(), z.unknown());
 export interface GitHubReactionClient {
   createReaction(input: {
     installationId: number;
@@ -132,13 +128,7 @@ export function createGitHubTriggerProvider(options: {
 }): TriggerProvider<"github", GitHubTriggerContext> {
   return {
     name: "github",
-    eventNames: [
-      "github.issue_comment",
-      "github.issues",
-      "github.pull_request_review",
-      "github.pull_request_review_comment",
-      "github.push",
-    ],
+    eventNames: GITHUB_TRIGGER_EVENT_NAMES,
     async match(externalTrigger) {
       const event = NormalizedGitHubEventSchema.parse(externalTrigger.payload);
       const stored = await options
@@ -146,7 +136,9 @@ export function createGitHubTriggerProvider(options: {
         .getRevision(externalTrigger.configurationRevisionId);
       if (stored === undefined) return "configuration_unavailable";
       if (
-        !stored.configuration.triggers.some((candidate) => candidate.on === externalTrigger.source)
+        !stored.configuration.triggers.some((candidate) =>
+          [externalTrigger.source, classifyGitHubEvent(event).semanticEvent].includes(candidate.on),
+        )
       )
         return "no_trigger_for_source";
       const matches: TriggerProviderMatch<GitHubTriggerContext>[] = [];
@@ -235,51 +227,9 @@ function buildGitHubMergeData(event: NormalizedGitHubEvent): GitHubMergeData {
       event_name: event.type,
       repository: { full_name: event.repo },
       received_at: event.createdAt,
-      item: readGitHubContextItem(event),
+      item: classifyGitHubEvent(event).item,
     },
   };
-}
-
-function readGitHubContextItem(event: NormalizedGitHubEvent): GitHubContextItem | null {
-  if (event.type === "issue_comment") {
-    const issue = IssueCommentPayloadSchema.parse(event.payload).issue;
-    return issue === undefined
-      ? null
-      : githubItem(issue.pull_request === undefined ? "issue" : "pull_request", issue);
-  }
-  if (event.type === "issues") {
-    const issue = IssuesPayloadSchema.parse(event.payload).issue;
-    return issue === undefined ? null : githubItem("issue", issue);
-  }
-  if (event.type === "pull_request_review") {
-    const pullRequest = PullRequestReviewPayloadSchema.parse(event.payload).pull_request;
-    return pullRequest === undefined ? null : githubItem("pull_request", pullRequest);
-  }
-  if (event.type === "pull_request_review_comment") {
-    const pullRequest = PullRequestReviewCommentPayloadSchema.parse(event.payload).pull_request;
-    return pullRequest === undefined ? null : githubItem("pull_request", pullRequest);
-  }
-  const pullRequest = PullRequestPayloadSchema.safeParse(event.payload);
-  if (!pullRequest.success || pullRequest.data.pull_request === undefined) return null;
-  return githubItem("pull_request", pullRequest.data.pull_request);
-}
-
-function githubItem(type: GitHubContextItem["type"], item: unknown): GitHubContextItem {
-  const record = asRecord(item);
-  const user = asRecord(record["user"]);
-  return {
-    type,
-    number: typeof record["number"] === "number" ? record["number"] : null,
-    title: typeof record["title"] === "string" ? record["title"] : null,
-    body: typeof record["body"] === "string" ? record["body"] : null,
-    url: typeof record["html_url"] === "string" ? record["html_url"] : null,
-    author: typeof user["login"] === "string" ? { login: user["login"] } : null,
-  };
-}
-
-function asRecord(value: unknown): Record<string, unknown> {
-  const parsed = SafeRecordSchema.safeParse(value);
-  return parsed.success ? parsed.data : {};
 }
 
 async function reactToLifecycle(

--- a/src/triggers/github/webhook.test.ts
+++ b/src/triggers/github/webhook.test.ts
@@ -130,13 +130,17 @@ describe("GitHub webhook", () => {
       repositoryId: number;
       deliveryId: string;
     }> = [];
+    const acceptedDeliveries: Array<{ source: string; deliveryId: string }> = [];
     const endpoint = createWebhookSource(SECRET, {
       ...webhookOptions(),
-      accept: async () => ({
-        status: "dropped" as const,
-        receiptId: "receipt-config-only",
-        reason: "no_project_route",
-      }),
+      accept: async (input) => {
+        acceptedDeliveries.push({ source: input.source, deliveryId: input.deliveryId });
+        return {
+          status: "dropped" as const,
+          receiptId: "receipt-config-only",
+          reason: "no_project_route",
+        };
+      },
       synchronizePush: async (input) => {
         synchronized.push({
           installationId: input.installationId,
@@ -161,6 +165,9 @@ describe("GitHub webhook", () => {
     );
     assert.deepEqual(synchronized, [
       { installationId: 42, repositoryId: 9001, deliveryId: "config-only-push" },
+    ]);
+    assert.deepEqual(acceptedDeliveries, [
+      { source: "github.push", deliveryId: "config-only-push" },
     ]);
   });
 


### PR DESCRIPTION
GitHub workflows can now subscribe to six explicit events for issue creation, pull-request creation, issue and pull-request comments, and label addition. `label` matches the added label and `labels` requires all current labels, while the five existing GitHub triggers keep their behavior.

## Goals

- Expose the six semantic GitHub trigger events.
- Support case-insensitive changed-label and current-label filtering.
- Preserve legacy trigger matching and delivery/dispatch idempotency.
- Include Pull requests in GitHub App event onboarding and summarize created pull requests in activity.

## Non-goals

- No additional GitHub event families, action filters, item types, database migrations, or documentation changes.

## Verification

- `npm test`
- `npm run release:check`
- Runtime activation coverage verifies every semantic event is published through the dynamic provider registry.

## Risk surface

- GitHub trigger matching and runtime event registration; legacy aliases and duplicate-delivery behavior are covered by regression tests.