### PR TITLE
Restore cross-provider workflow capabilities

### DIFF
--- a/src/daemons/daemons.test.ts
+++ b/src/daemons/daemons.test.ts
@@ -493,7 +493,6 @@ describe("daemon enrollment and execution", () => {
     assert.equal(launchEnv["GIT_CONFIG_COUNT"], "5");
     assert.deepEqual(hub.authorityMintInputs(), [
       {
-        executionId: handedOff.execution.id,
         projectId: "00000000-0000-4000-8000-000000000001",
         connectionSlug: "getpaseo-github",
         repositories: ["getpaseo/paseo"],

--- a/src/daemons/daemons.test.ts
+++ b/src/daemons/daemons.test.ts
@@ -1254,8 +1254,7 @@ describe("daemon enrollment and execution", () => {
 
     await assert.rejects(
       hub.dispatch(),
-      (error: unknown) =>
-        error instanceof DaemonDispatchFailure && error.reason === "daemon_unreachable",
+      (error: unknown) => error instanceof DaemonDispatchFailure && error.reason === "internal",
     );
 
     const execution = await hub.acceptanceExecution();
@@ -1263,7 +1262,7 @@ describe("daemon enrollment and execution", () => {
       { status: execution.status, result: execution.result },
       {
         status: "failed",
-        result: { status: "failed", reason: "daemon_unreachable" },
+        result: { status: "failed", reason: "internal" },
       },
     );
     await hub.drainWorkflowOutbox();

--- a/src/daemons/lifecycle.test.ts
+++ b/src/daemons/lifecycle.test.ts
@@ -7,12 +7,16 @@ import type {
   DaemonEvent,
   DaemonConnection,
 } from "./protocol.js";
-import { createDaemonDispatchLifecycle, type DaemonDispatchLifecycle } from "./lifecycle.js";
+import {
+  createDaemonDispatchLifecycle,
+  DaemonDispatchFailure,
+  type DaemonDispatchLifecycle,
+} from "./lifecycle.js";
 import { createDurableWorkflowHandler } from "../workflows/engine.js";
 import type { TriggerProvider } from "../triggers/index.js";
 import { createUnlimitedEntitlementsService } from "../entitlements/test-utils.js";
 import type { DaemonRecord } from "../db/types.js";
-import { createLogger } from "../logger.js";
+import { createLogger, serializeError } from "../logger.js";
 import { assertOneFailure, FailureLogStream } from "../test-utils/failure-logs.js";
 
 const DAEMON_ID = "daemon-ack-test";
@@ -21,6 +25,22 @@ const EXECUTION_ID = "00000000-0000-4000-8000-000000000001";
 const ACKNOWLEDGED_AT = new Date("2026-01-01T00:00:01.000Z");
 
 describe("durable Hub action acknowledgement state", () => {
+  it("keeps the classified dispatch code in redacted error logs", () => {
+    const diagnostic = serializeError(
+      new DaemonDispatchFailure("github_authority_unavailable", {
+        cause: Object.assign(new Error("credential detail must not be logged"), {
+          code: "github_authority_unavailable",
+        }),
+      }),
+    );
+
+    assert.equal(diagnostic["code"], "github_authority_unavailable");
+    const cause = diagnostic["cause"];
+    assert.ok(typeof cause === "object" && cause !== null);
+    assert.equal(Reflect.get(cause, "code"), "github_authority_unavailable");
+    assert.equal(JSON.stringify(diagnostic).includes("credential detail"), false);
+  });
+
   it("logs a daemon execution recovery failure exactly once", async () => {
     const canary = "daemon-lifecycle-secret-4c09";
     const database = createMemoryDatabase();

--- a/src/daemons/lifecycle.ts
+++ b/src/daemons/lifecycle.ts
@@ -110,12 +110,15 @@ export interface DaemonDispatchLifecycleOptions {
 }
 
 export class DaemonDispatchFailure extends Error {
+  readonly code: string;
+
   constructor(
     readonly reason: string,
     options?: { cause?: unknown },
   ) {
     super(`daemon dispatch failed: ${reason}`);
     this.name = "DaemonDispatchFailure";
+    this.code = reason;
     this.cause = options?.cause;
   }
 }
@@ -603,14 +606,6 @@ export class DaemonDispatchLifecycle {
     );
   }
 
-  private async createAgent(
-    connection: DaemonConnection,
-    intent: LaunchMachineIntent,
-    hubExecutionEnv: HubExecutionEnv,
-  ): Promise<Awaited<ReturnType<DaemonConnection["createAgent"]>>> {
-    return connection.createAgent(await this.buildCreateAgentOptions(intent, hubExecutionEnv));
-  }
-
   async handleAgentStreamEvent(
     executionId: string,
     event: DaemonAgentStreamEvent,
@@ -1018,12 +1013,17 @@ export class DaemonDispatchLifecycle {
     const intent = current.launchIntent;
     if (intent === null || this.options.publicBaseUrl === undefined)
       throw new Error("execution launch intent cannot be recovered");
-    this.subscribeRecoveredExecution(current.id, daemon.id, connection);
-    this.armExecutionDeadline(current);
-    const agent = await this.createAgent(connection, intent, {
+    const createOptions = await this.buildCreateAgentOptions(intent, {
       executionId: current.id,
       completionToken: this.completionToken(current.id),
       publicBaseUrl: this.options.publicBaseUrl,
+    }).catch((error: unknown) => {
+      throw toDispatchPreparationFailure(error);
+    });
+    this.subscribeRecoveredExecution(current.id, daemon.id, connection);
+    this.armExecutionDeadline(current);
+    const agent = await connection.createAgent(createOptions).catch((error: unknown) => {
+      throw toDaemonTransportFailure(error);
     });
     if (isInterruptedAgentState(agent.state)) {
       await this.failAgentExecution(current.id, "agent_interrupted");
@@ -1533,6 +1533,15 @@ export class DaemonDispatchLifecycle {
     if (connection === undefined) {
       throw new DaemonDispatchFailure("daemon_unreachable");
     }
+    const createOptions = await this.buildCreateAgentOptions(
+      input.intent,
+      input.hubExecutionEnv,
+    ).catch((error: unknown) => {
+      throw toDispatchPreparationFailure(error);
+    });
+    if (isCanceled()) {
+      throw new DaemonSpawnAckTimeoutError(this.dispatchTimeoutMs);
+    }
     const pendingHandlers = new Set<Promise<void>>();
     let disposed = false;
     let settleTerminal: ((failure?: DaemonDispatchFailure) => void) | undefined;
@@ -1589,7 +1598,9 @@ export class DaemonDispatchLifecycle {
         throw new DaemonSpawnAckTimeoutError(this.dispatchTimeoutMs);
       }
       const agent = await Promise.race([
-        this.createAgent(connection, input.intent, input.hubExecutionEnv),
+        connection
+          .createAgent(createOptions)
+          .catch((error: unknown) => Promise.reject(toDaemonTransportFailure(error))),
         terminal.then<never>(() => new Promise<never>(() => undefined)),
       ]);
       if (isCanceled()) {
@@ -1935,8 +1946,36 @@ function toDaemonDispatchFailure(error: unknown): DaemonDispatchFailure {
     return new DaemonDispatchFailure(daemonCreateFailureReason(error), { cause: error });
   }
 
-  return new DaemonDispatchFailure("daemon_unreachable", { cause: error });
+  return new DaemonDispatchFailure("internal", { cause: error });
 }
+
+function toDispatchPreparationFailure(error: unknown): DaemonDispatchFailure {
+  const candidate =
+    typeof error === "object" && error !== null && "code" in error && typeof error.code === "string"
+      ? error.code
+      : "internal";
+  const code = DISPATCH_PREPARATION_FAILURE_CODES.has(candidate) ? candidate : "internal";
+  return new DaemonDispatchFailure(code, { cause: error });
+}
+
+function toDaemonTransportFailure(error: unknown): Error {
+  if (error instanceof DaemonCreateResponseLostError) return error;
+  const classified = toDaemonDispatchFailure(error);
+  return classified.reason === "internal"
+    ? new DaemonDispatchFailure("daemon_unreachable", { cause: error })
+    : classified;
+}
+
+const DISPATCH_PREPARATION_FAILURE_CODES = new Set([
+  "discord_trigger_unavailable",
+  "execution_authority_stopped",
+  "execution_terminal",
+  "github_authority_scope_invalid",
+  "github_authority_unavailable",
+  "github_integration_unavailable",
+  "github_trigger_unavailable",
+  "slack_trigger_unavailable",
+]);
 
 function isDurablePrelaunchFailure(error: unknown): error is DaemonDispatchFailure {
   return error instanceof DaemonDispatchFailure && error.reason === "daemon_not_registered";

--- a/src/execution-authority/index.test.ts
+++ b/src/execution-authority/index.test.ts
@@ -80,7 +80,6 @@ describe("Hub execution authority", () => {
 
     assert.deepEqual(mint.inputs, [
       {
-        executionId: "execution-manual",
         projectId: "project-1",
         connectionSlug: "getpaseo-github",
         repositories: ["getpaseo/paseo", "getpaseo/hub"],
@@ -148,7 +147,10 @@ describe("Hub execution authority", () => {
           durationMs: 60 * 60 * 1000,
         },
       }),
-      /github\.repositories is required.*cannot safely expand/iu,
+      (error: unknown) =>
+        error instanceof Error &&
+        "code" in error &&
+        error.code === "github_authority_scope_invalid",
     );
     assert.deepEqual(mint.inputs, []);
   });
@@ -255,7 +257,8 @@ describe("Hub execution authority", () => {
           durationMs: 60 * 60 * 1000,
         },
       }),
-      /terminal execution/iu,
+      (error: unknown) =>
+        error instanceof Error && "code" in error && error.code === "execution_terminal",
     );
     assert.equal(mints, 0);
   });

--- a/src/execution-authority/index.ts
+++ b/src/execution-authority/index.ts
@@ -134,11 +134,13 @@ export function createExecutionAuthority(
       const env = await materializeEnvironment(input, context, tokenRevocations);
       if (input.github !== undefined) {
         if (options.githubAuthority === undefined) {
-          throw new Error("GitHub step authority is unavailable");
+          throw authorityError(
+            "github_authority_unavailable",
+            "GitHub step authority is unavailable",
+          );
         }
         const repositories = repositoriesForAuthority(input.github, input.triggerContext);
         const authority = await options.githubAuthority.mint({
-          executionId: input.executionId,
           projectId: input.projectId,
           connectionSlug: input.github.connection,
           repositories,
@@ -583,7 +585,8 @@ function repositoriesForAuthority(
   ) {
     return [triggerContext.target.repository];
   }
-  throw new Error(
+  throw authorityError(
+    "github_authority_scope_invalid",
     "github.repositories is required for this trigger source; Hub cannot safely expand authority to all installation repositories",
   );
 }
@@ -613,11 +616,18 @@ function githubEnvironment(
 }
 
 function terminalExecutionError(executionId: string): Error {
-  return new Error(`cannot materialize terminal execution ${executionId}`);
+  return authorityError(
+    "execution_terminal",
+    `cannot materialize terminal execution ${executionId}`,
+  );
 }
 
 function authorityStoppedError(): Error {
-  return new Error("execution authority is stopped");
+  return authorityError("execution_authority_stopped", "execution authority is stopped");
+}
+
+function authorityError(code: string, message: string): Error & { code: string } {
+  return Object.assign(new Error(message), { code });
 }
 
 function removeLease(

--- a/src/provider-applications/internal/runtime-owner.test.ts
+++ b/src/provider-applications/internal/runtime-owner.test.ts
@@ -60,7 +60,7 @@ describe("dynamic provider runtime", () => {
     assert.ok(trigger.eventNames.includes(eventName));
   });
 
-  it("publishes a started replacement, retires old resources, and retains in-flight snapshots", async () => {
+  it("publishes a started replacement and routes later callbacks through it", async () => {
     const started: string[] = [];
     const stopped: string[] = [];
     const completed: string[] = [];
@@ -108,7 +108,7 @@ describe("dynamic provider runtime", () => {
     second.publish();
     await new Promise((resolve) => setImmediate(resolve));
 
-    // Inbound delivery retires immediately; the old execution keeps its leased trigger/output.
+    // The replaced source retires immediately; later callbacks use the active registration.
     assert.deepEqual(stopped, ["A1"]);
 
     await trigger.onAgentExecutionCompleted?.(oldMatch!.triggerContext, oldMatch!.outputContext, {
@@ -121,11 +121,11 @@ describe("dynamic provider runtime", () => {
     );
     assert.deepEqual(started, ["A1", "A2"]);
     assert.deepEqual(stopped, ["A1"]);
-    assert.deepEqual(completed, ["A1"]);
+    assert.deepEqual(completed, ["A2"]);
     assert.deepEqual(await response.json(), { url: "https://provider.test/A2" });
   });
 
-  it("keeps replies and attachments on the registration that matched the trigger", async () => {
+  it("routes replies and attachments through the active registration", async () => {
     const used: string[] = [];
     const stopped: string[] = [];
     const database = createMemoryDatabase();
@@ -190,14 +190,106 @@ describe("dynamic provider runtime", () => {
       executionId: "execution-1",
     });
 
-    assert.deepEqual(used, ["launch:A1", "reply:A1", "attachment:A1"]);
+    assert.deepEqual(used, ["launch:A1", "reply:A2", "attachment:A2"]);
     assert.deepEqual(stopped, ["A1"]);
     await trigger.onAgentExecutionTerminal?.("execution-1", match.triggerContext);
     await new Promise((resolve) => setImmediate(resolve));
     assert.deepEqual(stopped, ["A1"]);
   });
 
-  it("leases integrations, GitHub authority, and configuration calls across rotation", async () => {
+  it("lets a Discord-triggered execution use the active GitHub integration and authority", async () => {
+    const used: string[] = [];
+    const runtime = new DynamicProviderRuntime({
+      database: createMemoryDatabase(),
+      auth: testAuth(),
+      applicationBaseUrl: "https://hub.test",
+      registrationFactory: ({ configuration }) =>
+        downstreamRegistration(providerConfigurationId(configuration), used, []),
+    });
+    const github = runtime
+      .registrations()
+      .find((registration) => registration.connection.name === "github")!;
+    const discord = runtime
+      .registrations()
+      .find((registration) => registration.connection.name === "discord")!;
+    const discordTrigger = discord.triggerProviders[0]!({
+      configurationStoreForProject: () => {
+        throw new Error("unused");
+      },
+      connectionsForProject: () => {
+        throw new Error("unused");
+      },
+    })!;
+    const githubCandidate = await runtime.prepare(
+      "github",
+      providerConfiguration("github", "A1"),
+      "https://hub.test",
+      providerIdentity("github", "A1"),
+      1,
+    );
+    await githubCandidate.start();
+    githubCandidate.publish();
+    const discordCandidate = await runtime.prepare(
+      "discord",
+      providerConfiguration("discord", "D1"),
+      "https://hub.test",
+      providerIdentity("discord", "D1"),
+      1,
+    );
+    await discordCandidate.start();
+    discordCandidate.publish();
+
+    const matches = await discordTrigger.match({
+      ...externalTrigger(),
+      source: "discord.mention",
+    });
+    if (typeof matches === "string") throw new Error("expected a match");
+    const match = matches[0]!;
+    await discordTrigger.materializeLaunch?.({
+      executionId: "execution-1",
+      organizationId: "org",
+      projectId: "project",
+      triggerContext: match.triggerContext,
+    });
+
+    await github.integration!.resolve("project", "github", "token", {
+      executionId: "execution-1",
+    });
+    const authority = await github.integration!.githubAuthority!.mint({
+      projectId: "project",
+      connectionSlug: "github",
+      repositories: ["acme/repository"],
+      permissions: { contents: "write" },
+    });
+
+    assert.deepEqual(used, ["launch:D1", "integration:A1", "authority-mint:A1"]);
+    await github.integration!.githubAuthority!.revoke(authority.token);
+  });
+
+  it("reports an unavailable capability with a stable diagnostic code", async () => {
+    const runtime = new DynamicProviderRuntime({
+      database: createMemoryDatabase(),
+      auth: testAuth(),
+      applicationBaseUrl: "https://hub.test",
+    });
+    const github = runtime
+      .registrations()
+      .find((registration) => registration.connection.name === "github")!;
+
+    await assert.rejects(
+      async () =>
+        github.integration!.githubAuthority!.mint({
+          projectId: "project",
+          connectionSlug: "github",
+          repositories: ["acme/repository"],
+          permissions: { contents: "read" },
+        }),
+      (error: unknown) =>
+        error instanceof Error && "code" in error && error.code === "github_authority_unavailable",
+    );
+  });
+
+  it("drains in-flight configuration calls while later GitHub capabilities use the replacement", async () => {
     const used: string[] = [];
     const stopped: string[] = [];
     let releaseConfiguration: (() => void) | undefined;
@@ -271,7 +363,6 @@ describe("dynamic provider runtime", () => {
       executionId: "execution-1",
     });
     const authority = await stable.integration!.githubAuthority!.mint({
-      executionId: "execution-1",
       projectId: "project",
       connectionSlug: "github",
       repositories: ["acme/repository"],
@@ -282,8 +373,8 @@ describe("dynamic provider runtime", () => {
     assert.deepEqual(used, [
       "launch:A1",
       "configuration:A1",
-      "integration:A1",
-      "authority-mint:A1",
+      "integration:A2",
+      "authority-mint:A2",
     ]);
     assert.deepEqual(stopped, ["A1"]);
     await trigger.onAgentExecutionTerminal?.("execution-1", match.triggerContext);
@@ -291,7 +382,7 @@ describe("dynamic provider runtime", () => {
     assert.deepEqual(stopped, ["A1"]);
     await stable.integration!.githubAuthority!.revoke(authority.token);
     await new Promise((resolve) => setImmediate(resolve));
-    assert.equal(used.at(-1), "authority-revoke:A1");
+    assert.equal(used.at(-1), "authority-revoke:A2");
     assert.deepEqual(stopped, ["A1"]);
   });
 

--- a/src/provider-applications/internal/runtime-owner.ts
+++ b/src/provider-applications/internal/runtime-owner.ts
@@ -26,7 +26,6 @@ import { GITHUB_TRIGGER_EVENT_NAMES } from "../../triggers/github/classification
 
 interface Slot {
   active: ActiveRegistration | undefined;
-  retained: Map<string, ActiveRegistration>;
   identity: ProviderApplicationIdentity | undefined;
   triggerResources: TriggerProviderResources | undefined;
   handler: TriggerHandler | undefined;
@@ -34,23 +33,25 @@ interface Slot {
 
 interface ActiveRegistration {
   provider: Provider;
-  snapshotId: string;
   registration: ProviderRegistration;
   triggers: readonly TriggerProvider[];
   sourcesStarted: boolean;
   acceptingEvents: boolean;
   leases: number;
-  longLeases: Set<string>;
   retiring: boolean;
   retirement: Promise<void> | undefined;
 }
 
-interface RuntimeSnapshotMarker {
-  snapshotId: string;
-  leaseId: string;
+class ProviderRuntimeUnavailableError extends Error {
+  constructor(readonly code: string) {
+    super(code.replaceAll("_", " "));
+    this.name = "ProviderRuntimeUnavailableError";
+  }
 }
 
-const RUNTIME_SNAPSHOT_KEY = "__paseoProviderRuntimeSnapshot";
+function unavailable(code: string): ProviderRuntimeUnavailableError {
+  return new ProviderRuntimeUnavailableError(code);
+}
 
 type SlackInstallationHandler = Parameters<
   NonNullable<ProviderRuntimeOwner["onSlackInstallation"]>
@@ -81,10 +82,6 @@ export class DynamicProviderRuntime implements ProviderRuntimeOwner {
   ]);
   private readonly stable = new Map<Provider, ProviderRegistration>();
   private slackInstallationHandler: SlackInstallationHandler | undefined;
-  private nextSnapshot = 0;
-  private nextLease = 0;
-  private readonly executionSnapshots = new Map<string, RuntimeSnapshotMarker>();
-  private readonly githubAuthoritySnapshots = new Map<string, RuntimeSnapshotMarker>();
 
   constructor(private readonly options: DynamicProviderRuntimeOptions) {
     for (const provider of ["github", "slack", "discord"] as const) {
@@ -132,7 +129,6 @@ export class DynamicProviderRuntime implements ProviderRuntimeOwner {
     const triggerResources = slot.triggerResources;
     const active: ActiveRegistration = {
       provider,
-      snapshotId: `${provider}:${configurationVersion}:${++this.nextSnapshot}`,
       registration,
       triggers:
         triggerResources === undefined
@@ -143,7 +139,6 @@ export class DynamicProviderRuntime implements ProviderRuntimeOwner {
       sourcesStarted: false,
       acceptingEvents: false,
       leases: 0,
-      longLeases: new Set(),
       retiring: false,
       retirement: undefined,
     };
@@ -155,20 +150,20 @@ export class DynamicProviderRuntime implements ProviderRuntimeOwner {
       },
       beginConnection: async (request) => {
         const response = await registration.connection.actions["start"]?.(request);
-        if (response === undefined || !response.ok) throw new Error("provider unavailable");
+        if (response === undefined || !response.ok)
+          throw unavailable("provider_application_unavailable");
         const body: unknown = await response.json();
         const url =
           body !== null && typeof body === "object" && "url" in body
             ? Reflect.get(body, "url")
             : undefined;
-        if (typeof url !== "string") throw new Error("provider unavailable");
+        if (typeof url !== "string") throw unavailable("provider_application_unavailable");
         return { url };
       },
       publish: () => {
         const previous = slot.active;
         if (previous !== undefined) previous.acceptingEvents = false;
         slot.active = active;
-        slot.retained.set(active.snapshotId, active);
         slot.identity = identity;
         active.acceptingEvents = true;
         published = true;
@@ -181,7 +176,7 @@ export class DynamicProviderRuntime implements ProviderRuntimeOwner {
               provider,
             });
           });
-          void this.retireWhenDrained(provider, slot, previous);
+          void this.retireWhenDrained(provider, previous);
         }
       },
       close: () => (published ? Promise.resolve() : stopSources(active)),
@@ -208,7 +203,7 @@ export class DynamicProviderRuntime implements ProviderRuntimeOwner {
         activateConfiguration: activation?.activateConfiguration ?? false,
         onVerifiedSlackInstallation: (input) => {
           if (this.slackInstallationHandler === undefined) {
-            throw new Error("Slack installation handler unavailable");
+            throw unavailable("slack_installation_handler_unavailable");
           }
           return this.slackInstallationHandler(input);
         },
@@ -235,7 +230,7 @@ export class DynamicProviderRuntime implements ProviderRuntimeOwner {
         activateConfiguration: activation?.activateConfiguration ?? false,
         onVerifiedInstallation: (input) => {
           if (this.slackInstallationHandler === undefined) {
-            throw new Error("Slack installation handler unavailable");
+            throw unavailable("slack_installation_handler_unavailable");
           }
           return this.slackInstallationHandler(input);
         },
@@ -301,16 +296,12 @@ export class DynamicProviderRuntime implements ProviderRuntimeOwner {
               resolve: (
                 ...args: Parameters<NonNullable<ProviderRegistration["integration"]>["resolve"]>
               ) => {
-                const context = args[3];
-                return this.registrationForExecution(provider, slot, context?.executionId).then(
-                  (active) => {
-                    const integration = active?.registration.integration;
-                    if (active === undefined || integration === undefined) {
-                      throw new Error("github integration unavailable");
-                    }
-                    return this.withLease(active, () => integration.resolve(...args));
-                  },
-                );
+                const active = slot.active;
+                const integration = active?.registration.integration;
+                if (active === undefined || integration === undefined) {
+                  throw unavailable("github_integration_unavailable");
+                }
+                return this.withLease(active, () => integration.resolve(...args));
               },
               githubAuthority: {
                 mint: (
@@ -320,34 +311,20 @@ export class DynamicProviderRuntime implements ProviderRuntimeOwner {
                     >["mint"]
                   >[0],
                 ) => {
-                  return this.registrationForExecution(provider, slot, input.executionId).then(
-                    async (active) => {
-                      const authority = active?.registration.integration?.githubAuthority;
-                      if (active === undefined || authority === undefined) {
-                        throw new Error("github authority unavailable");
-                      }
-                      const minted = await this.withLease(active, () => authority.mint(input));
-                      this.githubAuthoritySnapshots.set(
-                        minted.token,
-                        this.acquireLongLease(active),
-                      );
-                      return minted;
-                    },
-                  );
-                },
-                revoke: (token: string) => {
-                  const marker = this.githubAuthoritySnapshots.get(token);
-                  const active =
-                    marker === undefined ? slot.active : slot.retained.get(marker.snapshotId);
+                  const active = slot.active;
                   const authority = active?.registration.integration?.githubAuthority;
                   if (active === undefined || authority === undefined) {
-                    throw new Error("github authority unavailable");
+                    throw unavailable("github_authority_unavailable");
                   }
-                  return this.withLease(active, () => authority.revoke(token)).then(() => {
-                    this.githubAuthoritySnapshots.delete(token);
-                    if (marker !== undefined) this.releaseLongLease(provider, slot, marker);
-                    return undefined;
-                  });
+                  return this.withLease(active, () => authority.mint(input));
+                },
+                revoke: (token: string) => {
+                  const active = slot.active;
+                  const authority = active?.registration.integration?.githubAuthority;
+                  if (active === undefined || authority === undefined) {
+                    throw unavailable("github_authority_unavailable");
+                  }
+                  return this.withLease(active, () => authority.revoke(token));
                 },
               },
             },
@@ -374,16 +351,14 @@ export class DynamicProviderRuntime implements ProviderRuntimeOwner {
                 tool: replyOutputTool,
                 available: outputContextProvider(provider),
                 execute: (input) => {
-                  const active = this.registrationForContext(slot, input.outputContext);
+                  const active = slot.active;
                   const output = active?.registration.outputs.find(
                     (candidate) => candidate.type === `${provider}.reply`,
                   );
                   if (active === undefined || output === undefined) {
-                    throw new Error(`${provider} output unavailable`);
+                    throw unavailable(`${provider}_output_unavailable`);
                   }
-                  return this.withLease(active, () =>
-                    output.execute({ ...input, outputContext: unmarkContext(input.outputContext) }),
-                  );
+                  return this.withLease(active, () => output.execute(input));
                 },
               },
             ],
@@ -410,15 +385,12 @@ export class DynamicProviderRuntime implements ProviderRuntimeOwner {
             attachment: {
               provider,
               resolve: (input) => {
-                return this.registrationForExecution(provider, slot, input.executionId).then(
-                  (active) => {
-                    const attachment = active?.registration.attachment;
-                    if (active === undefined || attachment === undefined) {
-                      throw new Error(`${provider} attachment unavailable`);
-                    }
-                    return this.withLease(active, () => attachment.resolve(input));
-                  },
-                );
+                const active = slot.active;
+                const attachment = active?.registration.attachment;
+                if (active === undefined || attachment === undefined) {
+                  throw unavailable(`${provider}_attachment_unavailable`);
+                }
+                return this.withLease(active, () => attachment.resolve(input));
               },
             },
           }
@@ -437,18 +409,12 @@ export class DynamicProviderRuntime implements ProviderRuntimeOwner {
       const active = slot.active;
       const trigger = active?.triggers[0];
       if (active === undefined || trigger === undefined) {
-        throw new Error(`${provider} trigger provider unavailable`);
+        throw unavailable(`${provider}_trigger_unavailable`);
       }
       return { active, trigger };
     };
-    const select = (value: unknown) => {
-      const active = this.registrationForContext(slot, value);
-      const trigger = active?.triggers[0];
-      if (active === undefined || trigger === undefined) return current();
-      return { active, trigger };
-    };
-    const invoke = <T>(value: unknown, operation: (trigger: TriggerProvider) => Promise<T>) => {
-      const selected = select(value);
+    const invoke = <T>(operation: (trigger: TriggerProvider) => Promise<T>) => {
+      const selected = current();
       return this.withLease(selected.active, () => operation(selected.trigger));
     };
     return {
@@ -456,100 +422,53 @@ export class DynamicProviderRuntime implements ProviderRuntimeOwner {
       eventNames: eventNames(provider),
       match: async (external) => {
         const selected = current();
-        return this.withLease(selected.active, async () => {
-          const result = await selected.trigger.match(external);
-          if (typeof result === "string") return result;
-          for (const match of result) {
-            if (match.invocation.status === "rejected") continue;
-            const marker = this.acquireLongLease(selected.active);
-            match.triggerContext = markContext(match.triggerContext, marker);
-            match.outputContext = markContext(match.outputContext, marker);
-          }
-          return result;
-        });
+        return this.withLease(selected.active, () => selected.trigger.match(external));
       },
-      materializeLaunch: (input) => {
-        const marker = snapshotMarker(input.triggerContext);
-        if (marker !== undefined) this.executionSnapshots.set(input.executionId, marker);
-        return invoke(
-          input.triggerContext,
-          (trigger) =>
-            trigger.materializeLaunch?.({
-              ...input,
-              triggerContext: unmarkContext(input.triggerContext),
-            }) ?? Promise.resolve({}),
-        );
-      },
+      materializeLaunch: (input) =>
+        invoke((trigger) => trigger.materializeLaunch?.(input) ?? Promise.resolve({})),
       materializeContext: (input) =>
-        invoke(
-          input.triggerContext,
-          (trigger) =>
-            trigger.materializeContext?.({
-              ...input,
-              triggerContext: unmarkContext(input.triggerContext),
-            }) ?? Promise.resolve(undefined),
-        ),
+        invoke((trigger) => trigger.materializeContext?.(input) ?? Promise.resolve(undefined)),
       onDispatchAccepted: (triggerContext, outputContext, reactionState) =>
         invoke(
-          triggerContext,
           (trigger) =>
-            trigger.onDispatchAccepted?.(
-              unmarkContext(triggerContext),
-              unmarkContext(outputContext),
-              reactionState,
-            ) ?? Promise.resolve(),
+            trigger.onDispatchAccepted?.(triggerContext, outputContext, reactionState) ??
+            Promise.resolve(),
         ),
       onAgentExecutionStarted: (triggerContext, outputContext, reactionState) =>
         invoke(
-          triggerContext,
           (trigger) =>
-            trigger.onAgentExecutionStarted?.(
-              unmarkContext(triggerContext),
-              unmarkContext(outputContext),
-              reactionState,
-            ) ?? Promise.resolve(),
+            trigger.onAgentExecutionStarted?.(triggerContext, outputContext, reactionState) ??
+            Promise.resolve(),
         ),
       onAgentExecutionCompleted: (triggerContext, outputContext, result, reactionState) =>
         invoke(
-          triggerContext,
           (trigger) =>
             trigger.onAgentExecutionCompleted?.(
-              unmarkContext(triggerContext),
-              unmarkContext(outputContext),
+              triggerContext,
+              outputContext,
               result,
               reactionState,
             ) ?? Promise.resolve(),
         ),
       onAgentExecutionFailed: (triggerContext, outputContext, reason, reactionState) =>
         invoke(
-          triggerContext,
           (trigger) =>
             trigger.onAgentExecutionFailed?.(
-              unmarkContext(triggerContext),
-              unmarkContext(outputContext),
+              triggerContext,
+              outputContext,
               reason,
               reactionState,
             ) ?? Promise.resolve(),
         ),
-      onAgentExecutionTerminal: async (executionId, triggerContext) => {
-        const marker = snapshotMarker(triggerContext) ?? this.executionSnapshots.get(executionId);
-        try {
-          await invoke(
-            triggerContext,
-            (trigger) =>
-              trigger.onAgentExecutionTerminal?.(executionId, unmarkContext(triggerContext)) ??
-              Promise.resolve(),
-          );
-        } finally {
-          this.executionSnapshots.delete(executionId);
-          if (marker !== undefined) this.releaseLongLease(provider, slot, marker);
-        }
-      },
+      onAgentExecutionTerminal: (executionId, triggerContext) =>
+        invoke(
+          (trigger) =>
+            trigger.onAgentExecutionTerminal?.(executionId, triggerContext) ?? Promise.resolve(),
+        ),
       onMachineTerminated: (triggerContext, reason, reactionState) =>
         invoke(
-          triggerContext,
           (trigger) =>
-            trigger.onMachineTerminated?.(unmarkContext(triggerContext), reason, reactionState) ??
+            trigger.onMachineTerminated?.(triggerContext, reason, reactionState) ??
             Promise.resolve(),
         ),
     };
@@ -560,7 +479,7 @@ export class DynamicProviderRuntime implements ProviderRuntimeOwner {
       const active = slot.active;
       const configuration = active?.registration.githubConfiguration;
       if (active === undefined || configuration === undefined) {
-        throw new Error("github configuration unavailable");
+        throw unavailable("github_configuration_unavailable");
       }
       return this.withLease(active, () => operation(configuration));
     };
@@ -575,26 +494,6 @@ export class DynamicProviderRuntime implements ProviderRuntimeOwner {
     };
   }
 
-  private registrationForContext(slot: Slot, value: unknown): ActiveRegistration | undefined {
-    const marker = snapshotMarker(value);
-    return marker === undefined ? slot.active : slot.retained.get(marker.snapshotId);
-  }
-
-  private async registrationForExecution(
-    _provider: Provider,
-    slot: Slot,
-    executionId: string | undefined,
-  ): Promise<ActiveRegistration | undefined> {
-    if (executionId === undefined) return slot.active;
-    let marker = this.executionSnapshots.get(executionId);
-    if (marker === undefined) {
-      const execution = await this.options.database.findAgentExecutionById(executionId);
-      marker = snapshotMarker(execution?.triggerContext);
-      if (marker !== undefined) this.executionSnapshots.set(executionId, marker);
-    }
-    return marker === undefined ? slot.active : slot.retained.get(marker.snapshotId);
-  }
-
   private async withLease<T>(active: ActiveRegistration, operation: () => Promise<T>): Promise<T> {
     active.leases += 1;
     try {
@@ -602,35 +501,14 @@ export class DynamicProviderRuntime implements ProviderRuntimeOwner {
     } finally {
       active.leases -= 1;
       if (active.retiring) {
-        const slot = this.slots.get(active.provider);
-        if (slot !== undefined) void this.retireWhenDrained(active.provider, slot, active);
+        void this.retireWhenDrained(active.provider, active);
       }
     }
   }
 
-  private acquireLongLease(active: ActiveRegistration): RuntimeSnapshotMarker {
-    const leaseId = `lease:${++this.nextLease}`;
-    active.longLeases.add(leaseId);
-    active.leases += 1;
-    return { snapshotId: active.snapshotId, leaseId };
-  }
-
-  private releaseLongLease(provider: Provider, slot: Slot, marker: RuntimeSnapshotMarker): void {
-    const active = slot.retained.get(marker.snapshotId);
-    if (active === undefined || !active.longLeases.delete(marker.leaseId)) return;
-    active.leases -= 1;
-    if (active.retiring) void this.retireWhenDrained(provider, slot, active);
-  }
-
-  private retireWhenDrained(
-    provider: Provider,
-    slot: Slot,
-    active: ActiveRegistration,
-  ): Promise<void> {
+  private retireWhenDrained(provider: Provider, active: ActiveRegistration): Promise<void> {
     if (active.leases > 0) return Promise.resolve();
-    active.retirement ??= retire(provider, active).finally(() => {
-      slot.retained.delete(active.snapshotId);
-    });
+    active.retirement ??= retire(provider, active);
     return active.retirement;
   }
 
@@ -668,13 +546,11 @@ export class DynamicProviderRuntime implements ProviderRuntimeOwner {
       );
       const restored: ActiveRegistration = {
         provider,
-        snapshotId: `${provider}:${snapshot.configurationVersion}:callback`,
         registration,
         triggers: [],
         sourcesStarted: false,
         acceptingEvents: false,
         leases: 0,
-        longLeases: new Set(),
         retiring: false,
         retirement: undefined,
       };
@@ -693,7 +569,6 @@ export class DynamicProviderRuntime implements ProviderRuntimeOwner {
 function emptySlot(): Slot {
   return {
     active: undefined,
-    retained: new Map(),
     identity: undefined,
     triggerResources: undefined,
     handler: undefined,
@@ -759,33 +634,4 @@ async function retire(provider: Provider, active: ActiveRegistration): Promise<v
       { logger, kind: "internal" },
     );
   }
-}
-
-function markContext(value: unknown, marker: RuntimeSnapshotMarker): unknown {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) {
-    throw new Error("provider runtime contexts must be objects");
-  }
-  return { ...value, [RUNTIME_SNAPSHOT_KEY]: marker };
-}
-
-function snapshotMarker(value: unknown): RuntimeSnapshotMarker | undefined {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) return undefined;
-  const marker = ownValue(value, RUNTIME_SNAPSHOT_KEY);
-  if (typeof marker !== "object" || marker === null) return undefined;
-  const snapshotId = ownValue(marker, "snapshotId");
-  const leaseId = ownValue(marker, "leaseId");
-  return typeof snapshotId === "string" && typeof leaseId === "string"
-    ? { snapshotId, leaseId }
-    : undefined;
-}
-
-function unmarkContext(value: unknown): unknown {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) return value;
-  const context = { ...value };
-  Reflect.deleteProperty(context, RUNTIME_SNAPSHOT_KEY);
-  return context;
-}
-
-function ownValue(value: object, key: PropertyKey): unknown {
-  return Object.getOwnPropertyDescriptor(value, key)?.value as unknown;
 }

--- a/src/providers/registration.ts
+++ b/src/providers/registration.ts
@@ -33,7 +33,6 @@ export interface ProviderIntegrationRegistration {
 
 export interface GitHubAuthorityRegistration {
   mint(input: {
-    executionId?: string;
     projectId: string;
     connectionSlug: string;
     repositories: readonly string[];


### PR DESCRIPTION
Workflows triggered by one provider can use capabilities owned by another provider again. Preparation failures also retain their actual safe reason instead of appearing as an offline daemon.

## Goals

- Preserve cross-provider workflow composition across Discord, Slack, GitHub, and manual triggers.
- Keep provider-owned trigger and output contexts private and unchanged.
- Resolve outbound capabilities from the active provider registration for each call.
- Reserve `daemon_unreachable` for an absent or failing daemon connection.
- Preserve actionable error codes through redacted production logging.

## Non-goals

- Change workflow configuration syntax or provider setup.
- Change provider identities, token scope, or token lifetime policy.
- Redesign provider reply, reaction, attachment, or configuration-sync behavior.
- Add a new user-facing error presentation layer.

## Why

The provider runtime persisted a private generation marker inside durable trigger and output contexts. Later capability calls interpreted that marker within whichever provider handled the call, coupling otherwise independent providers. A trigger owned by one provider could therefore make valid authority from another provider appear unavailable.

This removes execution-to-generation coordination entirely. Each capability uses the active registration under a short call lease, while execution authority remains the sole owner of scoped-token lifetime and revocation. Dispatch preparation is now classified before daemon transport, so unrelated failures no longer inherit a transport label.

## Verification

- `npx vitest run src/provider-applications/internal/runtime-owner.test.ts src/execution-authority/index.test.ts src/providers/github/registration.test.ts src/daemons/lifecycle.test.ts --bail=1` — 63 passed.
- `npm run typecheck` — passed.
- `npm run lint` — passed.
- `npm run format:check` — passed.
- `git diff --check` — passed.
- The container-backed daemon suite was attempted but could not start locally because this host has no container runtime; CI must exercise its updated behavioral assertion.
- No manual production QA was performed from this branch.

## Risk surface

Provider callbacks, replies, attachments, integrations, authority, and configuration reads now use the active credentials for the same configured provider identity. Calls already in progress remain protected until completion; later calls use the active registration. The largest regression surface is daemon dispatch and recovery classification, including ambiguous create handling and deadlines, which remains covered by the existing integration suite in CI.

No related open issue or superseded PR was found.