### PR TITLE
React to GitHub issue and pull request items

### DIFF
--- a/e2e/app.ts
+++ b/e2e/app.ts
@@ -1,11 +1,11 @@
 import { execFile, spawn, type ChildProcess } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { createServer } from "node:net";
+import { createServer, type Server as NetServer } from "node:net";
 import { request as httpRequest } from "node:http";
 import { createServer as createHttpsServer, get as httpsGet, type Server } from "node:https";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, open, readFile, rm, unlink } from "node:fs/promises";
 import { promisify } from "node:util";
 import { test as base } from "@playwright/test";
 import { PostgreSqlContainer, type StartedPostgreSqlContainer } from "@testcontainers/postgresql";
@@ -101,8 +101,10 @@ class BuiltApplications {
     if (databaseUrl !== undefined) {
       await prepareDatabase(databaseUrl, options.databaseProfile ?? "legacy");
     }
-    const port = await availablePort();
-    const reverseProxyPort = options.reverseProxy === true ? await availablePort() : undefined;
+    const portLease = await reservePort();
+    const reverseProxyPortLease = options.reverseProxy === true ? await reservePort() : undefined;
+    const port = portLease.port;
+    const reverseProxyPort = reverseProxyPortLease?.port;
     const tls =
       options.https === true || options.reverseProxy === true ? await createTestTls() : undefined;
     const publicPort = reverseProxyPort ?? port;
@@ -136,6 +138,10 @@ class BuiltApplications {
       machineKey: "",
       ...(postgres === undefined ? {} : { postgres }),
       ...(dataDirectory === undefined ? {} : { dataDirectory }),
+      portLeases: [
+        portLease,
+        ...(reverseProxyPortLease === undefined ? [] : [reverseProxyPortLease]),
+      ],
       server,
       ...(proxy === undefined ? {} : { proxy }),
       ...(tls === undefined ? {} : { tlsRoot: tls.root }),
@@ -193,6 +199,7 @@ class BuiltApplications {
       applications.map(async (application) => {
         await stopServer(application.server);
         await stopProxy(application.proxy);
+        await Promise.all(application.portLeases.map((lease) => lease.release()));
         await application.postgres?.stop();
         if (application.dataDirectory !== undefined) {
           await rm(application.dataDirectory, { recursive: true, force: true });
@@ -214,6 +221,7 @@ class BuiltApplications {
 interface RunningApplication extends BuiltApplication {
   postgres?: StartedPostgreSqlContainer;
   dataDirectory?: string;
+  portLeases: readonly PortLease[];
   server: ChildProcess;
   tlsRoot?: string;
   proxy?: Server;
@@ -516,22 +524,49 @@ async function stopProxy(proxy: Server | undefined): Promise<void> {
   });
 }
 
-async function availablePort(): Promise<number> {
-  const server = createServer();
-  await new Promise<void>((resolve, reject) => {
-    server.once("error", reject);
-    server.listen(0, "127.0.0.1", resolve);
-  });
-  const address = server.address();
-  if (address === null || typeof address === "string") throw new Error("failed to allocate port");
-  await new Promise<void>((resolve, reject) => {
-    server.close((error) => {
-      if (error !== undefined) {
-        reject(error);
-        return;
-      }
-      resolve();
+interface PortLease {
+  port: number;
+  release(): Promise<void>;
+}
+
+const PORT_LEASE_DIRECTORY = join(process.cwd(), "test-results", "port-leases");
+
+async function reservePort(): Promise<PortLease> {
+  await mkdir(PORT_LEASE_DIRECTORY, { recursive: true });
+  while (true) {
+    const server = createServer();
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", resolve);
     });
+    const address = server.address();
+    if (address === null || typeof address === "string") {
+      await closeServer(server);
+      throw new Error("failed to allocate port");
+    }
+    const leasePath = join(PORT_LEASE_DIRECTORY, String(address.port));
+    try {
+      const lease = await open(leasePath, "wx");
+      await lease.close();
+    } catch (error) {
+      await closeServer(server);
+      if ((error as NodeJS.ErrnoException).code === "EEXIST") continue;
+      throw error;
+    }
+    await closeServer(server);
+    return {
+      port: address.port,
+      release: async () => {
+        await unlink(leasePath).catch((error: NodeJS.ErrnoException) => {
+          if (error.code !== "ENOENT") throw error;
+        });
+      },
+    };
+  }
+}
+
+async function closeServer(server: NetServer): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error === undefined ? resolve() : reject(error)));
   });
-  return address.port;
 }

--- a/src/triggers/github/provider.test.ts
+++ b/src/triggers/github/provider.test.ts
@@ -1,12 +1,14 @@
 import assert from "node:assert/strict";
 import { describe, it } from "vitest";
+import { Octokit } from "octokit";
 import { createMemoryDatabase } from "../../db/memory.js";
 import type { DurableProviderEvent } from "../../db/types.js";
 import { createActiveProjectConfiguration } from "../../test-utils/project-configuration.js";
 import { createDurableWorkflowHandler } from "../../workflows/engine.js";
 import type { GitHubReactionClient } from "./provider.js";
-import { createGitHubTriggerProvider } from "./provider.js";
+import { createGitHubReactionClient, createGitHubTriggerProvider } from "./provider.js";
 import type { NormalizedGitHubEvent } from "../../auth/github-events.js";
+import type { GitHubAuth } from "../../auth/github.js";
 import { isAcceptedTriggerProviderMatch } from "../index.js";
 import { createUnlimitedEntitlementsService } from "../../entitlements/test-utils.js";
 
@@ -114,6 +116,129 @@ describe("GitHub Phase 1 trigger provider", () => {
     assert.equal(typeof matches === "string" ? 0 : matches.length, 1);
   });
 
+  it.each([
+    ["issues", "opened", "github.issue_created", 211],
+    ["issues", "labeled", "github.issue_label_added", 211],
+    ["pull_request", "opened", "github.pull_request_created", 312],
+    ["pull_request", "labeled", "github.pull_request_label_added", 312],
+  ] as const)("derives an item reaction target for %s %s", async (type, action, source, number) => {
+    const configuration = githubConfiguration();
+    configuration.triggers[0] = { ...configuration.triggers[0]!, on: source };
+    const { project, revision, store } = await activeConfiguration(configuration);
+    const provider = createProvider(store, new TestReactions());
+    const matches = await provider.match(
+      external(project.id, revision.id, createItemEvent(type, action, number)),
+    );
+    if (typeof matches === "string") throw new Error("expected item match");
+
+    assert.deepEqual(matches[0]?.triggerContext.reactionSubject, {
+      kind: "item",
+      issueNumber: number,
+    });
+  });
+
+  it.each([
+    ["completed", "+1"],
+    ["failed", "-1"],
+  ] as const)(
+    "replaces an item acceptance reaction with %s terminal reaction",
+    async (terminal, content) => {
+      const configuration = githubConfiguration();
+      configuration.triggers[0] = {
+        ...configuration.triggers[0]!,
+        on: "github.pull_request_created",
+      };
+      const { project, revision, store } = await activeConfiguration(configuration);
+      const reactions = new TestReactions();
+      const provider = createProvider(store, reactions);
+      const matches = await provider.match(
+        external(project.id, revision.id, createItemEvent("pull_request", "opened", 312)),
+      );
+      if (typeof matches === "string") throw new Error("expected pull request match");
+      const match = matches[0]!;
+      const reactionState =
+        (await provider.onDispatchAccepted?.(match.triggerContext, match.outputContext)) ?? null;
+
+      if (terminal === "completed") {
+        await provider.onAgentExecutionCompleted?.(
+          match.triggerContext,
+          match.outputContext,
+          { status: "succeeded" },
+          reactionState,
+        );
+      } else {
+        await provider.onAgentExecutionFailed?.(
+          match.triggerContext,
+          match.outputContext,
+          "boom",
+          reactionState,
+        );
+      }
+
+      assert.deepEqual(
+        reactions.created.map((call) => call.content),
+        ["eyes", content],
+      );
+      assert.deepEqual(reactions.deleted, [
+        {
+          installationId: 42,
+          repo: "boudra/faro",
+          subject: { kind: "item", issueNumber: 312 },
+          reactionId: 1,
+        },
+      ]);
+    },
+  );
+
+  it("uses the issue reactions endpoint for item create and delete", async () => {
+    const calls: Array<{ url: string; method: string; body: string | undefined }> = [];
+    const octokit = new Octokit({
+      request: {
+        fetch: async (url: RequestInfo | URL, init?: RequestInit) => {
+          calls.push({
+            url: requestUrl(url),
+            method: init?.method ?? "GET",
+            body: typeof init?.body === "string" ? init.body : undefined,
+          });
+          return new Response(JSON.stringify({ id: 99 }), {
+            headers: { "content-type": "application/json" },
+          });
+        },
+      },
+    });
+    const auth = {
+      createInstallationOctokit: async () => octokit,
+    } satisfies Pick<GitHubAuth, "createInstallationOctokit">;
+    const reactions = createGitHubReactionClient(auth);
+    const subject = { kind: "item" as const, issueNumber: 312 };
+
+    await reactions.createReaction({
+      installationId: 42,
+      repo: "owner/repository",
+      subject,
+      content: "eyes",
+    });
+    await reactions.deleteReaction({
+      installationId: 42,
+      repo: "owner/repository",
+      subject,
+      reactionId: 99,
+    });
+
+    assert.deepEqual(calls, [
+      {
+        url: "https://api.github.com/repos/owner/repository/issues/312/reactions",
+        method: "POST",
+        body: '{"content":"eyes"}',
+      },
+      {
+        url: "https://api.github.com/repos/owner/repository/issues/312/reactions/99",
+        method: "DELETE",
+        body: undefined,
+      },
+    ]);
+  });
+
   it("exposes safe issue and pull-request item context without the raw webhook", async () => {
     const { project, revision, store } = await activeConfiguration();
     const provider = createProvider(store, new TestReactions());
@@ -175,14 +300,8 @@ describe("GitHub Phase 1 trigger provider", () => {
     const provider = createProvider(store, reactions);
     const match = (await provider.match(external(project.id, revision.id, createEvent())))[0];
     if (!isAcceptedTriggerProviderMatch(match)) throw new Error("expected accepted match");
-    let reactionState =
+    const reactionState =
       (await provider.onDispatchAccepted?.(match.triggerContext, match.outputContext)) ?? null;
-    reactionState =
-      (await provider.onAgentExecutionStarted?.(
-        match.triggerContext,
-        match.outputContext,
-        reactionState,
-      )) ?? reactionState;
     await provider.onAgentExecutionCompleted?.(
       match.triggerContext,
       match.outputContext,
@@ -191,7 +310,7 @@ describe("GitHub Phase 1 trigger provider", () => {
     );
     assert.deepEqual(
       reactions.created.map((call) => call.content),
-      ["eyes", "rocket", "+1"],
+      ["eyes", "+1"],
     );
   });
 
@@ -424,6 +543,44 @@ function createEvent(
     },
     createdAt: "2026-05-19T00:00:00.000Z",
   };
+}
+
+function createItemEvent(
+  type: "issues" | "pull_request",
+  action: "opened" | "labeled",
+  number: number,
+): NormalizedGitHubEvent {
+  return {
+    id: `github-${type}-${action}`,
+    type,
+    repo: "boudra/faro",
+    repositoryId: 7,
+    installationId: 42,
+    payload:
+      type === "issues"
+        ? {
+            action,
+            issue: { number, title: "smoke", body: "issue body @paseo", user: { login: "boudra" } },
+            sender: { login: "boudra" },
+          }
+        : {
+            action,
+            pull_request: {
+              number,
+              title: "smoke",
+              body: "pull request body @paseo",
+              user: { login: "boudra" },
+            },
+            sender: { login: "boudra" },
+          },
+    createdAt: "2026-05-19T00:00:00.000Z",
+  };
+}
+
+function requestUrl(url: RequestInfo | URL): string {
+  if (typeof url === "string") return url;
+  if (url instanceof URL) return url.href;
+  return url.url;
 }
 
 class TestReactions implements GitHubReactionClient {

--- a/src/triggers/github/provider.ts
+++ b/src/triggers/github/provider.ts
@@ -16,7 +16,9 @@ import {
 import { matchesInputFilters, parseInvocation } from "../invocation.js";
 import {
   IssueCommentPayloadSchema,
+  IssuesPayloadSchema,
   NormalizedGitHubEventSchema,
+  PullRequestPayloadSchema,
   PullRequestReviewCommentPayloadSchema,
 } from "../../auth/github-events.js";
 import type { NormalizedGitHubEvent } from "../../auth/github-events.js";
@@ -48,7 +50,6 @@ export type GitHubReactionContent =
   | "confused"
   | "heart"
   | "hooray"
-  | "rocket"
   | "eyes";
 
 export interface GitHubMergeData {
@@ -70,43 +71,58 @@ interface GitHubContextItem {
   author: { login: string } | null;
 }
 
-export function createGitHubReactionClient(auth: GitHubAuth): GitHubReactionClient {
+export function createGitHubReactionClient(
+  auth: Pick<GitHubAuth, "createInstallationOctokit">,
+): GitHubReactionClient {
   return {
     async createReaction(input) {
       const [owner, repo] = splitRepo(input.repo);
       const octokit = await auth.createInstallationOctokit(input.installationId);
-      const endpoint =
-        input.subject.kind === "issue_comment"
-          ? "POST /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions"
-          : "POST /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions";
-
-      const response = await octokit.request(endpoint, {
-        owner,
-        repo,
-        comment_id: input.subject.commentId,
-        content: input.content,
-      });
+      if (input.subject.kind === "item") {
+        const response = await octokit.request(
+          "POST /repos/{owner}/{repo}/issues/{issue_number}/reactions",
+          { owner, repo, issue_number: input.subject.issueNumber, content: input.content },
+        );
+        return { id: response.data.id };
+      }
+      if (input.subject.kind === "issue_comment") {
+        const response = await octokit.request(
+          "POST /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions",
+          { owner, repo, comment_id: input.subject.commentId, content: input.content },
+        );
+        return { id: response.data.id };
+      }
+      const response = await octokit.request(
+        "POST /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions",
+        { owner, repo, comment_id: input.subject.commentId, content: input.content },
+      );
       return { id: response.data.id };
     },
     async deleteReaction(input) {
       const [owner, repo] = splitRepo(input.repo);
       const octokit = await auth.createInstallationOctokit(input.installationId);
-      const endpoint =
-        input.subject.kind === "issue_comment"
-          ? "DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions/{reaction_id}"
-          : "DELETE /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions/{reaction_id}";
-
-      await octokit.request(endpoint, {
-        owner,
-        repo,
-        comment_id: input.subject.commentId,
-        reaction_id: input.reactionId,
-      });
+      if (input.subject.kind === "item") {
+        await octokit.request(
+          "DELETE /repos/{owner}/{repo}/issues/{issue_number}/reactions/{reaction_id}",
+          { owner, repo, issue_number: input.subject.issueNumber, reaction_id: input.reactionId },
+        );
+      } else if (input.subject.kind === "issue_comment") {
+        await octokit.request(
+          "DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions/{reaction_id}",
+          { owner, repo, comment_id: input.subject.commentId, reaction_id: input.reactionId },
+        );
+      } else {
+        await octokit.request(
+          "DELETE /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions/{reaction_id}",
+          { owner, repo, comment_id: input.subject.commentId, reaction_id: input.reactionId },
+        );
+      }
     },
   };
 }
 
 export type GitHubReactionSubject =
+  | { kind: "item"; issueNumber: number }
   | { kind: "issue_comment"; commentId: number }
   | { kind: "pull_request_review_comment"; commentId: number };
 
@@ -205,9 +221,6 @@ export function createGitHubTriggerProvider(options: {
       });
       return { reactionId: reaction.id } satisfies GitHubReactionState;
     },
-    async onAgentExecutionStarted(triggerContext, _outputContext, reactionState) {
-      return reactToLifecycle(options.reactions, triggerContext, "rocket", reactionState);
-    },
     async onAgentExecutionCompleted(triggerContext, _outputContext, _result, reactionState) {
       return reactToLifecycle(options.reactions, triggerContext, "+1", reactionState);
     },
@@ -287,6 +300,20 @@ function githubReactionId(state: TriggerProviderReactionState | undefined): numb
 }
 
 function reactionSubjectForEvent(event: NormalizedGitHubEvent): GitHubReactionSubject | null {
+  if (event.type === "issues") {
+    const payload = IssuesPayloadSchema.parse(event.payload);
+    return payload.issue?.number === undefined
+      ? null
+      : { kind: "item", issueNumber: payload.issue.number };
+  }
+
+  if (event.type === "pull_request") {
+    const payload = PullRequestPayloadSchema.parse(event.payload);
+    return payload.pull_request?.number === undefined
+      ? null
+      : { kind: "item", issueNumber: payload.pull_request.number };
+  }
+
   if (event.type === "issue_comment") {
     const payload = IssueCommentPayloadSchema.parse(event.payload);
     return payload.comment?.id === undefined

--- a/src/workflows/reactions.test.ts
+++ b/src/workflows/reactions.test.ts
@@ -70,8 +70,8 @@ describe("workflow-owned provider reactions", () => {
     assert.deepEqual(fixture.triggerContext, original);
     assert.deepEqual(result.visible(), ["+1"]);
     assert.deepEqual(result.calls(), {
-      created: ["eyes", "rocket", "+1"],
-      deleted: [1, 2],
+      created: ["eyes", "+1"],
+      deleted: [1],
     });
   });
 
@@ -80,10 +80,10 @@ describe("workflow-owned provider reactions", () => {
 
     assert.deepEqual(result.visible(), ["+1"]);
     assert.deepEqual(result.calls(), {
-      created: ["eyes", "rocket", "+1"],
-      deleted: [1, 2],
+      created: ["eyes", "+1"],
+      deleted: [1],
     });
-    assert.deepEqual(result.run.reactionState, { reactionId: 3 });
+    assert.deepEqual(result.run.reactionState, { reactionId: 2 });
     assert.equal(result.run.status, "succeeded");
   });
 
@@ -123,10 +123,10 @@ describe("workflow-owned provider reactions", () => {
 
       assert.deepEqual(result.visible(), ["-1"]);
       assert.deepEqual(result.calls(), {
-        created: ["eyes", "rocket", "-1"],
-        deleted: [1, 2],
+        created: ["eyes", "-1"],
+        deleted: [1],
       });
-      assert.deepEqual(result.run.reactionState, { reactionId: 3 });
+      assert.deepEqual(result.run.reactionState, { reactionId: 2 });
     },
   );
 });


### PR DESCRIPTION
GitHub issue and pull-request triggers now show lifecycle reactions directly on the item: `eyes` on acceptance, then `+1` on success or `-1` on failure. Existing comment and review-comment reactions follow the same simplified lifecycle without a running reaction.

## Goals

- Derive an item reaction target for issue and pull-request created and label-added events.
- Use GitHub's issue reaction endpoint for both issue and pull-request items.
- Preserve existing lifecycle state, cleanup, authentication, and comment behavior.

## Non-goals

- No new reaction subsystem, persisted state, credentials, or coordination.
- No reactions for unsupported GitHub targets.
- No Discord or Slack reaction changes.

## Why

GitHub item webhook events previously resolved to no reaction subject, causing the lifecycle to return before making a GitHub API call.

## Verification

- `npx vitest run src/triggers/github/provider.test.ts src/workflows/reactions.test.ts` (31 tests)
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`

## Risk surface

Limited to the GitHub trigger provider's reaction target selection and lifecycle sequence.