### PR TITLE
fix(auth): prefer explicit HTTPS app URL over downgraded trusted origin

### DIFF
--- a/src/auth/server.ts
+++ b/src/auth/server.ts
@@ -359,7 +359,23 @@ function headersBrowserOrigin(headers: Headers, fallback: string): string {
   ) {
     throw new Error("invalid trusted request origin");
   }
-  return url.origin;
+  const trustedOrigin = url.origin;
+  // The trusted origin header is derived from the direct origin connection,
+  // which is plain HTTP behind a TLS-terminating reverse proxy (Cloudflare
+  // Tunnel, nginx SSL pass-through, ...) even though the browser talks HTTPS.
+  // An explicitly configured HTTPS app URL (the fallback passed by the auth
+  // boundary) is authoritative: prefer it over a scheme-downgraded http:
+  // trusted origin for the same host so a proxy cannot reject every
+  // cookie-mutating action with a spurious origin mismatch.
+  const configured = new URL(fallback);
+  if (
+    configured.protocol === "https:" &&
+    url.protocol === "http:" &&
+    configured.host === url.host
+  ) {
+    return fallback;
+  }
+  return trustedOrigin;
 }
 
 function requireBrowserOrigin(headers: Headers, browserOrigin: string): void {


### PR DESCRIPTION
Fixes #67

## Problem

`provider_applications.verify_and_save` (Apps → GitHub → Replace credentials) fails with `forbidden` — UI: `"Only an instance operator can change the GitHub app. Nothing was saved."` — when Hub is reached through a TLS-terminating reverse proxy (reproduced with Cloudflare Tunnel, origin plain HTTP), even with a valid operator session and `PASEO_HUB_APP_URL=https://…` set.

The auth boundary computes the expected browser origin from the internal `x-paseo-trusted-request-origin` header (seeded from the **direct** origin connection — plain HTTP behind the proxy) and compares it against the browser's `https:` Origin → mismatch → `rejectCookieMutation` → 403. The sign-in path already prefers the explicit app URL, which is why sign-in works but every cookie-mutating action is rejected.

## Fix

In `headersBrowserOrigin` prefer the explicitly configured HTTPS app URL (the fallback the auth boundary passes in) whenever the trusted header is only an `http:` origin for the same host. This mirrors the explicit-app-url precedence already used in the `resolveCallbackOrigin` (provider-applications) and sign-in paths, and leaves all other deployments (no explicit app URL, plain http, or matching forwarded origins) with existing behavior.

## Verification

- `npm run typecheck:node` passes.
- Reproduced and confirmed fixed against a real 0.7.0 deployment behind Cloudflare Tunnel: with this logic the dashboard credential edit succeeds; (separate note: in production we bypassed via direct DB write and webhook verification is unaffected — issue #67 has the full log evidence).
