### PR TITLE
Route pull request workflow triggers

### DIFF
--- a/src/provider-applications/internal/runtime-owner.test.ts
+++ b/src/provider-applications/internal/runtime-owner.test.ts
@@ -17,16 +17,11 @@ describe("dynamic provider runtime", () => {
   it.each([
     "github.issues",
     "github.issue_comment",
+    "github.pull_request",
     "github.pull_request_review",
     "github.pull_request_review_comment",
     "github.push",
-    "github.issue_created",
-    "github.pull_request_created",
-    "github.issue_comment_created",
-    "github.pull_request_comment_created",
-    "github.issue_label_added",
-    "github.pull_request_label_added",
-  ] as const)("publishes %s through the activated GitHub runtime registry", async (eventName) => {
+  ] as const)("publishes raw source %s through the activated GitHub runtime", async (eventName) => {
     const runtime = new DynamicProviderRuntime({
       database: createMemoryDatabase(),
       auth: testAuth(),

--- a/src/provider-applications/internal/runtime-owner.ts
+++ b/src/provider-applications/internal/runtime-owner.ts
@@ -22,7 +22,7 @@ import type {
 } from "../index.js";
 import { parseProviderApplicationConfiguration } from "./store.js";
 import type { SlackDeliveryStatus } from "../../triggers/slack/source/index.js";
-import { GITHUB_TRIGGER_EVENT_NAMES } from "../../triggers/github/classification.js";
+import { GITHUB_TRIGGER_SOURCE_NAMES } from "../../triggers/github/classification.js";
 
 interface Slot {
   active: ActiveRegistration | undefined;
@@ -708,7 +708,7 @@ function actionNames(provider: Provider): readonly string[] {
 function eventNames(provider: Provider): TriggerProvider["eventNames"] {
   if (provider === "slack") return ["slack.mention"];
   if (provider === "discord") return ["discord.mention"];
-  return GITHUB_TRIGGER_EVENT_NAMES;
+  return GITHUB_TRIGGER_SOURCE_NAMES;
 }
 
 async function startSources(active: ActiveRegistration, handler: TriggerHandler): Promise<void> {

--- a/src/triggers/github/classification.ts
+++ b/src/triggers/github/classification.ts
@@ -18,13 +18,13 @@ export const GITHUB_SEMANTIC_TRIGGER_EVENT_NAMES = [
 
 export type GitHubSemanticEvent = (typeof GITHUB_SEMANTIC_TRIGGER_EVENT_NAMES)[number];
 
-export const GITHUB_TRIGGER_EVENT_NAMES = [
+export const GITHUB_TRIGGER_SOURCE_NAMES = [
   "github.issue_comment",
   "github.issues",
+  "github.pull_request",
   "github.pull_request_review",
   "github.pull_request_review_comment",
   "github.push",
-  ...GITHUB_SEMANTIC_TRIGGER_EVENT_NAMES,
 ] as const;
 
 export interface GitHubClassifiedEvent {

--- a/src/triggers/github/provider.ts
+++ b/src/triggers/github/provider.ts
@@ -20,7 +20,7 @@ import {
   PullRequestReviewCommentPayloadSchema,
 } from "../../auth/github-events.js";
 import type { NormalizedGitHubEvent } from "../../auth/github-events.js";
-import { classifyGitHubEvent, GITHUB_TRIGGER_EVENT_NAMES } from "./classification.js";
+import { classifyGitHubEvent, GITHUB_TRIGGER_SOURCE_NAMES } from "./classification.js";
 
 export interface GitHubReactionClient {
   createReaction(input: {
@@ -128,7 +128,7 @@ export function createGitHubTriggerProvider(options: {
 }): TriggerProvider<"github", GitHubTriggerContext> {
   return {
     name: "github",
-    eventNames: GITHUB_TRIGGER_EVENT_NAMES,
+    eventNames: GITHUB_TRIGGER_SOURCE_NAMES,
     async match(externalTrigger) {
       const event = NormalizedGitHubEventSchema.parse(externalTrigger.payload);
       const stored = await options


### PR DESCRIPTION
Pull-request-created and pull-request-label-added workflows now receive GitHub webhook deliveries instead of appearing as unrouted events. Existing GitHub trigger behavior remains unchanged.

## Goals

- Route raw `github.pull_request` webhook deliveries to the GitHub trigger provider.
- Preserve semantic workflow matching for `github.pull_request_created` and `github.pull_request_label_added`.
- Keep inbound webhook source names separate from authored semantic trigger names.
- Lock every supported raw GitHub source at the dynamic runtime boundary.

## Non-goals

- Add new GitHub event families or action filters.
- Change workflow configuration syntax or label matching.
- Reprocess previously dropped webhook deliveries.

## Why

GitHub delivers both opened and labeled pull requests with the raw `pull_request` event name. Provider selection happens before semantic action classification, but the provider registry advertised semantic workflow names and omitted the raw pull-request source. The engine therefore dropped these deliveries before the GitHub matcher could classify their action.

## Verification

- `pnpm vitest run src/provider-applications/internal/runtime-owner.test.ts src/triggers/github/match.test.ts src/triggers/github/provider.test.ts src/triggers/github/webhook.test.ts --reporter=dot` — 68 tests passed.
- `pnpm release:check` — passed.
- `pnpm test` — 759 tests passed locally; PostgreSQL/Testcontainers cases could not start because this host has no working container runtime.

## Risk surface

Limited to GitHub provider source registration. Existing issue, comment, review, and push sources remain registered; semantic classification and filter matching are unchanged.