### PR TITLE
fix: 405 for unsupported MCP route methods + survive invalid WebSocket close frames

### DIFF
--- a/src/daemons/registry.test.ts
+++ b/src/daemons/registry.test.ts
@@ -328,4 +328,23 @@ describe("daemon socket generations", () => {
 
     await assert.rejects(pending.promise, /daemon disconnected/u);
   });
+
+  it("survives an invalid WebSocket close code instead of crashing the process", async () => {
+    // Real production crash: a peer sending a close frame with a code the
+    // protocol forbids on the wire (1006 is reserved and must never be
+    // sent) makes `ws`'s Receiver emit `error` on the server socket. With
+    // no `error` listener, Node rethrows it as an uncaught exception and
+    // kills the whole Hub process. If `accept()` regresses, this test
+    // crashes the worker instead of merely failing an assertion.
+    daemon.sendInvalidClose(1006);
+    await daemon.waitUntilCurrentClosed();
+    await new Promise((resolve) => setImmediate(resolve));
+
+    assertOneFailure(stream, {
+      operation: "daemon.socket.error",
+      component: "daemons",
+      failureKind: "network",
+      canary: "invalid-close-code-1006-never-logged",
+    });
+  });
 });

--- a/src/daemons/registry.ts
+++ b/src/daemons/registry.ts
@@ -132,6 +132,15 @@ export class ActiveDaemonRegistry {
     previous?.agents.close();
     previous?.socket.close(4001, "replaced");
     socket.on("message", (data) => this.receive(active, readText(data)));
+    socket.on("error", (error) => {
+      // A peer that sends a malformed control frame (e.g. an invalid close
+      // status code) makes the `ws` receiver emit `error` on this socket.
+      // Node's EventEmitter rethrows unlistened `error` events as an
+      // uncaught exception, which without this listener kills the whole
+      // Hub process over one bad daemon connection. Report and let the
+      // subsequent `close` event drive the normal offline-presence cleanup.
+      this.report(error, "daemon.socket.error", daemon.id, "network");
+    });
     socket.on("close", () => {
       active.agents.close();
       if (this.active.get(daemon.id)?.generation === active.generation) {

--- a/src/daemons/test-utils/daemon-registry-harness.ts
+++ b/src/daemons/test-utils/daemon-registry-harness.ts
@@ -29,6 +29,11 @@ interface PendingRequest<T> {
   request: z.infer<typeof SessionRequestSchema>["message"];
 }
 
+/** Shape of the internal fields `ws` leaves untyped but always populates. */
+interface WebSocketInternals {
+  _socket: { write(data: Buffer): void };
+}
+
 export class DaemonRegistryHarness {
   private readonly presence = new DaemonPresence();
   private readonly registry: ActiveDaemonRegistry;
@@ -271,6 +276,10 @@ export class DaemonRegistryHarness {
     this.currentSocket().sendRaw(value);
   }
 
+  sendInvalidClose(code: number): void {
+    this.currentSocket().sendInvalidClose(code);
+  }
+
   waitUntilCurrentClosed(): Promise<void> {
     return this.currentSocket().waitUntilClosed();
   }
@@ -485,6 +494,27 @@ class RegistrySocket {
 
   sendRaw(value: string): void {
     this.socket.send(value);
+  }
+
+  /**
+   * Writes a raw WebSocket close control frame directly onto the
+   * underlying TCP socket, bypassing `ws`'s own `close()` validation so a
+   * status code the protocol forbids on the wire (e.g. 1006, reserved for
+   * abnormal closure and never legally sent) reaches the server's
+   * `Receiver`, reproducing WS_ERR_INVALID_CLOSE_CODE.
+   */
+  sendInvalidClose(code: number): void {
+    // `ws` does not type its internal `_socket`, but every `ws` WebSocket
+    // instance exposes the underlying net.Socket at runtime once open.
+    // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- `ws` leaves `_socket` untyped
+    const internals = this.socket as unknown as WebSocketInternals;
+    const tcpSocket = internals._socket;
+    const mask = Buffer.alloc(4);
+    const payload = Buffer.alloc(2);
+    payload.writeUInt16BE(code, 0);
+    const maskedPayload = Buffer.alloc(2);
+    for (let i = 0; i < 2; i += 1) maskedPayload[i] = payload[i]! ^ mask[i]!;
+    tcpSocket.write(Buffer.concat([Buffer.from([0x88, 0x82]), mask, maskedPayload]));
   }
 
   close(): void {

--- a/src/mcp-route-method-guard.test.ts
+++ b/src/mcp-route-method-guard.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { it } from "vitest";
+import { Route } from "./routes/agent-executions/$executionId/mcp.js";
+
+/**
+ * TanStack's `Constrain<ObjectLiteral, Fn>` handlers type resolves member
+ * access against the function-form branch of the union even though this
+ * route declares the plain object-literal form, so the generated route
+ * type cannot express calling an individual method handler directly.
+ */
+interface McpRouteMethodHandlers {
+  GET(): Response | Promise<Response>;
+  DELETE(): Response | Promise<Response>;
+}
+
+// The execution capability MCP server is stateless and POST-only. Before this
+// guard, an unhandled GET (SSE stream open) or DELETE (session terminate)
+// fell through to the SPA route render: 200 HTML for an unknown execution id,
+// or a 500 for a real one once it hit `handleExecutionCapabilities`. A 500
+// makes MCP Streamable HTTP clients treat the server as dead instead of
+// retrying with the one method it actually supports.
+it("rejects GET on the MCP route with 405 and an Allow: POST header", async () => {
+  // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- the generated route type cannot express calling one handler directly
+  const handlers = Route.options.server?.handlers as unknown as McpRouteMethodHandlers;
+  const response = await handlers.GET();
+
+  assert.equal(response.status, 405);
+  assert.equal(response.headers.get("allow"), "POST");
+});
+
+it("rejects DELETE on the MCP route with 405 and an Allow: POST header", async () => {
+  // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- the generated route type cannot express calling one handler directly
+  const handlers = Route.options.server?.handlers as unknown as McpRouteMethodHandlers;
+  const response = await handlers.DELETE();
+
+  assert.equal(response.status, 405);
+  assert.equal(response.headers.get("allow"), "POST");
+});

--- a/src/routes/agent-executions/$executionId/mcp.ts
+++ b/src/routes/agent-executions/$executionId/mcp.ts
@@ -9,6 +9,23 @@ export const Route = createFileRoute("/agent-executions/$executionId/mcp")({
           request,
           new URL(request.url).pathname.split("/")[2] ?? "",
         ),
+      // This MCP server is stateless and POST-only: every call opens a
+      // fresh transport and closes it once the response finishes, so there
+      // is no SSE stream to resume (GET) or session to terminate (DELETE).
+      // Without an explicit handler these methods fell through to the SPA
+      // route render, which returned a misleading 200 (unknown execution
+      // id) or crashed to 500 (real execution id) instead of the 405 the
+      // MCP Streamable HTTP spec requires for an unsupported method - and a
+      // 500 makes MCP clients mark the server as dead instead of retrying.
+      GET: methodNotAllowed,
+      DELETE: methodNotAllowed,
     },
   },
 });
+
+function methodNotAllowed(): Response {
+  return Response.json(
+    { error: "method_not_allowed" },
+    { status: 405, headers: { Allow: "POST" } },
+  );
+}


### PR DESCRIPTION
## Symptom

Running a self-hosted Hub against real daemon/agent traffic, two failures showed up:

1. `GET /agent-executions/:id/mcp` (and `DELETE`) is not handled by the route, so it falls through to the SPA route render: a 200 with the app-shell HTML for an unknown execution id, or a 500 for a real one. An MCP client that probes the transport with a method other than POST (or a proxy/monitor that does a GET health check) reads the 500 as "server is dead" instead of a clean "method not supported, retry with POST".
2. The Hub process crashed outright with:
   ```
   RangeError [WS_ERR_INVALID_CLOSE_CODE]: invalid status code
       at Receiver.controlMessage (ws/lib/receiver.js)
   ```
   as an unhandled `process.uncaught_exception`, taking down every daemon connection on the instance, not just the one that sent the bad frame.

## Cause

1. `src/routes/agent-executions/$executionId/mcp.ts` only declared a `POST` handler. TanStack Start has no fallback 405 for undeclared methods on a route that also matches page rendering, so GET/DELETE hit the SPA path instead.
2. `ActiveDaemonRegistry.accept()` (`src/daemons/registry.ts`) registers `"message"` and `"close"` listeners on a daemon's WebSocket but never `"error"`. When a peer sends a close control frame carrying a status code the protocol forbids on the wire (`ws`'s `Receiver` rejects reserved codes such as 1004-1006), `ws` emits `error` on that socket. Node's `EventEmitter` rethrows an unlistened `error` event as an uncaught exception, killing the whole process.

## Fix

- Add explicit `GET`/`DELETE` handlers on the MCP route that return `405` with `Allow: POST`, matching the `error` body shape already used by `handleExecutionCapabilities` in the same module.
- Add an `error` listener in `accept()` that reports through the existing `reportFailure`/`report` pipeline. `ws` already closes the connection itself once the error fires, so the existing `close` handler still drives normal offline-presence cleanup — only that one daemon's socket is affected now.

## How to reproduce / verify

- WebSocket crash: `src/daemons/registry.test.ts` — new test writes a raw close frame with status `1006` directly to the underlying TCP socket (bypassing `ws`'s own `close()` validation, which already rejects invalid codes client-side) via a new `DaemonRegistryHarness.sendInvalidClose()` helper. Without the fix this crashes the vitest worker with the exact `WS_ERR_INVALID_CLOSE_CODE` seen in production; with the fix it asserts the failure is reported and the socket still closes cleanly.
- 405 route guard: `src/mcp-route-method-guard.test.ts` — calls the route's `GET`/`DELETE` handlers directly and asserts `405` + `Allow: POST`. Without the fix, `Route.options.server.handlers.GET` doesn't exist and the test throws `handlers.GET is not a function`.
- Manually verified against a built instance of this branch (embedded/pglite database, no `DATABASE_URL`): `curl` against `/agent-executions/does-not-exist/mcp` returns `405` with `Allow: POST` for both `GET` and `DELETE`, and `/health` still returns `200`.

## Not changed

Checked whether `@modelcontextprotocol/sdk` could be bumped to support MCP protocol version `2026-07-28` (seen advertised by an external client). The installed version, `1.30.0`, is also the latest version published to npm, and its `SUPPORTED_PROTOCOL_VERSIONS` tops out at `2025-11-25`. No published SDK version supports `2026-07-28` yet, so there is nothing to bump here — that ceiling is upstream in `@modelcontextprotocol/sdk`.

## Test commands run

```
npm run typecheck:node
npm run typecheck:start
npx oxlint --config oxlint.json --tsconfig tsconfig.json src/daemons/registry.ts src/daemons/test-utils/daemon-registry-harness.ts src/mcp-route-method-guard.test.ts
npx oxlint --config oxlint.json --tsconfig tsconfig.json src/routes/agent-executions/\$executionId/mcp.ts
npx vitest run src/daemons/registry.test.ts src/mcp-route-method-guard.test.ts
npm run build
```

Did not run the full `npm test`/`npm run lint`/`npm run release:check` suite (out of scope for this change; the e2e suite additionally requires Docker/Postgres via testcontainers).
