### PR TITLE
Stop Discord notification retries after trigger messages are deleted

### DIFF
--- a/src/triggers/discord/bot.test.ts
+++ b/src/triggers/discord/bot.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { EventEmitter } from "node:events";
-import type { Client } from "discord.js";
+import { DiscordAPIError, RESTJSONErrorCodes, type Client } from "discord.js";
 import { describe, it } from "vitest";
 import { createDiscordBotClient } from "./bot.js";
 
@@ -195,16 +195,58 @@ describe("Discord bot client", () => {
     );
     assert.deepEqual(channel.sentPayloads, []);
   });
+
+  it("treats reactions to a deleted message as already converged", async () => {
+    const missingMessage = new DiscordAPIError(
+      { code: RESTJSONErrorCodes.UnknownMessage, message: "Unknown Message" },
+      RESTJSONErrorCodes.UnknownMessage,
+      404,
+      "PUT",
+      "https://discord.test/channels/200/messages/300/reactions/%E2%9C%85/@me",
+      { body: null, files: [] },
+    );
+    const channel = new FakeSendableChannel({ messageFetchError: missingMessage });
+    const bot = createDiscordBotClient({
+      token: "token",
+      clientId: "900",
+      client: createFakeClient(channel, undefined, { deleteReactionError: missingMessage }),
+    });
+
+    await bot.createReaction({ channelId: "200", messageId: "300", emoji: "✅" });
+    await bot.deleteOwnReaction({ channelId: "200", messageId: "300", emoji: "⏳" });
+  });
+
+  it("preserves other reaction failures for retry", async () => {
+    const unavailable = new Error("Discord unavailable");
+    const channel = new FakeSendableChannel({ messageFetchError: unavailable });
+    const bot = createDiscordBotClient({
+      token: "token",
+      clientId: "900",
+      client: createFakeClient(channel, undefined, { deleteReactionError: unavailable }),
+    });
+
+    await assert.rejects(
+      bot.createReaction({ channelId: "200", messageId: "300", emoji: "✅" }),
+      (error: unknown) => error === unavailable,
+    );
+    await assert.rejects(
+      bot.deleteOwnReaction({ channelId: "200", messageId: "300", emoji: "⏳" }),
+      (error: unknown) => error === unavailable,
+    );
+  });
 });
 
 class FakeSendableChannel {
   readonly sentPayloads: unknown[] = [];
   readonly messages: { fetch: (messageId: string) => Promise<FakeMessage> };
 
-  constructor(readonly options: { message?: FakeMessage } = {}) {
+  constructor(readonly options: { message?: FakeMessage; messageFetchError?: Error } = {}) {
     this.messages = {
       fetch: async (messageId: string) => {
         assert.equal(messageId, "300");
+        if (this.options.messageFetchError !== undefined) {
+          throw this.options.messageFetchError;
+        }
         if (this.options.message === undefined) {
           throw new Error("message unavailable");
         }
@@ -257,7 +299,11 @@ class FakeMessage {
   }
 }
 
-function createFakeClient(channel: FakeSendableChannel, thread?: FakeSendableChannel): Client {
+function createFakeClient(
+  channel: FakeSendableChannel,
+  thread?: FakeSendableChannel,
+  options: { deleteReactionError?: Error } = {},
+): Client {
   const fakeClient = {
     on() {
       return fakeClient;
@@ -275,7 +321,9 @@ function createFakeClient(channel: FakeSendableChannel, thread?: FakeSendableCha
       },
     },
     rest: {
-      async delete(): Promise<void> {},
+      async delete(): Promise<void> {
+        if (options.deleteReactionError !== undefined) throw options.deleteReactionError;
+      },
     },
     async login(): Promise<string> {
       return "logged-in";

--- a/src/triggers/discord/bot.ts
+++ b/src/triggers/discord/bot.ts
@@ -1,6 +1,8 @@
 import {
   Client,
+  DiscordAPIError,
   GatewayIntentBits,
+  RESTJSONErrorCodes,
   type GuildBasedChannel,
   type Message,
   type TextBasedChannel,
@@ -190,17 +192,23 @@ export function createDiscordBotClient(options: CreateDiscordBotClientOptions): 
       return DiscordSnowflakeSchema.parse(id);
     },
     async createReaction(input) {
-      const message = await fetchMessage(
-        client,
-        DiscordSnowflakeSchema.parse(input.channelId),
-        DiscordSnowflakeSchema.parse(input.messageId),
-      );
-      await message.react(input.emoji);
+      await ignoreDeletedMessage(async () => {
+        const message = await fetchMessage(
+          client,
+          DiscordSnowflakeSchema.parse(input.channelId),
+          DiscordSnowflakeSchema.parse(input.messageId),
+        );
+        await message.react(input.emoji);
+      });
     },
     async deleteOwnReaction(input) {
       const channelId = DiscordSnowflakeSchema.parse(input.channelId);
       const messageId = DiscordSnowflakeSchema.parse(input.messageId);
-      await client.rest.delete(Routes.channelMessageOwnReaction(channelId, messageId, input.emoji));
+      await ignoreDeletedMessage(async () => {
+        await client.rest.delete(
+          Routes.channelMessageOwnReaction(channelId, messageId, input.emoji),
+        );
+      });
     },
     async sendChannelMessage(input) {
       const channelId = DiscordSnowflakeSchema.parse(input.threadId ?? input.channelId);
@@ -249,6 +257,17 @@ export function createDiscordBotClient(options: CreateDiscordBotClientOptions): 
       return () => guildDeleteHandlers.delete(handler);
     },
   };
+}
+
+async function ignoreDeletedMessage(operation: () => Promise<void>): Promise<void> {
+  try {
+    await operation();
+  } catch (error) {
+    if (error instanceof DiscordAPIError && error.code === RESTJSONErrorCodes.UnknownMessage) {
+      return;
+    }
+    throw error;
+  }
 }
 
 async function resolveReplyDestination(


### PR DESCRIPTION
Deleting a Discord message that triggered a workflow no longer leaves Hub retrying an impossible terminal reaction and filling logs. Deleted reaction targets now converge as already complete, while temporary Discord failures continue through the durable retry path.

## Goals

- Complete terminal notification delivery when the original Discord message was deleted.
- Stop repeated `workflow.notification.terminal.deliver` failures for that permanent condition.
- Preserve retries for availability, permission, rate-limit, and other Discord failures.

## Non-goals

- Change workflow outbox retry policy or persistence.
- Suppress other Discord API failures.
- Change Discord reply or context hydration behavior.

## Why

Discord returns structured error `10008` when a reaction targets a deleted message. The adapter previously propagated it like a transient failure, so the durable terminal-notification lease expired and retried forever. Classifying that one permanent result inside the Discord adapter keeps provider-specific semantics out of the generic workflow engine without weakening transient recovery.

## Verification

- TDD red: the regression initially failed with `DiscordAPIError[10008]: Unknown Message`.
- `npx vitest run src/triggers/discord/bot.test.ts src/triggers/discord/provider.test.ts src/workflows/engine.test.ts src/workflows/reactions.test.ts` — 81 passed.
- `npm run typecheck` — passed.
- `npm run lint` — passed.
- `npm run format:check` — passed.
- `npm run db:check` — passed.
- `npm run build` — passed.
- Unfiltered `npm test` reached the container-backed PostgreSQL integration suite but could not run it locally because no container runtime is available; CI should exercise that environment.

## Risk surface

The change is limited to Discord reaction creation and cleanup. Only `DiscordAPIError` code `10008` becomes an idempotent success; tests assert that other reaction failures still propagate for retry. There are no schema, configuration, workflow-engine, or public API changes.
