### PR TITLE
Add Hub setup resources API and activity redirect

### DIFF
--- a/e2e/onboarding-foundation.spec.ts
+++ b/e2e/onboarding-foundation.spec.ts
@@ -1,0 +1,21 @@
+import { expect } from "@playwright/test";
+import { test } from "./app.js";
+
+test("the legacy project activity URL redirects through the active organization", async ({
+  hub,
+  page,
+}) => {
+  await hub.signUpAs("activity-owner", {
+    name: "Activity Owner",
+    email: "activity-owner@example.com",
+    password: "activity-owner-password",
+  });
+  await hub.createOrganization("activity-owner", "Activity Organization");
+
+  await page.goto(`${hub.primaryApplication().origin}/projects/default/activity`);
+
+  await expect(page).toHaveURL(
+    /\/o\/activity-organization-[a-f0-9]{8}\/projects\/default\/activity\/?$/u,
+  );
+  await expect(page.getByRole("heading", { name: "Activity" })).toBeVisible();
+});

--- a/src/http/node-server.test.ts
+++ b/src/http/node-server.test.ts
@@ -191,6 +191,7 @@ describe("HTTP failure ownership", () => {
     const operations: PublicOperations = {
       listProjects: failOperation,
       listConfigurationResources: failOperation,
+      listSetupResources: failOperation,
       validateConfiguration: failOperation,
       installConfiguration: failOperation,
       dispatchManualRun: failOperation,

--- a/src/public-api/built-server.integration.test.ts
+++ b/src/public-api/built-server.integration.test.ts
@@ -19,6 +19,7 @@ import {
   CliAuthorizationPollSchema,
   CliAuthorizationSchema,
   ConfigurationResourcesSchema,
+  SetupResourcesSchema,
   InstalledConfigurationSchema,
   ProblemSchema,
   ProjectListSchema,
@@ -53,6 +54,24 @@ builtServerTests("built TanStack public API PostgreSQL contract", () => {
         ('member-b', 'organization-b', 'user-b', 'owner');
       insert into session (id, token, user_id, active_organization_id, expires_at) values
         ('session-a', 'session-token-a', 'user-a', 'organization-a', now() + interval '1 day');
+      insert into github_connections
+        (id, organization_id, installation_id, slug, account_id, account_login, account_type, status)
+      values
+        ('10000000-0000-4000-8000-000000000001', 'organization-a', 101, 'github-a', 'account-a', 'octocat-a', 'User', 'active'),
+        ('10000000-0000-4000-8000-000000000002', 'organization-b', 102, 'github-b', 'account-b', 'octocat-b', 'Organization', 'active');
+      insert into github_repositories
+        (organization_id, connection_id, repository_id, full_name, default_branch)
+      values
+        ('organization-a', '10000000-0000-4000-8000-000000000001', 1001, 'octocat-a/starter', 'main'),
+        ('organization-b', '10000000-0000-4000-8000-000000000002', 1002, 'octocat-b/starter', 'main');
+      insert into discord_connections (organization_id, guild_id, slug, guild_name) values
+        ('organization-a', 'guild-a', 'discord-a', 'Discord A'),
+        ('organization-b', 'guild-b', 'discord-b', 'Discord B');
+      insert into slack_connections
+        (organization_id, team_id, slug, team_name, bot_user_id, bot_access_token, scopes)
+      values
+        ('organization-a', 'team-a', 'slack-a', 'Slack A', 'bot-a', 'token-a', '[]'::jsonb),
+        ('organization-b', 'team-b', 'slack-b', 'Slack B', 'bot-b', 'token-b', '[]'::jsonb);
     `);
     await client.close();
     for (const [organizationId, userId] of [
@@ -193,7 +212,52 @@ builtServerTests("built TanStack public API PostgreSQL contract", () => {
       );
       const resources = await get("/api/v1/configuration-resources", secrets[organizationId]);
       assert.equal(resources.status, 200);
-      assert.equal(ConfigurationResourcesSchema.parse(await resources.json()).daemons.length, 1);
+      const configurationResources = ConfigurationResourcesSchema.parse(await resources.json());
+      assert.equal(configurationResources.daemons.length, 1);
+      assert.deepEqual(configurationResources.github, [
+        {
+          slug: `github-${organizationId.at(-1)}`,
+          accountLogin: `octocat-${organizationId.at(-1)}`,
+          accountType: organizationId === "organization-a" ? "User" : "Organization",
+          repositories: [`octocat-${organizationId.at(-1)}/starter`],
+        },
+      ]);
+      assert.deepEqual(configurationResources.discord, [
+        {
+          slug: `discord-${organizationId.at(-1)}`,
+          guildName: `Discord ${organizationId.at(-1)?.toUpperCase()}`,
+        },
+      ]);
+      assert.deepEqual(configurationResources.slack, [
+        {
+          slug: `slack-${organizationId.at(-1)}`,
+          teamName: `Slack ${organizationId.at(-1)?.toUpperCase()}`,
+        },
+      ]);
+      const setupResources = await get("/api/v1/setup-resources", secrets[organizationId]);
+      assert.equal(setupResources.status, 200);
+      assert.deepEqual(SetupResourcesSchema.parse(await setupResources.json()), {
+        github: [
+          {
+            slug: `github-${organizationId.at(-1)}`,
+            accountLogin: `octocat-${organizationId.at(-1)}`,
+            accountType: organizationId === "organization-a" ? "User" : "Organization",
+            repositories: [`octocat-${organizationId.at(-1)}/starter`],
+          },
+        ],
+        discord: [
+          {
+            guildId: `guild-${organizationId.at(-1)}`,
+            guildName: `Discord ${organizationId.at(-1)?.toUpperCase()}`,
+          },
+        ],
+        slack: [
+          {
+            teamId: `team-${organizationId.at(-1)}`,
+            teamName: `Slack ${organizationId.at(-1)?.toUpperCase()}`,
+          },
+        ],
+      });
       const validation = await post("/api/v1/configurations/validate", secrets[organizationId], {
         projectSlug: "same-project",
         files: configurationBundleFixture(validPublicApiConfiguration()),

--- a/src/public-api/contracts.ts
+++ b/src/public-api/contracts.ts
@@ -214,6 +214,24 @@ export const ConfigurationResourcesSchema = z
   .strict()
   .openapi("ConfigurationResources");
 
+export const SetupResourcesSchema = z
+  .object({
+    github: z.array(
+      z
+        .object({
+          slug: z.string(),
+          accountLogin: z.string(),
+          accountType: z.string(),
+          repositories: z.array(z.string()),
+        })
+        .strict(),
+    ),
+    discord: z.array(z.object({ guildId: z.string(), guildName: z.string() }).strict()),
+    slack: z.array(z.object({ teamId: z.string(), teamName: z.string() }).strict()),
+  })
+  .strict()
+  .openapi("SetupResources");
+
 export const DispatchManualRunRequestSchema = z
   .object({
     projectSlug: z.string().trim().min(1).max(100),

--- a/src/public-api/index.ts
+++ b/src/public-api/index.ts
@@ -8,6 +8,7 @@ import type {
   IssueEnrollmentTokenResult,
   ListProjectsResult,
   ListConfigurationResourcesResult,
+  ListSetupResourcesResult,
   PublicAuthorization,
   PublicOperations,
   ValidateConfigurationResult,
@@ -18,6 +19,7 @@ import {
   InstalledConfigurationSchema,
   ProjectListSchema,
   ConfigurationResourcesSchema,
+  SetupResourcesSchema,
   ProblemSchema,
   ValidatedConfigurationSchema,
   type Problem,
@@ -27,6 +29,7 @@ import {
   publicOperation,
   publicOperationManifest,
   type PublicOperationId,
+  type PublicOperationDefinition,
 } from "./operation-manifest.js";
 
 export type { PublicOperationId } from "./operation-manifest.js";
@@ -34,6 +37,7 @@ export type { PublicOperationId } from "./operation-manifest.js";
 type PublicOperationResult =
   | ListProjectsResult
   | ListConfigurationResourcesResult
+  | ListSetupResourcesResult
   | ValidateConfigurationResult
   | InstallConfigurationResult
   | DispatchManualRunResult
@@ -203,7 +207,15 @@ async function execute(
     input = parsed.data;
   }
   const result = await definition.invoke(operations, access, input);
-  switch (definition.resultMapping) {
+  return operationResponse(definition.resultMapping, requestId, result);
+}
+
+function operationResponse(
+  mapping: PublicOperationDefinition["resultMapping"],
+  requestId: string,
+  result: PublicOperationResult,
+): Response {
+  switch (mapping) {
     case "projects":
       if (!isProjectsResult(result)) throw new Error("invalid projects operation result");
       return projectsResponse(requestId, result);
@@ -211,6 +223,10 @@ async function execute(
       if (!isConfigurationResourcesResult(result))
         throw new Error("invalid configuration resources operation result");
       return configurationResourcesResponse(requestId, result);
+    case "setup-resources":
+      if (!isSetupResourcesResult(result))
+        throw new Error("invalid setup resources operation result");
+      return setupResourcesResponse(requestId, result);
     case "validation":
       if (!isValidationResult(result)) throw new Error("invalid validation operation result");
       return validationResponse(requestId, result);
@@ -224,7 +240,7 @@ async function execute(
       if (!isEnrollmentResult(result)) throw new Error("invalid enrollment operation result");
       return enrollmentResponse(requestId, result);
   }
-  return assertNever(definition.resultMapping);
+  return assertNever(mapping);
 }
 
 function projectsResponse(requestId: string, result: ListProjectsResult): Response {
@@ -240,6 +256,16 @@ function configurationResourcesResponse(
   return result.status === "listed"
     ? success(requestId, 200, ConfigurationResourcesSchema, {
         daemons: result.daemons,
+        github: result.github,
+        discord: result.discord,
+        slack: result.slack,
+      })
+    : infrastructureProblem(requestId);
+}
+
+function setupResourcesResponse(requestId: string, result: ListSetupResourcesResult): Response {
+  return result.status === "listed"
+    ? success(requestId, 200, SetupResourcesSchema, {
         github: result.github,
         discord: result.discord,
         slack: result.slack,
@@ -530,6 +556,13 @@ function isConfigurationResourcesResult(
   return (
     result.status === "infrastructure_unavailable" ||
     (result.status === "listed" && "daemons" in result)
+  );
+}
+
+function isSetupResourcesResult(result: PublicOperationResult): result is ListSetupResourcesResult {
+  return (
+    result.status === "infrastructure_unavailable" ||
+    (result.status === "listed" && "github" in result)
   );
 }
 

--- a/src/public-api/operation-manifest.ts
+++ b/src/public-api/operation-manifest.ts
@@ -4,6 +4,7 @@ import type {
   InstallConfigurationResult,
   IssueEnrollmentTokenResult,
   ListConfigurationResourcesResult,
+  ListSetupResourcesResult,
   ListProjectsResult,
   PublicOperations,
   ValidateConfigurationResult,
@@ -16,12 +17,14 @@ import {
   InstalledConfigurationSchema,
   ProjectListSchema,
   ConfigurationResourcesSchema,
+  SetupResourcesSchema,
   ValidatedConfigurationSchema,
 } from "./contracts.js";
 
 export type PublicOperationId =
   | "listProjects"
   | "listConfigurationResources"
+  | "listSetupResources"
   | "validateConfiguration"
   | "installConfiguration"
   | "dispatchManualRun"
@@ -38,12 +41,14 @@ export interface PublicOperationDefinition {
     | typeof ValidatedConfigurationSchema
     | typeof ProjectListSchema
     | typeof ConfigurationResourcesSchema
+    | typeof SetupResourcesSchema
     | typeof DispatchedManualRunSchema
     | typeof EnrollmentTokenSchema;
   successStatus: 200 | 201;
   resultMapping:
     | "projects"
     | "configuration-resources"
+    | "setup-resources"
     | "validation"
     | "configuration"
     | "manual-run"
@@ -59,6 +64,7 @@ export interface PublicOperationDefinition {
   ): Promise<
     | ListProjectsResult
     | ListConfigurationResourcesResult
+    | ListSetupResourcesResult
     | ValidateConfigurationResult
     | InstallConfigurationResult
     | DispatchManualRunResult
@@ -107,6 +113,27 @@ export const publicOperationManifest: readonly PublicOperationDefinition[] = [
       503: "Hub authentication or storage is unavailable.",
     },
     invoke: (operations, authorization) => operations.listConfigurationResources(authorization),
+  },
+  {
+    id: "listSetupResources",
+    method: "get",
+    path: "/api/v1/setup-resources",
+    scope: "configuration:validate",
+    successSchema: SetupResourcesSchema,
+    successStatus: 200,
+    resultMapping: "setup-resources",
+    summary: "List setup resources",
+    description:
+      "Lists provider-native identifiers and labels needed to author starter workflow filters.",
+    tag: "Configurations",
+    responses: {
+      200: "The organization's setup resources.",
+      401: "The bearer credential is missing, malformed, or revoked.",
+      403: "The bearer credential lacks configuration:validate.",
+      500: "The operation failed unexpectedly.",
+      503: "Hub authentication or storage is unavailable.",
+    },
+    invoke: (operations, authorization) => operations.listSetupResources(authorization),
   },
   {
     id: "validateConfiguration",

--- a/src/public-api/public-api.test.ts
+++ b/src/public-api/public-api.test.ts
@@ -12,6 +12,7 @@ import { DatabaseUnavailableError } from "../db/errors.js";
 import type { PublicOperations } from "../public-operations/index.js";
 import {
   ConfigurationResourcesSchema,
+  SetupResourcesSchema,
   createPublicApi,
   DispatchedManualRunSchema,
   EnrollmentTokenSchema,
@@ -156,6 +157,29 @@ describe("public API interface", () => {
         )
       ).json(),
     );
+    assert.deepEqual(
+      SetupResourcesSchema.parse(
+        await (
+          await successApi.handle(
+            new Request("https://hub.test/api/v1/setup-resources", {
+              headers: { authorization: "Bearer valid" },
+            }),
+          )
+        ).json(),
+      ),
+      {
+        github: [
+          {
+            slug: "github-connection",
+            accountLogin: "octocat",
+            accountType: "User",
+            repositories: ["octocat/starter"],
+          },
+        ],
+        discord: [{ guildId: "123456789", guildName: "Paseo Guild" }],
+        slack: [{ teamId: "T01234567", teamName: "Paseo Workspace" }],
+      },
+    );
     ValidatedConfigurationSchema.parse(
       await (await successApi.handle(installRequest("/api/v1/configurations/validate"))).json(),
     );
@@ -265,6 +289,7 @@ describe("generated public OpenAPI", () => {
       "/api/v1/daemons/enrollment-tokens",
       "/api/v1/manual-runs",
       "/api/v1/projects",
+      "/api/v1/setup-resources",
     ]);
     const expectations = {
       "/api/v1/configurations/install": [
@@ -279,6 +304,7 @@ describe("generated public OpenAPI", () => {
         "configuration:validate",
         ["200", "401", "403", "500", "503"],
       ],
+      "/api/v1/setup-resources": ["configuration:validate", ["200", "401", "403", "500", "503"]],
       "/api/v1/projects": ["projects:read", ["200", "401", "403", "500", "503"]],
       "/api/v1/manual-runs": [
         "runs:dispatch",
@@ -288,7 +314,9 @@ describe("generated public OpenAPI", () => {
     } as const;
     for (const [path, [scope, statuses]] of Object.entries(expectations)) {
       const operation =
-        path === "/api/v1/projects" || path === "/api/v1/configuration-resources"
+        path === "/api/v1/projects" ||
+        path === "/api/v1/configuration-resources" ||
+        path === "/api/v1/setup-resources"
           ? publicOpenApiDocument.paths?.[path]?.get
           : publicOpenApiDocument.paths?.[path]?.post;
       assert.ok(operation?.operationId);
@@ -397,6 +425,20 @@ function successfulOperations(): PublicOperations {
         github: [],
         discord: [],
         slack: [],
+      }),
+    listSetupResources: () =>
+      Promise.resolve({
+        status: "listed",
+        github: [
+          {
+            slug: "github-connection",
+            accountLogin: "octocat",
+            accountType: "User",
+            repositories: ["octocat/starter"],
+          },
+        ],
+        discord: [{ guildId: "123456789", guildName: "Paseo Guild" }],
+        slack: [{ teamId: "T01234567", teamName: "Paseo Workspace" }],
       }),
     validateConfiguration: () =>
       Promise.resolve({

--- a/src/public-operations/database-adapter.ts
+++ b/src/public-operations/database-adapter.ts
@@ -14,9 +14,8 @@ export function createDatabasePublicOperationRepository(
         .map(({ id, name, slug }) => ({ id, name, slug }));
     },
     async listConfigurationResources(organizationId) {
-      const [connections, repositories, daemons] = await Promise.all([
-        database.organizationConnectionUsage(organizationId),
-        database.listGitHubRepositories(organizationId),
+      const [{ connections, repositories }, daemons] = await Promise.all([
+        providerResources(database, organizationId),
         database.listDaemonsForOrganization(organizationId),
       ]);
       return {
@@ -33,6 +32,21 @@ export function createDatabasePublicOperationRepository(
         })),
         discord: connections.discord.map(({ slug, guildName }) => ({ slug, guildName })),
         slack: connections.slack.map(({ slug, teamName }) => ({ slug, teamName })),
+      };
+    },
+    async listSetupResources(organizationId) {
+      const { connections, repositories } = await providerResources(database, organizationId);
+      return {
+        github: connections.github.map(({ id, slug, accountLogin, accountType }) => ({
+          slug,
+          accountLogin,
+          accountType,
+          repositories: repositories
+            .filter(({ connectionId }) => connectionId === id)
+            .map(({ fullName }) => fullName),
+        })),
+        discord: connections.discord.map(({ guildId, guildName }) => ({ guildId, guildName })),
+        slack: connections.slack.map(({ teamId, teamName }) => ({ teamId, teamName })),
       };
     },
     async findActiveProject(organizationId, projectSlug) {
@@ -61,4 +75,12 @@ export function createDatabasePublicOperationRepository(
       return issued ? "issued" : "credential_revoked";
     },
   };
+}
+
+async function providerResources(database: Database, organizationId: string) {
+  const [connections, repositories] = await Promise.all([
+    database.organizationConnectionUsage(organizationId),
+    database.listGitHubRepositories(organizationId),
+  ]);
+  return { connections, repositories };
 }

--- a/src/public-operations/index.ts
+++ b/src/public-operations/index.ts
@@ -44,6 +44,16 @@ export function createPublicOperations(
         return storageUnavailableOrThrow(error);
       }
     },
+    async listSetupResources(authorization) {
+      try {
+        return {
+          status: "listed",
+          ...(await repository.listSetupResources(authorization.organizationId)),
+        };
+      } catch (error) {
+        return storageUnavailableOrThrow(error);
+      }
+    },
     async validateConfiguration(authorization, input) {
       try {
         const resolved = await resolveConfigurationDeployment(

--- a/src/public-operations/types.ts
+++ b/src/public-operations/types.ts
@@ -50,6 +50,21 @@ export type ListConfigurationResourcesResult =
   | ({ status: "listed" } & ConfigurationResources)
   | InfrastructureUnavailable;
 
+export interface SetupResources {
+  github: readonly {
+    slug: string;
+    accountLogin: string;
+    accountType: string;
+    repositories: readonly string[];
+  }[];
+  discord: readonly { guildId: string; guildName: string }[];
+  slack: readonly { teamId: string; teamName: string }[];
+}
+
+export type ListSetupResourcesResult =
+  | ({ status: "listed" } & SetupResources)
+  | InfrastructureUnavailable;
+
 export type InstallConfigurationResult =
   | {
       status: "installed";
@@ -120,6 +135,7 @@ export interface PublicOperations {
   listConfigurationResources(
     authorization: PublicAuthorization,
   ): Promise<ListConfigurationResourcesResult>;
+  listSetupResources(authorization: PublicAuthorization): Promise<ListSetupResourcesResult>;
   validateConfiguration(
     authorization: PublicAuthorization,
     input: ValidateConfigurationInput,
@@ -138,6 +154,7 @@ export interface PublicOperations {
 export interface PublicOperationRepository {
   listActiveProjects(organizationId: string): Promise<readonly PublicProject[]>;
   listConfigurationResources(organizationId: string): Promise<ConfigurationResources>;
+  listSetupResources(organizationId: string): Promise<SetupResources>;
   findActiveProject(
     organizationId: string,
     projectSlug: string,

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -38,6 +38,7 @@ import { Route as ApiIntegrationsGithubSetupRouteImport } from './routes/api/int
 import { Route as ApiIntegrationsGithubCallbackRouteImport } from './routes/api/integrations/github/callback'
 import { Route as ApiIntegrationsDiscordCallbackRouteImport } from './routes/api/integrations/discord/callback'
 import { Route as AgentExecutionsExecutionIdAttachmentsAttachmentIdRouteImport } from './routes/agent-executions/$executionId/attachments/$attachmentId'
+import { Route as ShellProjectsProjectSlugActivityRouteImport } from './routes/_shell/projects/$projectSlug/activity'
 import { Route as ShellOOrganizationSlugUsageRouteImport } from './routes/_shell/o/$organizationSlug/usage'
 import { Route as ShellOOrganizationSlugTeamRouteImport } from './routes/_shell/o/$organizationSlug/team'
 import { Route as ShellOOrganizationSlugProjectsRouteImport } from './routes/_shell/o/$organizationSlug/projects'
@@ -205,6 +206,12 @@ const AgentExecutionsExecutionIdAttachmentsAttachmentIdRoute =
     path: '/agent-executions/$executionId/attachments/$attachmentId',
     getParentRoute: () => rootRouteImport,
   } as any)
+const ShellProjectsProjectSlugActivityRoute =
+  ShellProjectsProjectSlugActivityRouteImport.update({
+    id: '/projects/$projectSlug/activity',
+    path: '/projects/$projectSlug/activity',
+    getParentRoute: () => ShellRoute,
+  } as any)
 const ShellOOrganizationSlugUsageRoute =
   ShellOOrganizationSlugUsageRouteImport.update({
     id: '/o/$organizationSlug/usage',
@@ -321,6 +328,7 @@ export interface FileRoutesByFullPath {
   '/o/$organizationSlug/projects': typeof ShellOOrganizationSlugProjectsRouteWithChildren
   '/o/$organizationSlug/team': typeof ShellOOrganizationSlugTeamRoute
   '/o/$organizationSlug/usage': typeof ShellOOrganizationSlugUsageRoute
+  '/projects/$projectSlug/activity': typeof ShellProjectsProjectSlugActivityRoute
   '/agent-executions/$executionId/attachments/$attachmentId': typeof AgentExecutionsExecutionIdAttachmentsAttachmentIdRoute
   '/api/integrations/discord/callback': typeof ApiIntegrationsDiscordCallbackRoute
   '/api/integrations/github/callback': typeof ApiIntegrationsGithubCallbackRoute
@@ -364,6 +372,7 @@ export interface FileRoutesByTo {
   '/o/$organizationSlug/daemons': typeof ShellOOrganizationSlugDaemonsRoute
   '/o/$organizationSlug/team': typeof ShellOOrganizationSlugTeamRoute
   '/o/$organizationSlug/usage': typeof ShellOOrganizationSlugUsageRoute
+  '/projects/$projectSlug/activity': typeof ShellProjectsProjectSlugActivityRoute
   '/agent-executions/$executionId/attachments/$attachmentId': typeof AgentExecutionsExecutionIdAttachmentsAttachmentIdRoute
   '/api/integrations/discord/callback': typeof ApiIntegrationsDiscordCallbackRoute
   '/api/integrations/github/callback': typeof ApiIntegrationsGithubCallbackRoute
@@ -409,6 +418,7 @@ export interface FileRoutesById {
   '/_shell/o/$organizationSlug/projects': typeof ShellOOrganizationSlugProjectsRouteWithChildren
   '/_shell/o/$organizationSlug/team': typeof ShellOOrganizationSlugTeamRoute
   '/_shell/o/$organizationSlug/usage': typeof ShellOOrganizationSlugUsageRoute
+  '/_shell/projects/$projectSlug/activity': typeof ShellProjectsProjectSlugActivityRoute
   '/agent-executions/$executionId/attachments/$attachmentId': typeof AgentExecutionsExecutionIdAttachmentsAttachmentIdRoute
   '/api/integrations/discord/callback': typeof ApiIntegrationsDiscordCallbackRoute
   '/api/integrations/github/callback': typeof ApiIntegrationsGithubCallbackRoute
@@ -455,6 +465,7 @@ export interface FileRouteTypes {
     | '/o/$organizationSlug/projects'
     | '/o/$organizationSlug/team'
     | '/o/$organizationSlug/usage'
+    | '/projects/$projectSlug/activity'
     | '/agent-executions/$executionId/attachments/$attachmentId'
     | '/api/integrations/discord/callback'
     | '/api/integrations/github/callback'
@@ -498,6 +509,7 @@ export interface FileRouteTypes {
     | '/o/$organizationSlug/daemons'
     | '/o/$organizationSlug/team'
     | '/o/$organizationSlug/usage'
+    | '/projects/$projectSlug/activity'
     | '/agent-executions/$executionId/attachments/$attachmentId'
     | '/api/integrations/discord/callback'
     | '/api/integrations/github/callback'
@@ -542,6 +554,7 @@ export interface FileRouteTypes {
     | '/_shell/o/$organizationSlug/projects'
     | '/_shell/o/$organizationSlug/team'
     | '/_shell/o/$organizationSlug/usage'
+    | '/_shell/projects/$projectSlug/activity'
     | '/agent-executions/$executionId/attachments/$attachmentId'
     | '/api/integrations/discord/callback'
     | '/api/integrations/github/callback'
@@ -790,6 +803,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AgentExecutionsExecutionIdAttachmentsAttachmentIdRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/_shell/projects/$projectSlug/activity': {
+      id: '/_shell/projects/$projectSlug/activity'
+      path: '/projects/$projectSlug/activity'
+      fullPath: '/projects/$projectSlug/activity'
+      preLoaderRoute: typeof ShellProjectsProjectSlugActivityRouteImport
+      parentRoute: typeof ShellRoute
+    }
     '/_shell/o/$organizationSlug/usage': {
       id: '/_shell/o/$organizationSlug/usage'
       path: '/o/$organizationSlug/usage'
@@ -948,6 +968,7 @@ interface ShellRouteChildren {
   ShellOOrganizationSlugProjectsRoute: typeof ShellOOrganizationSlugProjectsRouteWithChildren
   ShellOOrganizationSlugTeamRoute: typeof ShellOOrganizationSlugTeamRoute
   ShellOOrganizationSlugUsageRoute: typeof ShellOOrganizationSlugUsageRoute
+  ShellProjectsProjectSlugActivityRoute: typeof ShellProjectsProjectSlugActivityRoute
 }
 
 const ShellRouteChildren: ShellRouteChildren = {
@@ -964,6 +985,7 @@ const ShellRouteChildren: ShellRouteChildren = {
     ShellOOrganizationSlugProjectsRouteWithChildren,
   ShellOOrganizationSlugTeamRoute: ShellOOrganizationSlugTeamRoute,
   ShellOOrganizationSlugUsageRoute: ShellOOrganizationSlugUsageRoute,
+  ShellProjectsProjectSlugActivityRoute: ShellProjectsProjectSlugActivityRoute,
 }
 
 const ShellRouteWithChildren = ShellRoute._addFileChildren(ShellRouteChildren)

--- a/src/routes/_shell/projects/$projectSlug/activity.tsx
+++ b/src/routes/_shell/projects/$projectSlug/activity.tsx
@@ -1,0 +1,18 @@
+/* oxlint-disable typescript-eslint/no-unsafe-type-assertion -- the generated route type cannot express a current-organization redirect */
+import { createFileRoute, Navigate } from "@tanstack/react-router";
+import { useActiveAccount } from "../../../../auth/active-account.js";
+
+export const Route = createFileRoute("/_shell/projects/$projectSlug/activity")({
+  component: LegacyProjectActivityRedirect,
+});
+
+function LegacyProjectActivityRedirect() {
+  const account = useActiveAccount();
+  const { projectSlug } = Route.useParams();
+  return (
+    <Navigate
+      to={`/o/${account.organization.slug}/projects/${projectSlug}/activity` as never}
+      replace
+    />
+  );
+}


### PR DESCRIPTION
## What changed

This is the Hub compatibility foundation for zero-friction onboarding. It gives guided setup clients the exact provider values needed to author filters and repairs the stable legacy activity link.

## Goals

- Add authenticated `GET /api/v1/setup-resources` with GitHub repositories plus Slack `{ teamId, teamName }` and Discord `{ guildId, guildName }`.
- Keep `GET /api/v1/configuration-resources` unchanged for released strict clients.
- Redirect authenticated `/projects/:projectSlug/activity` requests through the operator's active organization to the canonical organization-scoped activity route.

## Non-goals

- CLI guided setup behavior.
- Browser onboarding or daemon handoff.
- Database migrations or onboarding state.

## Why

Slack and Discord authored filters match provider-native workspace and guild identifiers, while the released configuration-resources response exposes Hub connection slugs and is parsed strictly by existing clients. The additive API preserves that compatibility contract.

## Verification

- `npm run release:check`
- `RUN_BUILT_PUBLIC_API_TESTS=1 npm test -- --run src/public-api/built-server.integration.test.ts src/public-api/public-api.test.ts src/http/node-server.test.ts` — 23 passed
- `npx playwright test e2e/onboarding-foundation.spec.ts --project=desktop-chromium` — 1 passed
- `npm run lint`
- `npm run format:check`
- `npm run db:check`
- `npm run build`

## Risk surface

The public API gains one authenticated additive endpoint. The existing configuration-resources serialization is covered by regression tests and remains unchanged. The legacy URL redirects only after the existing authenticated shell resolves the operator's active organization.

## Phase

Phase 1 only; this does not include CLI or browser onboarding.