### PR TITLE
Hand off to a daemon after app setup

### DIFF
--- a/e2e/app.ts
+++ b/e2e/app.ts
@@ -151,6 +151,8 @@ class BuiltApplications {
       cancelSubscription: (organizationId: string) =>
         deliverCommand(server, { type: "billing-cancel-subscription", organizationId }),
       failNextAccountSetup: () => deliverCommand(server, { type: "fail-next-account-setup" }),
+      issueDaemonEnrollment: (verifier: string) =>
+        deliverCommand(server, { type: "daemon-enrollment-token", verifier }),
       failNextProjectRead: () => deliverCommand(server, { type: "fail-next-project-read" }),
       prepareSlackSocketWorkflow: () => deliverCommand(server, { type: "slack-socket-prepare" }),
       deliverSlackSocketMention: (eventId: string) =>

--- a/e2e/apps-mobile.spec.ts
+++ b/e2e/apps-mobile.spec.ts
@@ -25,9 +25,6 @@ test("a phone operator can skip app setup and reach their dashboard", async ({ h
   try {
     await session.surface.leave("Do this later");
     await expect(
-      session.page.getByRole("heading", { name: "Projects", exact: true }),
-    ).toBeVisible();
-    await expect(
       session.page
         .getByRole("navigation", { name: "Breadcrumb", exact: true })
         .getByText("Paseo Hub", { exact: true }),

--- a/e2e/apps.spec.ts
+++ b/e2e/apps.spec.ts
@@ -63,7 +63,6 @@ test("a first account continues to app setup, and skipping it is durable", async
     await surface.shoot(SHOTS, "apps-01-chooser.desktop");
 
     await surface.leave("Do this later");
-    await expect(page.getByRole("heading", { name: "Projects", exact: true })).toBeVisible();
     await expect(
       page
         .getByRole("navigation", { name: "Breadcrumb", exact: true })
@@ -72,7 +71,7 @@ test("a first account continues to app setup, and skipping it is durable", async
     await surface.shoot(SHOTS, "apps-14-skip-dashboard.desktop");
     // Business as usual once the transition completes: reloading never returns here.
     await page.reload();
-    await expect(page.getByRole("heading", { name: "Projects", exact: true })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Overview" })).toBeVisible();
   } finally {
     await session.close();
   }

--- a/e2e/apps.spec.ts
+++ b/e2e/apps.spec.ts
@@ -868,7 +868,8 @@ test("an exit that never reaches Hub says so, keeps the work, and retries in pla
     // The same screen retries, without reloading or retyping.
     await page.unroute("**/_serverFn/**");
     await surface.exitFailure().getByRole("button", { name: "Try again", exact: true }).click();
-    await expect(page.getByRole("heading", { name: "Projects", exact: true })).toBeVisible();
+    await surface.daemonHandoff.expectWaiting();
+    await surface.daemonHandoff.leave("Do this later");
 
     // A request that never left the browser is nobody's failure to record on the server.
     expect(recordsFor(session.application.logs(), "auth.complete_app_setup")).toHaveLength(0);

--- a/e2e/daemon-handoff.spec.ts
+++ b/e2e/daemon-handoff.spec.ts
@@ -2,8 +2,8 @@ import { expect } from "@playwright/test";
 import { test } from "./app.js";
 import { ProjectNavigation } from "./helpers/projects/navigation.js";
 
-// Each journey claims its own pristine application, so the fixture's primary is never navigated
-// to and must not cost a PostgreSQL container nobody reads.
+// Each journey claims its own pristine embedded application: nothing here needs PostgreSQL, and
+// the fixture's primary is never navigated to, so neither should cost a container.
 test.describe.configure({ timeout: 150_000 });
 test.use({ primaryDatabase: "embedded" });
 
@@ -16,7 +16,7 @@ const OPERATOR = {
 test("app setup hands off to a daemon, and the daemon that connects opens the dashboard", async ({
   hub,
 }) => {
-  const session = await hub.openAppSetup({ account: OPERATOR });
+  const session = await hub.openAppSetup({ account: OPERATOR, embedded: true });
   const handoff = session.surface.daemonHandoff;
   try {
     const { page, origin } = session;
@@ -45,9 +45,10 @@ test("app setup hands off to a daemon, and the daemon that connects opens the da
     const slug = await session.connectDaemon();
     await handoff.expectConnected(slug);
 
+    // Onboarding ends inside the project instance setup already provisioned — the operator picks
+    // nothing off a list, and the handoff created nothing.
     await handoff.leave("Continue");
-    // Setup already provisioned the project the operator lands on; the handoff created nothing.
-    await new ProjectNavigation(page).openProject("Default");
+    await new ProjectNavigation(page).expectBreadcrumb("Paseo Hub", "Default", "Overview");
   } finally {
     await session.close();
   }
@@ -56,18 +57,19 @@ test("app setup hands off to a daemon, and the daemon that connects opens the da
 test("an operator with no daemon yet does it later and stays out of onboarding", async ({
   hub,
 }) => {
-  const session = await hub.openAppSetup({ account: OPERATOR });
+  const session = await hub.openAppSetup({ account: OPERATOR, embedded: true });
   const handoff = session.surface.daemonHandoff;
   try {
     const { page } = session;
     await session.surface.reachDaemonHandoff("Do this later");
+    // Skipping arrives where connecting does. Nothing about the daemon was needed to get here.
     await handoff.leave("Do this later");
+    await new ProjectNavigation(page).expectBreadcrumb("Paseo Hub", "Default", "Overview");
 
     // Skipping is as final as connecting: the phase lived in the tab, never in the database.
     await page.reload();
-    await expect(page.getByRole("heading", { name: "Projects", exact: true })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Overview" })).toBeVisible();
     await expect(page.getByRole("heading", { name: "Connect a daemon" })).toHaveCount(0);
-    await new ProjectNavigation(page).openProject("Default");
   } finally {
     await session.close();
   }

--- a/e2e/daemon-handoff.spec.ts
+++ b/e2e/daemon-handoff.spec.ts
@@ -1,0 +1,74 @@
+import { expect } from "@playwright/test";
+import { test } from "./app.js";
+import { ProjectNavigation } from "./helpers/projects/navigation.js";
+
+// Each journey claims its own pristine application, so the fixture's primary is never navigated
+// to and must not cost a PostgreSQL container nobody reads.
+test.describe.configure({ timeout: 150_000 });
+test.use({ primaryDatabase: "embedded" });
+
+const OPERATOR = {
+  name: "Handoff Operator",
+  email: "handoff-operator@example.com",
+  password: "handoff-operator-password",
+};
+
+test("app setup hands off to a daemon, and the daemon that connects opens the dashboard", async ({
+  hub,
+}) => {
+  const session = await hub.openAppSetup({ account: OPERATOR });
+  const handoff = session.surface.daemonHandoff;
+  try {
+    const { page, origin } = session;
+    await session.surface.reachDaemonHandoff("Do this later");
+
+    // A self-hosted Hub has to be named, and the only address that is certainly reachable is the
+    // one the operator is already looking at.
+    await handoff.expectCommand(`paseo hub login ${origin}`);
+    expect(await handoff.copyCommand()).toBe(`paseo hub login ${origin}`);
+    await handoff.accessible();
+
+    // The command sends the operator to a terminal, and the terminal sends a browser back here.
+    // App onboarding is already complete, so that tab reaches CLI login instead of app setup.
+    const terminal = await page.context().newPage();
+    try {
+      await terminal.goto(`${origin}/cli-login`);
+      await expect(terminal.getByRole("heading", { name: "Log in the Paseo CLI" })).toBeVisible();
+      await expect(terminal.getByLabel("Verification code")).toBeVisible();
+      await expect(terminal.getByRole("heading", { name: "Set up your apps" })).toHaveCount(0);
+    } finally {
+      await terminal.close();
+    }
+
+    // The handoff is still waiting on this tab, and notices the daemon on its own.
+    await handoff.expectWaiting();
+    const slug = await session.connectDaemon();
+    await handoff.expectConnected(slug);
+
+    await handoff.leave("Continue");
+    // Setup already provisioned the project the operator lands on; the handoff created nothing.
+    await new ProjectNavigation(page).openProject("Default");
+  } finally {
+    await session.close();
+  }
+});
+
+test("an operator with no daemon yet does it later and stays out of onboarding", async ({
+  hub,
+}) => {
+  const session = await hub.openAppSetup({ account: OPERATOR });
+  const handoff = session.surface.daemonHandoff;
+  try {
+    const { page } = session;
+    await session.surface.reachDaemonHandoff("Do this later");
+    await handoff.leave("Do this later");
+
+    // Skipping is as final as connecting: the phase lived in the tab, never in the database.
+    await page.reload();
+    await expect(page.getByRole("heading", { name: "Projects", exact: true })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Connect a daemon" })).toHaveCount(0);
+    await new ProjectNavigation(page).openProject("Default");
+  } finally {
+    await session.close();
+  }
+});

--- a/e2e/helpers/apps.ts
+++ b/e2e/helpers/apps.ts
@@ -1,5 +1,6 @@
 import { expect, type Locator, type Page } from "@playwright/test";
 import AxeBuilder from "@axe-core/playwright";
+import { DaemonHandoffSurface } from "./daemon-handoff.js";
 
 export type AppProvider = "GitHub" | "Slack" | "Discord";
 
@@ -431,11 +432,14 @@ export class AppSetupSurface {
   readonly github: AppSection;
   readonly slack: AppSection;
   readonly discord: AppSection;
+  /** Where the way out leads on first run, before the dashboard. */
+  readonly daemonHandoff: DaemonHandoffSurface;
 
   constructor(private readonly page: Page) {
     this.github = new AppSection(page, "GitHub");
     this.slack = new AppSection(page, "Slack");
     this.discord = new AppSection(page, "Discord");
+    this.daemonHandoff = new DaemonHandoffSurface(page);
   }
 
   sections(): readonly AppSection[] {
@@ -479,9 +483,16 @@ export class AppSetupSurface {
     return this.page.getByRole("button", { name: label, exact: true });
   }
 
-  async leave(label: "Finish" | "Do this later"): Promise<void> {
+  /** Leaves app setup and stops on the daemon handoff, which is where the way out now leads. */
+  async reachDaemonHandoff(label: "Finish" | "Do this later"): Promise<void> {
     await this.wayOut(label).click();
-    await expect(this.page.getByRole("heading", { name: "Projects", exact: true })).toBeVisible();
+    await this.daemonHandoff.expectWaiting();
+  }
+
+  /** All the way out: app setup, past the daemon handoff, onto the dashboard. */
+  async leave(label: "Finish" | "Do this later"): Promise<void> {
+    await this.reachDaemonHandoff(label);
+    await this.daemonHandoff.leave("Do this later");
   }
 
   async expectStatuses(expected: Readonly<Record<AppProvider, AppStatus>>): Promise<void> {

--- a/e2e/helpers/apps.ts
+++ b/e2e/helpers/apps.ts
@@ -489,7 +489,7 @@ export class AppSetupSurface {
     await this.daemonHandoff.expectWaiting();
   }
 
-  /** All the way out: app setup, past the daemon handoff, onto the dashboard. */
+  /** All the way out: app setup, past the daemon handoff, into the default project. */
   async leave(label: "Finish" | "Do this later"): Promise<void> {
     await this.reachDaemonHandoff(label);
     await this.daemonHandoff.leave("Do this later");

--- a/e2e/helpers/daemon-handoff.ts
+++ b/e2e/helpers/daemon-handoff.ts
@@ -1,0 +1,47 @@
+import { expect, type Locator, type Page } from "@playwright/test";
+import AxeBuilder from "@axe-core/playwright";
+
+/**
+ * The step between app setup and the dashboard: one command to run in a terminal, and a poll
+ * waiting for the daemon it connects. Both ways out land on the dashboard, so every journey that
+ * used to leave app setup for the dashboard still passes straight through.
+ */
+export class DaemonHandoffSurface {
+  constructor(private readonly page: Page) {}
+
+  async expectWaiting(): Promise<void> {
+    await expect(this.page.getByRole("heading", { name: "Connect a daemon" })).toBeVisible();
+    await expect(this.page.getByRole("status")).toContainText("Waiting for a daemon to connect");
+  }
+
+  /** The exact command the operator is told to paste, as it is rendered. */
+  command(): Locator {
+    return this.page.getByText(/^paseo hub login/u);
+  }
+
+  async expectCommand(expected: string): Promise<void> {
+    await expect(this.command()).toHaveText(expected);
+  }
+
+  async copyCommand(): Promise<string> {
+    await this.page.getByRole("button", { name: "Copy Command", exact: true }).click();
+    return await this.page.evaluate(() => navigator.clipboard.readText());
+  }
+
+  async expectConnected(slug: string): Promise<void> {
+    await expect(this.page.getByRole("heading", { name: "Daemon connected" })).toBeVisible();
+    await expect(this.page.getByRole("status")).toContainText(`${slug} is connected to this Hub`);
+  }
+
+  async accessible(): Promise<void> {
+    const results = await new AxeBuilder({ page: this.page })
+      .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
+      .analyze();
+    expect(results.violations).toEqual([]);
+  }
+
+  async leave(label: "Continue" | "Do this later"): Promise<void> {
+    await this.page.getByRole("button", { name: label, exact: true }).click();
+    await expect(this.page.getByRole("heading", { name: "Projects", exact: true })).toBeVisible();
+  }
+}

--- a/e2e/helpers/daemon-handoff.ts
+++ b/e2e/helpers/daemon-handoff.ts
@@ -40,8 +40,13 @@ export class DaemonHandoffSurface {
     expect(results.violations).toEqual([]);
   }
 
+  /**
+   * Both ways out land in the project instance setup already provisioned. Onboarding never hands
+   * the operator a list with one entry on it and asks them to pick.
+   */
   async leave(label: "Continue" | "Do this later"): Promise<void> {
     await this.page.getByRole("button", { name: label, exact: true }).click();
-    await expect(this.page.getByRole("heading", { name: "Projects", exact: true })).toBeVisible();
+    await expect(this.page).toHaveURL(/\/o\/[^/]+\/projects\/default\/overview$/u);
+    await expect(this.page.getByRole("heading", { name: "Overview" })).toBeVisible();
   }
 }

--- a/e2e/helpers/hub.ts
+++ b/e2e/helpers/hub.ts
@@ -332,6 +332,7 @@ export class PaseoHub {
       deliverSlackSocketMention: (eventId) => application.deliverSlackSocketMention(eventId),
       slackSocketEvidence: (eventId) => application.slackSocketEvidence(eventId),
       restart: () => application.restart(),
+      connectDaemon: () => this.enrollOperatorDaemon(application),
       openMember: async (member) => {
         const memberContext = await this.browser.newContext();
         const memberPage = await memberContext.newPage();
@@ -2298,6 +2299,25 @@ export class PaseoHub {
     }
   }
 
+  /**
+   * What `paseo hub login` leaves behind on the operator's own machine: a daemon enrolled into
+   * their organization and holding a live connection. The enrollment token is written straight
+   * to the database because the CLI's own path through it is the Paseo repository's to prove.
+   */
+  private async enrollOperatorDaemon(application: BuiltApplication): Promise<string> {
+    const enrollmentToken = randomUUID();
+    await this.queryDatabase(
+      application.databaseUrl,
+      `insert into daemon_enrollment_tokens (id, verifier, organization_id, expires_at)
+       select $1, $2, id, now() + interval '10 minutes' from organization`,
+      [randomUUID(), createHash("sha256").update(enrollmentToken).digest("base64url")],
+    );
+    const daemon = new ContractDaemon(application, this.requests);
+    await daemon.enroll(enrollmentToken);
+    await daemon.connect();
+    return daemon.slug;
+  }
+
   private async issueEnrollmentToken(
     application: BuiltApplication,
     headers: Record<string, string> = machineHeaders(application.machineKey),
@@ -2485,6 +2505,10 @@ class HubUser {
    */
   async skipAppSetup(): Promise<void> {
     await expect(this.page.getByRole("heading", { name: "Set up your apps" })).toBeVisible();
+    await this.page.getByRole("button", { name: "Do this later", exact: true }).click();
+    // Apps are followed by the daemon handoff. A journey that is not about either walks through
+    // both, exactly as the operator can.
+    await expect(this.page.getByRole("heading", { name: "Connect a daemon" })).toBeVisible();
     await this.page.getByRole("button", { name: "Do this later", exact: true }).click();
   }
 
@@ -4722,6 +4746,8 @@ export interface AppSetupSession {
   deliverSlackSocketMention(eventId: string): Promise<void>;
   slackSocketEvidence(eventId: string): Promise<{ receipts: number; runs: number }>;
   restart(): Promise<void>;
+  /** Enrolls and connects a daemon into the operator's organization; answers with its slug. */
+  connectDaemon(): Promise<string>;
   /** A second, ordinary account on the same instance. Never its operator. */
   openMember(member: Account): Promise<{ page: Page; close(): Promise<void> }>;
   close(): Promise<void>;

--- a/e2e/helpers/hub.ts
+++ b/e2e/helpers/hub.ts
@@ -48,6 +48,8 @@ export interface BuiltApplication {
   reportedSeatQuantity(organizationId: string): Promise<number | null>;
   /** Arms one account-setup failure inside the built application, for the error/retry journey. */
   failNextAccountSetup(): Promise<void>;
+  /** Records a daemon enrollment token for this instance's organization. */
+  issueDaemonEnrollment(verifier: string): Promise<void>;
   /** Arms one project snapshot read failure inside the disposable built application. */
   failNextProjectRead(): Promise<void>;
   prepareSlackSocketWorkflow(): Promise<void>;
@@ -2306,11 +2308,8 @@ export class PaseoHub {
    */
   private async enrollOperatorDaemon(application: BuiltApplication): Promise<string> {
     const enrollmentToken = randomUUID();
-    await this.queryDatabase(
-      application.databaseUrl,
-      `insert into daemon_enrollment_tokens (id, verifier, organization_id, expires_at)
-       select $1, $2, id, now() + interval '10 minutes' from organization`,
-      [randomUUID(), createHash("sha256").update(enrollmentToken).digest("base64url")],
+    await application.issueDaemonEnrollment(
+      createHash("sha256").update(enrollmentToken).digest("base64url"),
     );
     const daemon = new ContractDaemon(application, this.requests);
     await daemon.enroll(enrollmentToken);
@@ -2495,7 +2494,6 @@ class HubUser {
     await change.getByLabel("Confirm new password").fill(replacementPassword);
     await change.getByRole("button", { name: "Save password" }).click();
     await this.skipAppSetup();
-    await expect(this.page.getByRole("heading", { name: "Projects", exact: true })).toBeVisible();
     await this.expectActiveOrganization(organizationName);
   }
 
@@ -2507,9 +2505,10 @@ class HubUser {
     await expect(this.page.getByRole("heading", { name: "Set up your apps" })).toBeVisible();
     await this.page.getByRole("button", { name: "Do this later", exact: true }).click();
     // Apps are followed by the daemon handoff. A journey that is not about either walks through
-    // both, exactly as the operator can.
+    // both, exactly as the operator can, and lands in the default project the way they do.
     await expect(this.page.getByRole("heading", { name: "Connect a daemon" })).toBeVisible();
     await this.page.getByRole("button", { name: "Do this later", exact: true }).click();
+    await expect(this.page.getByRole("heading", { name: "Overview" })).toBeVisible();
   }
 
   async completeFirstRunJourney(
@@ -2534,8 +2533,9 @@ class HubUser {
     await this.page.keyboard.press("Tab");
     await expect(this.page.getByRole("button", { name: "Organization" })).toBeFocused();
 
-    // Setup provisioned a working organization, not just a row: its default project opens.
-    await this.navigation.openProject("Default");
+    // Setup provisioned a working organization, not just a row: onboarding ended inside its
+    // default project, and that project renders.
+    await this.navigation.expectBreadcrumb(INTERACTIVE_ORGANIZATION_NAME, "Default", "Overview");
     await this.returnToProjects();
     // The instance operator surface is the proof that this account owns the instance, not just
     // its organization: the console refuses anyone without the flag, server-side.
@@ -2654,7 +2654,6 @@ class HubUser {
    * the journey asserts it once it is back at desktop width. */
   private async expectFirstRunDashboard(): Promise<void> {
     await this.skipAppSetup();
-    await expect(this.page.getByRole("heading", { name: "Projects", exact: true })).toBeVisible();
     await this.expectActiveOrganization(INTERACTIVE_ORGANIZATION_NAME);
   }
 

--- a/src/auth/account-app.tsx
+++ b/src/auth/account-app.tsx
@@ -1,6 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
 import { useServerFn } from "@tanstack/react-start";
+import { useCallback, useState } from "react";
 import { accountState } from "./functions.js";
+import { DaemonHandoffEntry } from "../daemons/handoff.js";
 import { AccountEntry, InvitationEntry, OrganizationGate } from "./account-entry.js";
 import { FailedEntry, LoadingEntry, UnavailableInvitation } from "./account-states.js";
 import { DashboardShell } from "./dashboard-shell.js";
@@ -10,6 +12,14 @@ import { PasswordChangeEntry } from "./password-change.js";
 
 export function AccountApp() {
   const loadAccount = useServerFn(accountState);
+  /**
+   * The first-run phase between finishing app setup and the dashboard. A phase, not a gate: app
+   * onboarding is already complete on the server, so this tab is the only thing that remembers
+   * it, the CLI's own tab reaches its authorization page, and a reload lands on the dashboard.
+   */
+  const [handoff, setHandoff] = useState(false);
+  const enterHandoff = useCallback(() => setHandoff(true), []);
+  const leaveHandoff = useCallback(() => setHandoff(false), []);
   const invitation =
     typeof window === "undefined"
       ? undefined
@@ -31,11 +41,21 @@ export function AccountApp() {
     );
   }
   const state = account.data.data;
+  if (handoff && (state.status === "appSetupRequired" || state.status === "active")) {
+    return (
+      <DaemonHandoffEntry
+        accountId={state.account.id}
+        organizationId={state.organization.id}
+        organizationSlug={state.organization.slug}
+        onContinue={leaveHandoff}
+      />
+    );
+  }
   if (state.status === "instanceSetupRequired") return <InstanceSetupEntry />;
   if (state.status === "passwordChangeRequired")
     return <PasswordChangeEntry account={state.account} />;
   if (state.status === "appSetupRequired") {
-    return <AppSetupEntry organizationId={state.organization.id} />;
+    return <AppSetupEntry organizationId={state.organization.id} onLeft={enterHandoff} />;
   }
   if (state.invitationUnavailable === true) {
     return <UnavailableInvitation message="This invitation is unavailable." />;

--- a/src/auth/organization-contract.ts
+++ b/src/auth/organization-contract.ts
@@ -62,7 +62,9 @@ export const accountStateSchema = z.discriminatedUnion("status", [
   z.object({
     status: z.literal("appSetupRequired"),
     account: accountSchema,
-    organization: z.object({ id: z.string(), name: z.string(), slug: z.string().optional() }),
+    // The same resolved membership the active state carries, slug included: the daemon handoff
+    // that follows app setup addresses the organization by slug.
+    organization: z.object({ id: z.string(), name: z.string(), slug: z.string() }),
     memberships: z.array(membershipSchema),
     capabilities: organizationCapabilitiesSchema,
   }),

--- a/src/daemons/functions.ts
+++ b/src/daemons/functions.ts
@@ -25,6 +25,7 @@ const scopedRenameSchema = organizationScopeSchema.extend(renameSchema.shape);
 const scopedDaemonIdSchema = organizationScopeSchema.extend(daemonIdSchema.shape);
 
 export type BrowserDaemon = z.infer<typeof daemonSchema>;
+export type BrowserDaemonList = z.infer<typeof daemonListSchema>;
 export interface DaemonCommand {
   state: "complete" | "sessionExpired" | "organizationRequired";
 }

--- a/src/daemons/handoff.test.tsx
+++ b/src/daemons/handoff.test.tsx
@@ -1,0 +1,147 @@
+import assert from "node:assert/strict";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, it } from "vitest";
+import { daemonLink, daemonLoginCommand, DaemonHandoffView, type DaemonLink } from "./handoff.js";
+import type { BrowserDaemon, BrowserDaemonList } from "./functions.js";
+
+const NOOP = (): void => {};
+
+function daemon(overrides: Partial<BrowserDaemon> = {}): BrowserDaemon {
+  return {
+    id: "11111111-1111-4111-8111-111111111111",
+    slug: "workshop",
+    status: "active",
+    presence: "connected",
+    connectedAt: "2026-01-01T00:00:00.000Z",
+    lastSeenAt: "2026-01-01T00:00:00.000Z",
+    registeredAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function listing(daemons: readonly BrowserDaemon[]): { status: "ok"; data: BrowserDaemonList } {
+  return { status: "ok", data: { daemons: [...daemons], canManage: true } };
+}
+
+function markup(link: DaemonLink, command = "paseo hub login http://localhost:4173"): string {
+  return renderToStaticMarkup(
+    <DaemonHandoffView link={link} command={command} onRetry={NOOP} onContinue={NOOP} />,
+  );
+}
+
+describe("the daemon login command", () => {
+  it("names the address the operator is looking at, exactly", () => {
+    assert.equal(
+      daemonLoginCommand("http://localhost:4173"),
+      "paseo hub login http://localhost:4173",
+    );
+    assert.equal(
+      daemonLoginCommand("https://hub.internal.example:8443"),
+      "paseo hub login https://hub.internal.example:8443",
+    );
+  });
+
+  it("omits the argument only on the Hub the CLI already defaults to", () => {
+    assert.equal(daemonLoginCommand("https://hub.paseo.sh"), "paseo hub login");
+    // A look-alike is still somebody else's Hub and has to be named.
+    assert.equal(
+      daemonLoginCommand("https://hub.paseo.sh.example.com"),
+      "paseo hub login https://hub.paseo.sh.example.com",
+    );
+  });
+});
+
+describe("what the operator is waiting on", () => {
+  it("waits while the organization has no connected daemon", () => {
+    assert.deepEqual(daemonLink({ isPending: true, isError: false, data: undefined }), {
+      state: "checking",
+    });
+    assert.deepEqual(daemonLink({ isPending: false, isError: false, data: listing([]) }), {
+      state: "waiting",
+    });
+  });
+
+  it("counts only a live daemon this organization still has", () => {
+    assert.deepEqual(
+      daemonLink({
+        isPending: false,
+        isError: false,
+        data: listing([daemon({ presence: "offline", connectedAt: null })]),
+      }),
+      { state: "waiting" },
+    );
+    assert.deepEqual(
+      daemonLink({
+        isPending: false,
+        isError: false,
+        data: listing([daemon({ status: "revoked" })]),
+      }),
+      { state: "waiting" },
+    );
+    assert.deepEqual(
+      daemonLink({ isPending: false, isError: false, data: listing([daemon({ slug: "laptop" })]) }),
+      { state: "linked", slug: "laptop" },
+    );
+  });
+
+  it("reports a refused check with the server's own words, and a lost one in its own", () => {
+    assert.deepEqual(
+      daemonLink({
+        isPending: false,
+        isError: false,
+        data: { status: "error", error: { message: "Your session has expired." } },
+      }),
+      { state: "failed", message: "Your session has expired." },
+    );
+    const lost = daemonLink({ isPending: false, isError: true, data: undefined });
+    assert.equal(lost.state, "failed");
+    assert.match(lost.state === "failed" ? lost.message : "", /connection/u);
+  });
+
+  it("never takes a connection back because the next check failed", () => {
+    assert.deepEqual(daemonLink({ isPending: false, isError: true, data: listing([daemon()]) }), {
+      state: "linked",
+      slug: "workshop",
+    });
+  });
+});
+
+describe("the daemon handoff screen", () => {
+  it("gives the operator one command and one way to skip", () => {
+    const screen = markup({ state: "waiting" });
+
+    assert.match(screen, /Connect a daemon/u);
+    assert.ok(screen.includes("paseo hub login http://localhost:4173"));
+    assert.match(screen, /Waiting for a daemon to connect/u);
+    assert.match(screen, /Do this later/u);
+    assert.match(screen, /starter workflow/u);
+  });
+
+  it("says it is still looking before the first answer arrives", () => {
+    const screen = markup({ state: "checking" });
+
+    assert.match(screen, /Checking for daemons/u);
+    assert.doesNotMatch(screen, /Waiting for a daemon/u);
+  });
+
+  it("offers another check when one fails, without taking the command away", () => {
+    const screen = markup({ state: "failed", message: "Hub did not answer." });
+
+    assert.match(screen, /Hub couldn&#x27;t check for daemons/u);
+    assert.match(screen, /Hub did not answer\./u);
+    assert.match(screen, /Check again/u);
+    assert.ok(screen.includes("paseo hub login http://localhost:4173"));
+    // A failed check is not a reason to strand the operator here.
+    assert.match(screen, /Do this later/u);
+  });
+
+  it("names the daemon that connected and moves on", () => {
+    const screen = markup({ state: "linked", slug: "workshop" });
+
+    assert.match(screen, /Daemon connected/u);
+    assert.match(screen, /workshop is connected to this Hub/u);
+    assert.match(screen, /Continue/u);
+    // Nothing left to run: the command would only invite a second login.
+    assert.ok(!screen.includes("paseo hub login"));
+  });
+});

--- a/src/daemons/handoff.test.tsx
+++ b/src/daemons/handoff.test.tsx
@@ -1,7 +1,13 @@
 import assert from "node:assert/strict";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, it } from "vitest";
-import { daemonLink, daemonLoginCommand, DaemonHandoffView, type DaemonLink } from "./handoff.js";
+import {
+  daemonLink,
+  daemonLoginCommand,
+  DaemonHandoffView,
+  defaultProjectRoute,
+  type DaemonLink,
+} from "./handoff.js";
 import type { BrowserDaemon, BrowserDaemonList } from "./functions.js";
 
 const NOOP = (): void => {};
@@ -47,6 +53,15 @@ describe("the daemon login command", () => {
     assert.equal(
       daemonLoginCommand("https://hub.paseo.sh.example.com"),
       "paseo hub login https://hub.paseo.sh.example.com",
+    );
+  });
+});
+
+describe("where onboarding ends", () => {
+  it("addresses the project every organization is provisioned with", () => {
+    assert.equal(
+      defaultProjectRoute("paseo-hub-1a2b3c4d"),
+      "/o/paseo-hub-1a2b3c4d/projects/default/overview",
     );
   });
 });

--- a/src/daemons/handoff.tsx
+++ b/src/daemons/handoff.tsx
@@ -1,4 +1,6 @@
+/* oxlint-disable typescript-eslint/no-unsafe-type-assertion -- the generated route type cannot express a server-resolved organization slug */
 import { useQuery } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
 import { useServerFn } from "@tanstack/react-start";
 import { TriangleAlert } from "lucide-react";
 import { useCallback } from "react";
@@ -22,6 +24,15 @@ const HOSTED_HUB_ORIGIN = "https://hub.paseo.sh";
 /** The exact command to paste into a terminal on the machine that will run the agents. */
 export function daemonLoginCommand(origin: string): string {
   return origin === HOSTED_HUB_ORIGIN ? "paseo hub login" : `paseo hub login ${origin}`;
+}
+
+/**
+ * Where both ways out of the handoff land: the project every organization is provisioned with
+ * (`provisionOrganization` in src/organizations/provisioning.ts names it). Onboarding ends inside
+ * the operator's project, not on a list asking them to pick the only entry it has.
+ */
+export function defaultProjectRoute(organizationSlug: string): string {
+  return `/o/${organizationSlug}/projects/default/overview`;
 }
 
 /**
@@ -84,6 +95,18 @@ export function DaemonHandoffEntry({
   });
   const refetch = snapshot.refetch;
   const retry = useCallback(() => void refetch(), [refetch]);
+  const navigate = useNavigate();
+  /**
+   * Connecting and skipping end the same way: inside the default project. The route has to be
+   * committed before the phase is dropped — dropping it first would render the dashboard at
+   * whatever URL onboarding happens to be standing on, and flash the project list on the way.
+   */
+  const leave = useCallback(() => {
+    void (async () => {
+      await navigate({ to: defaultProjectRoute(organizationSlug) as never });
+      onContinue();
+    })();
+  }, [navigate, onContinue, organizationSlug]);
   return (
     <DaemonHandoffView
       link={daemonLink(snapshot)}
@@ -91,7 +114,7 @@ export function DaemonHandoffEntry({
       // Only a click in app setup reaches this step, so there is no server render to guard.
       command={daemonLoginCommand(window.location.origin)}
       onRetry={retry}
-      onContinue={onContinue}
+      onContinue={leave}
     />
   );
 }

--- a/src/daemons/handoff.tsx
+++ b/src/daemons/handoff.tsx
@@ -1,0 +1,167 @@
+import { useQuery } from "@tanstack/react-query";
+import { useServerFn } from "@tanstack/react-start";
+import { TriangleAlert } from "lucide-react";
+import { useCallback } from "react";
+import { AuthCard, AuthLayout } from "../components/app/auth-layout.js";
+import { CopyField } from "../components/app/copy-field.js";
+import { Alert, AlertDescription, AlertTitle } from "../components/ui/alert.js";
+import { Button } from "../components/ui/button.js";
+import type { Result } from "../contract/respond.js";
+import { daemonList, type BrowserDaemonList } from "./functions.js";
+import { daemonsQueryKey } from "./status.js";
+
+const POLL_INTERVAL_MS = 2_000;
+
+/**
+ * The origin `paseo hub login` resolves to when it is given no argument (`DEFAULT_HUB_ORIGIN` in
+ * the CLI). Every other Hub has to be named on the command line, so the argument is omitted only
+ * when this Hub is that one — no deployment flag, and nothing to configure per instance.
+ */
+const HOSTED_HUB_ORIGIN = "https://hub.paseo.sh";
+
+/** The exact command to paste into a terminal on the machine that will run the agents. */
+export function daemonLoginCommand(origin: string): string {
+  return origin === HOSTED_HUB_ORIGIN ? "paseo hub login" : `paseo hub login ${origin}`;
+}
+
+/**
+ * What the operator is waiting on, decided outside React so every state has a name and a test.
+ * A link that has already been made outranks a failed poll: a success is never taken back
+ * because the next request timed out.
+ */
+export type DaemonLink =
+  | { state: "checking" }
+  | { state: "waiting" }
+  | { state: "failed"; message: string }
+  | { state: "linked"; slug: string };
+
+export function daemonLink(snapshot: {
+  isPending: boolean;
+  isError: boolean;
+  data: Result<BrowserDaemonList> | undefined;
+}): DaemonLink {
+  const connected =
+    snapshot.data?.status === "ok"
+      ? snapshot.data.data.daemons.find(
+          (daemon) => daemon.status === "active" && daemon.presence === "connected",
+        )
+      : undefined;
+  if (connected !== undefined) return { state: "linked", slug: connected.slug };
+  if (snapshot.data?.status === "error") {
+    return { state: "failed", message: snapshot.data.error.message };
+  }
+  if (snapshot.isError) {
+    return {
+      state: "failed",
+      message: "Hub didn't answer. Check your connection, then check again.",
+    };
+  }
+  if (snapshot.isPending) return { state: "checking" };
+  return { state: "waiting" };
+}
+
+/**
+ * The step between app setup and the dashboard. App onboarding is already complete on the server
+ * by the time this renders, so the terminal's own browser tab reaches the CLI authorization page
+ * instead of being sent back into setup — this screen is a client-side phase, not a gate.
+ */
+export function DaemonHandoffEntry({
+  accountId,
+  organizationId,
+  organizationSlug,
+  onContinue,
+}: {
+  accountId: string;
+  organizationId: string;
+  organizationSlug: string;
+  onContinue: () => void;
+}) {
+  const load = useServerFn(daemonList);
+  const snapshot = useQuery({
+    queryKey: daemonsQueryKey(accountId, organizationId),
+    queryFn: () => load({ data: { organizationSlug } }),
+    refetchInterval: POLL_INTERVAL_MS,
+  });
+  const refetch = snapshot.refetch;
+  const retry = useCallback(() => void refetch(), [refetch]);
+  return (
+    <DaemonHandoffView
+      link={daemonLink(snapshot)}
+      // The address the operator reached this Hub at is the address their daemon has to be told.
+      // Only a click in app setup reaches this step, so there is no server render to guard.
+      command={daemonLoginCommand(window.location.origin)}
+      onRetry={retry}
+      onContinue={onContinue}
+    />
+  );
+}
+
+export function DaemonHandoffView({
+  link,
+  command,
+  onRetry,
+  onContinue,
+}: {
+  link: DaemonLink;
+  command: string;
+  onRetry: () => void;
+  onContinue: () => void;
+}) {
+  if (link.state === "linked") {
+    return (
+      <AuthLayout width="md">
+        <AuthCard
+          title="Daemon connected"
+          description={`${link.slug} is connected to this Hub. Finish the starter workflow in your terminal whenever you're ready.`}
+          descriptionRole="status"
+        >
+          <Button onClick={onContinue}>Continue</Button>
+        </AuthCard>
+      </AuthLayout>
+    );
+  }
+  return (
+    <AuthLayout width="md">
+      <AuthCard
+        title="Connect a daemon"
+        description="Hub runs your workflows on daemons you own. Run this on the machine where your code lives:"
+      >
+        <CopyField label="Command" value={command} />
+        <p className="text-sm text-muted-foreground">
+          Your terminal signs you in, connects this daemon, and offers to set up a starter workflow.
+        </p>
+        <LinkProgress link={link} onRetry={onRetry} />
+        <Button variant="ghost" onClick={onContinue}>
+          Do this later
+        </Button>
+      </AuthCard>
+    </AuthLayout>
+  );
+}
+
+/**
+ * Waiting is the ordinary case and reads as a quiet status line. A failed check is the one thing
+ * the operator can act on here, so it gets an alert and its own retry — the command stays on
+ * screen either way, because nothing about it has changed.
+ */
+function LinkProgress({ link, onRetry }: { link: DaemonLink; onRetry: () => void }) {
+  if (link.state === "failed") {
+    return (
+      <Alert variant="destructive">
+        <TriangleAlert />
+        <AlertTitle>Hub couldn't check for daemons</AlertTitle>
+        <AlertDescription>
+          <p>{link.message}</p>
+          <Button type="button" size="sm" variant="outline" onClick={onRetry}>
+            Check again
+          </Button>
+        </AlertDescription>
+      </Alert>
+    );
+  }
+  return (
+    <p role="status" aria-live="polite" className="text-sm text-muted-foreground">
+      {link.state === "checking" ? "Checking for daemons…" : "Waiting for a daemon to connect…"}
+    </p>
+  );
+}

--- a/src/e2e/harness/browser-child.ts
+++ b/src/e2e/harness/browser-child.ts
@@ -101,6 +101,16 @@ interface ProjectReadFailureCommand {
   type: "fail-next-project-read";
 }
 
+/**
+ * What `paseo hub connect` redeems. The child issues it because it is the process that owns the
+ * database, so a journey can enroll a daemon on an embedded instance with no PostgreSQL at all.
+ */
+interface DaemonEnrollmentCommand {
+  id: string;
+  type: "daemon-enrollment-token";
+  verifier: string;
+}
+
 // Fixture-only: signature verification is local HMAC, so any well-formed secret works
 // identically to a real one. STRIPE_WEBHOOK_SECRET must match what e2e/helpers/hub.ts signs
 // webhook payloads with — see WEBHOOK_SECRET there and GITHUB_WEBHOOK_SECRET for precedent.
@@ -422,6 +432,10 @@ async function acceptCommand(message: unknown, fixtures: CommandFixtures): Promi
     process.send?.({ id: message.id, ok: true });
     return;
   }
+  if (isDaemonEnrollmentCommand(message)) {
+    await acceptDaemonEnrollmentCommand(message, fixtures);
+    return;
+  }
   if (isSlackSocketCommand(message)) {
     await acceptSlackSocketCommand(message, fixtures);
     return;
@@ -430,6 +444,26 @@ async function acceptCommand(message: unknown, fixtures: CommandFixtures): Promi
   if (!isDiscordCommand(message)) return;
   try {
     await bot.deliver(message.event);
+    process.send?.({ id: message.id, ok: true });
+  } catch (error) {
+    process.send?.({
+      id: message.id,
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+async function acceptDaemonEnrollmentCommand(
+  message: DaemonEnrollmentCommand,
+  fixtures: CommandFixtures,
+): Promise<void> {
+  try {
+    await fixtures.databaseRuntime.query(
+      `insert into daemon_enrollment_tokens (id, verifier, organization_id, expires_at)
+       select gen_random_uuid(), $1, id, now() + interval '10 minutes' from organization`,
+      [message.verifier],
+    );
     process.send?.({ id: message.id, ok: true });
   } catch (error) {
     process.send?.({
@@ -619,6 +653,16 @@ function isAccountSetupFailureCommand(value: unknown): value is AccountSetupFail
     value !== null &&
     Reflect.get(value, "type") === "fail-next-account-setup" &&
     typeof Reflect.get(value, "id") === "string"
+  );
+}
+
+function isDaemonEnrollmentCommand(value: unknown): value is DaemonEnrollmentCommand {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    Reflect.get(value, "type") === "daemon-enrollment-token" &&
+    typeof Reflect.get(value, "id") === "string" &&
+    typeof Reflect.get(value, "verifier") === "string"
   );
 }
 

--- a/src/instance-setup/browser-claim.integration.test.ts
+++ b/src/instance-setup/browser-claim.integration.test.ts
@@ -30,7 +30,7 @@ const accountStateSchema = z
   .object({
     status: z.string(),
     account: z.object({ email: z.string() }).optional(),
-    organization: z.object({ name: z.string() }).optional(),
+    organization: z.object({ name: z.string(), slug: z.string() }).optional(),
     isInstanceOperator: z.boolean().optional(),
     registration: z.string().optional(),
   })
@@ -77,6 +77,9 @@ describe("first-run claim at the browser boundary", () => {
       const cookie = await signIn(instance.auth, operator.email, operator.password);
       const appSetup = await readAccountState(instance.auth, cookie);
       assert.equal(appSetup.status, "appSetupRequired");
+      // App setup already resolves the organization the daemon handoff has to address, and it is
+      // the same one the dashboard opens on — the handoff never re-resolves it.
+      assert.match(appSetup.organization?.slug ?? "", /^paseo-hub-[0-9a-f]{8}$/u);
       await instance.auth.completeAppOnboarding!(
         new Request(`${ORIGIN}/`, {
           method: "POST",
@@ -87,6 +90,7 @@ describe("first-run claim at the browser boundary", () => {
       assert.equal(active.status, "active");
       assert.equal(active.account?.email, operator.email);
       assert.equal(active.organization?.name, "Paseo Hub");
+      assert.equal(active.organization?.slug, appSetup.organization?.slug);
       assert.equal(active.isInstanceOperator, true);
 
       const storedNames = await instance.database.query<{

--- a/src/provider-applications/panel.tsx
+++ b/src/provider-applications/panel.tsx
@@ -110,8 +110,18 @@ function OverviewLoading() {
 /**
  * First run. The operator has an account and an organization and nothing else; the dashboard
  * would introduce projects before there is any reason to explain them.
+ *
+ * Leaving is a server fact — app onboarding is complete the moment the request succeeds, so a CLI
+ * authorization opened in another tab is no longer sent back here. Where the operator goes next
+ * is the journey's decision, not this surface's: `onLeft` is called once the server agrees.
  */
-export function AppSetupEntry({ organizationId }: { organizationId: string }) {
+export function AppSetupEntry({
+  organizationId,
+  onLeft,
+}: {
+  organizationId: string;
+  onLeft: () => void;
+}) {
   const queryClient = useQueryClient();
   const overview = useProviderApplicationsOverview();
   const connected = overview.data?.status === "ok" ? connectedProviderCount(overview.data.data) : 0;
@@ -122,7 +132,9 @@ export function AppSetupEntry({ organizationId }: { organizationId: string }) {
       input: Parameters<typeof completeAppSetup>[0],
     ) => Promise<Result<Record<string, never>>>,
     onSuccess: async (response) => {
-      if (response.status === "ok") await queryClient.invalidateQueries({ queryKey: ["account"] });
+      if (response.status !== "ok") return;
+      await queryClient.invalidateQueries({ queryKey: ["account"] });
+      onLeft();
     },
   });
   const done = useCallback(() => finish.mutate({}), [finish]);


### PR DESCRIPTION
## What changed

App setup used to end on the dashboard, leaving a new operator with a Hub that cannot run anything and no idea that a daemon is what runs it. This is the browser handoff phase of zero-friction Hub onboarding: after app setup, the operator gets one exact command to paste into a terminal, Hub watches for the daemon that command connects, and both ways out land them directly in the Default project their instance was provisioned with.

The intended journey is `npx @getpaseo/hub` → operator setup → app setup → **daemon handoff** → `paseo hub login` → connect → initialize and deploy.

## Goals

- Add a post-app onboarding step that asks the operator to link a daemon.
- Complete app onboarding server-side *before* that step renders, so a CLI authorization page opened in another tab is not blocked by the onboarding guard.
- Show one exact, copyable command: `paseo hub login <current-origin>` self-hosted, `paseo hub login` on the official hosted Hub.
- Poll existing organization daemon state with explicit loading, waiting, failure-with-retry, connected, and "Do this later" states.
- Land both success and skip directly in the already-created Default project.
- Add no durable onboarding state, no migration, and no project creation.

## Non-goals

- CLI behavior (owned by getpaseo/paseo#3651).
- Public documentation.
- Installing or operating a remote daemon automatically.
- Redesigning the dashboard, projects, or app setup.
- The setup-resources API and activity redirect (owned by #62).

## Why

### App onboarding completes before the handoff renders

The onboarding guard is server-side: an instance operator whose app onboarding is incomplete gets `appSetupRequired` for *every* authenticated route, including `/cli-login`. The terminal command on this screen opens a browser tab to approve a CLI login, so if the handoff were a gate, the flow would deadlock — the screen telling you to run the command would be the same screen blocking the command from finishing.

So leaving app setup is a server fact. `completeAppSetup` runs first; the moment it succeeds, `/cli-login` is reachable in any tab. The handoff itself is a **client-only phase** held in `AccountApp`, not a route and not a database row. It lives in the tab that finished app setup. A reload lands on the dashboard exactly as before, which is also why no migration or onboarding column is needed.

### The command names the address the operator is already looking at

`paseo hub login` with no argument resolves to the CLI's own default origin. Any other Hub has to be named, and the only address certainly reachable from the operator's machine is the one their browser is on. So the rule is one comparison against that single origin — no deployment flag, no per-instance configuration, nothing new to set.

- Self-hosted: `paseo hub login http://localhost:3000` (the live browser origin, exactly).
- Official hosted Hub: `paseo hub login`.

### Polling states

The handoff subscribes to the existing organization daemon query and maps it to four named states outside React, so each one has a test:

| State | What the operator sees |
| --- | --- |
| `checking` | "Checking for daemons…" before the first answer |
| `waiting` | "Waiting for a daemon to connect…" with the command still on screen |
| `failed` | An alert with the server's own message and a **Check again** retry; the command stays visible |
| `linked` | "Daemon connected", naming the daemon, with **Continue** |

A daemon counts as linked when it is active *and* connected. A connection is never taken back because a later poll failed — `linked` outranks `failed`.

### Both exits land in the Default project

Instance setup already provisions a `Default` project, so ending onboarding on a project list with one entry asks the operator to pick the only choice. `Continue` and `Do this later` both navigate to `/o/<organization-slug>/projects/default/overview`, reusing the organization slug already passed into the handoff. Nothing is queried and no project is created.

The route is committed before the client phase is dropped. Dropping it first renders the dashboard at whatever URL onboarding happens to be standing on, which flashes the project list on the way past.

## Related work

- Refs #62 — Phase 1 of the same epic (setup-resources API and the activity redirect). This branch does **not** contain those changes; it is listed as dependency and context for the broader epic only.
- Refs getpaseo/paseo#3651 — Phase 2, the guided CLI this screen's instructions describe.

## 🚫 Rollout is blocked

**Do not merge this PR until getpaseo/paseo#3651 is merged and released.**

This screen tells the operator that their terminal "signs you in, connects this daemon, and offers to set up a starter workflow". Today's released CLI authenticates only — connect, initialize, and deploy are added by #3651. Shipping the browser instructions first would promise a flow the CLI does not yet offer.

## Test harness correction

Enrolling a daemon in the E2E harness used to reach the database directly with `pg.Client`, which only works against PostgreSQL and forced the journey to pay for a container. Issuing the enrollment token now goes through the application-owned runtime boundary — the child process that owns the database answers a `daemon-enrollment-token` command — so it works on either runtime.

That removed the only runtime asymmetry in the journey, and the core handoff spec now runs fully on **embedded PGlite with no PostgreSQL container at all**. The same journey was also run forced onto PostgreSQL to confirm equivalence, and the affected shared suites still run against PostgreSQL as before.

## Verification

| Check | Result |
| --- | --- |
| `npx vitest run src/daemons/handoff.test.tsx` | 11 passed — exact origin in command, hosted omits the argument, look-alike origin still named, canonical Default-project route, all four polling states, success survives a failed poll |
| `npx playwright test e2e/daemon-handoff.spec.ts --project=desktop-chromium` (embedded PGlite) | **2 passed**, 21.3s |
| Same journey forced onto PostgreSQL (temporary variant, not committed) | **2 passed**, 21.4s |
| `npx vitest run src/instance-setup/browser-claim.integration.test.ts` (PostgreSQL, testcontainers) | 6 passed |
| `npx playwright test e2e/apps.spec.ts e2e/first-run.spec.ts --project=desktop-chromium` | 23 passed |
| `npx playwright test e2e/apps-mobile.spec.ts --project=mobile-chromium` | 6 passed |
| `npm run release:check` | exit 0 (test:release, typecheck ×3, lint, format:check, build, `npm pack --dry-run`) |

The E2E journey proves, in one causal run: app-setup completion reaches the handoff; the self-hosted command contains the current origin exactly and copies to the clipboard; `/cli-login` renders its verification-code form in a second tab *while the handoff is displayed*; a newly enrolled and connected daemon advances to the success state; and both exits assert the canonical Default-project URL and its Overview immediately after the click, rather than clicking a project link. The screen is axe-clean.

## Risk surface

- **Onboarding entry ordering.** `AccountApp` gained one client-side phase check ahead of the existing status branches. Worth confirming the handoff cannot capture a session that is signed out or has no organization — it renders only for `appSetupRequired` and `active`.
- **Account state contract.** `appSetupRequired` now declares `organization.slug` required instead of optional. The server has always sent the same resolved membership as the active state; the integration test asserts both states carry the same slug.
- **Shared E2E helpers.** `AppSetupSurface.leave()` and `skipAppSetup()` now walk through the handoff and end on the project Overview, so every journey that passes through app setup changed destination. Assertions were updated only where the new true destination required it.
- **No database change.** No migration, no new column, no durable onboarding row.
