### PR TITLE
Preserve root messages in provider thread context

### DIFF
--- a/src/triggers/discord/bot.test.ts
+++ b/src/triggers/discord/bot.test.ts
@@ -177,6 +177,45 @@ describe("Discord bot client", () => {
     ]);
   });
 
+  it("keeps the thread starter ahead of the latest replies in context", async () => {
+    const starter = contextMessage("200", "100", "root request", 0);
+    const replies = Array.from({ length: 50 }, (_, index) =>
+      contextMessage(String(250 + index), "207", `reply-${index + 1}`, index + 1),
+    );
+    const thread = new FakeReadableThread(starter, replies);
+    const bot = createDiscordBotClient({
+      token: "token",
+      clientId: "900",
+      client: createFakeClient(new FakeSendableChannel(), thread),
+    });
+
+    const messages = await bot.readThreadMessages({
+      channelId: "207",
+      beforeMessageId: "300",
+    });
+
+    assert.equal(messages.length, 50);
+    assert.deepEqual(
+      messages.map((message) => message.content),
+      ["root request", ...replies.slice(1).map((message) => message.content)],
+    );
+    assert.deepEqual(thread.historyRequests, [{ before: "300", limit: 50 }]);
+    assert.equal(thread.starterReads, 1);
+  });
+
+  it("rejects thread context when Discord cannot provide its starter", async () => {
+    const bot = createDiscordBotClient({
+      token: "token",
+      clientId: "900",
+      client: createFakeClient(new FakeSendableChannel(), new FakeReadableThread(null, [])),
+    });
+
+    await assert.rejects(
+      () => bot.readThreadMessages({ channelId: "207", beforeMessageId: "300" }),
+      /thread starter unavailable/u,
+    );
+  });
+
   it("rejects invalid snowflakes before calling Discord", async () => {
     const channel = new FakeSendableChannel();
     const bot = createDiscordBotClient({
@@ -264,6 +303,58 @@ class FakeSendableChannel {
   }
 }
 
+class FakeReadableThread {
+  readonly historyRequests: unknown[] = [];
+  starterReads = 0;
+  readonly messages = {
+    fetch: (request: unknown) => {
+      this.historyRequests.push(request);
+      return Promise.resolve(new Map(this.replies.map((message) => [message.id, message])));
+    },
+  };
+
+  constructor(
+    private readonly starter: FakeContextMessage | null,
+    private readonly replies: FakeContextMessage[],
+  ) {}
+
+  isThread(): boolean {
+    return true;
+  }
+
+  fetchStarterMessage(): Promise<FakeContextMessage | null> {
+    this.starterReads += 1;
+    return Promise.resolve(this.starter);
+  }
+}
+
+interface FakeContextMessage {
+  id: string;
+  channelId: string;
+  content: string;
+  author: { id: string; username: string; bot: boolean };
+  createdAt: Date;
+  attachments: Map<string, never>;
+  reference: null;
+}
+
+function contextMessage(
+  id: string,
+  channelId: string,
+  content: string,
+  seconds: number,
+): FakeContextMessage {
+  return {
+    id,
+    channelId,
+    content,
+    author: { id: "400", username: "maintainer", bot: false },
+    createdAt: new Date(1_700_000_000_000 + seconds * 1_000),
+    attachments: new Map<string, never>(),
+    reference: null,
+  };
+}
+
 class FakeGatewayClient extends EventEmitter {
   constructor(
     private readonly closeCode: number,
@@ -301,7 +392,7 @@ class FakeMessage {
 
 function createFakeClient(
   channel: FakeSendableChannel,
-  thread?: FakeSendableChannel,
+  thread?: FakeSendableChannel | FakeReadableThread,
   options: { deleteReactionError?: Error } = {},
 ): Client {
   const fakeClient = {
@@ -309,7 +400,7 @@ function createFakeClient(
       return fakeClient;
     },
     channels: {
-      async fetch(channelId: string): Promise<FakeSendableChannel> {
+      async fetch(channelId: string): Promise<FakeSendableChannel | FakeReadableThread> {
         if (channelId === "207" && thread !== undefined) {
           return thread;
         }

--- a/src/triggers/discord/bot.ts
+++ b/src/triggers/discord/bot.ts
@@ -102,6 +102,12 @@ type DiscordSendableChannel = TextBasedChannel & {
   send: (...args: unknown[]) => Promise<unknown>;
 };
 
+type DiscordReadableThread = TextBasedChannel & {
+  fetchStarterMessage(): Promise<Message | null>;
+};
+
+const DISCORD_THREAD_CONTEXT_LIMIT = 50;
+
 export interface CreateDiscordBotClientOptions {
   token: string;
   clientId?: string;
@@ -240,11 +246,17 @@ export function createDiscordBotClient(options: CreateDiscordBotClientOptions): 
       if (channel === null || !isThreadChannel(channel)) {
         throw new Error(`discord channel is not a readable thread: ${input.channelId}`);
       }
-      const page = await channel.messages.fetch({ before: beforeMessageId, limit: 50 });
-      return Array.from(page.values())
-        .filter((message) => message.id !== beforeMessageId)
+      const [starter, page] = await Promise.all([
+        channel.fetchStarterMessage(),
+        channel.messages.fetch({ before: beforeMessageId, limit: DISCORD_THREAD_CONTEXT_LIMIT }),
+      ]);
+      if (starter === null) throw new Error("Discord thread starter unavailable");
+      const replies = Array.from(page.values())
+        .filter((message) => message.id !== beforeMessageId && message.id !== starter.id)
         .map(normalizeContextMessage)
-        .sort(compareThreadMessages);
+        .sort(compareThreadMessages)
+        .slice(-(DISCORD_THREAD_CONTEXT_LIMIT - 1));
+      return [normalizeContextMessage(starter), ...replies];
     },
     onMessageCreate(handler) {
       handlers.add(handler);
@@ -327,8 +339,13 @@ function isTextChannel(channel: GuildBasedChannel | TextBasedChannel): channel i
 
 function isThreadChannel(
   channel: GuildBasedChannel | TextBasedChannel,
-): channel is TextBasedChannel & { isThread(): boolean } {
-  return isTextChannel(channel) && typeof channel.isThread === "function" && channel.isThread();
+): channel is DiscordReadableThread {
+  return (
+    isTextChannel(channel) &&
+    typeof channel.isThread === "function" &&
+    channel.isThread() &&
+    typeof Reflect.get(channel, "fetchStarterMessage") === "function"
+  );
 }
 
 function isSendableChannel(

--- a/src/triggers/slack/client.test.ts
+++ b/src/triggers/slack/client.test.ts
@@ -129,16 +129,19 @@ describe("Slack Web API client", () => {
     assert.equal(requestSignal?.aborted, true);
   });
 
-  it("hydrates the latest 50 preceding replies across Slack pagination, oldest first", async () => {
+  it("keeps the root with the latest 49 preceding Slack replies, oldest first", async () => {
     const requests: Array<{ method: string; url: string; body: BodyInit | null | undefined }> = [];
-    const messages = Array.from({ length: 455 }, (_, index) => {
-      const sequence = index + 1;
-      return {
-        ts: `1700000000.${String(sequence).padStart(6, "0")}`,
-        text: `reply-${sequence}`,
-        ...(sequence === 455 ? { bot_id: "B455" } : { user: `U${sequence}` }),
-      };
-    });
+    const messages = [
+      { ts: "1700000000.000000", text: "root request", user: "UROOT" },
+      ...Array.from({ length: 455 }, (_, index) => {
+        const sequence = index + 1;
+        return {
+          ts: `1700000000.${String(sequence).padStart(6, "0")}`,
+          text: `reply-${sequence}`,
+          ...(sequence === 455 ? { bot_id: "B455" } : { user: `U${sequence}` }),
+        };
+      }),
+    ];
     const pageSize = 100;
     const client = createSlackBotClient({
       tokenForWorkspace: () => Promise.resolve("xoxb-secret"),
@@ -171,7 +174,8 @@ describe("Slack Web API client", () => {
     });
 
     assert.equal(hydrated?.messages.length, 50);
-    assert.equal(hydrated?.messages[0]?.content, "reply-406");
+    assert.equal(hydrated?.messages[0]?.content, "root request");
+    assert.equal(hydrated?.messages[1]?.content, "reply-407");
     assert.equal(hydrated?.messages.at(-1)?.content, "reply-455");
     assert.deepEqual(hydrated?.messages.at(-1)?.author, { id: "B455" });
     assert.equal(hydrated?.complete, true);
@@ -202,6 +206,7 @@ describe("Slack Web API client", () => {
           ? Response.json({
               ok: true,
               messages: [
+                { ts: "1700000000.000000", text: "root request", user: "UROOT" },
                 { ts: "1700000000.000001", text: "reply-1", user: "U1" },
                 { ts: "1700000000.000002", text: "reply-2", user: "U2" },
               ],
@@ -221,10 +226,34 @@ describe("Slack Web API client", () => {
 
     assert.deepEqual(
       hydrated?.messages.map((message) => message.content),
-      ["reply-1", "reply-2"],
+      ["root request", "reply-1", "reply-2"],
     );
     assert.equal(hydrated?.complete, false);
     assert.equal(requests, 2);
+  });
+
+  it("rejects Slack thread context when the API omits its root", async () => {
+    const client = createSlackBotClient({
+      tokenForWorkspace: () => Promise.resolve("xoxb-secret"),
+      fetch: () =>
+        Promise.resolve(
+          Response.json({
+            ok: true,
+            messages: [{ ts: "1700000000.000001", text: "reply-1", user: "U1" }],
+          }),
+        ),
+    });
+    await assert.rejects(
+      () =>
+        client.readThreadMessages!({
+          organizationId: "org-1",
+          teamId: "T1",
+          channelId: "C1",
+          threadTs: "1700000000.000000",
+          beforeTs: "1700000000.000002",
+        }),
+      /thread root unavailable/u,
+    );
   });
 
   it("keeps Slack file credentials and private URLs inside the client", async () => {

--- a/src/triggers/slack/client.ts
+++ b/src/triggers/slack/client.ts
@@ -39,6 +39,7 @@ const SlackUserInfoSchema = SlackApiResponseSchema.extend({
 });
 const SLACK_API_TIMEOUT_MS = 10_000;
 const SLACK_THREAD_REPLIES_MAX_PAGES = 10;
+const SLACK_THREAD_CONTEXT_LIMIT = 50;
 
 export interface SlackAttachmentMetadata {
   id: string;
@@ -178,7 +179,8 @@ export function createSlackBotClient(options: {
     beforeTs: string;
   }): Promise<SlackThreadReadResult> {
     let cursor: string | undefined;
-    let selected: SlackThreadMessage[] = [];
+    let root: SlackThreadMessage | undefined;
+    let selectedReplies: SlackThreadMessage[] = [];
     const seenCursors = new Set<string>();
     let complete = true;
     let pagesRead = 0;
@@ -197,7 +199,7 @@ export function createSlackBotClient(options: {
         );
         if (!result.ok) throw new Error(`Slack API ${result.error ?? "unknown_error"}`);
       } catch (error) {
-        if (selected.length === 0) throw error;
+        if (root === undefined && selectedReplies.length === 0) throw error;
         reportFailure(
           error,
           { operation: "slack.thread.history.page", component: "providers", provider: "slack" },
@@ -206,10 +208,16 @@ export function createSlackBotClient(options: {
         complete = false;
         break;
       }
-      selected = [...selected, ...(result.messages ?? []).map(normalizeThreadMessage)]
-        .filter((message) => compareSlackTs(message.ts, input.beforeTs) < 0)
+      const page = (result.messages ?? [])
+        .map(normalizeThreadMessage)
+        .filter((message) => compareSlackTs(message.ts, input.beforeTs) < 0);
+      root ??= page.find((message) => message.ts === input.threadTs);
+      selectedReplies = [
+        ...selectedReplies,
+        ...page.filter((message) => message.ts !== input.threadTs),
+      ]
         .sort((left, right) => compareSlackTs(right.ts, left.ts))
-        .slice(0, 50);
+        .slice(0, SLACK_THREAD_CONTEXT_LIMIT - 1);
       pagesRead += 1;
       const next = result.response_metadata?.next_cursor;
       cursor = next === undefined || next.length === 0 ? undefined : next;
@@ -225,8 +233,9 @@ export function createSlackBotClient(options: {
       }
     }
 
+    if (root === undefined) throw new Error("Slack thread root unavailable");
     return {
-      messages: selected.sort((left, right) => compareSlackTs(left.ts, right.ts)),
+      messages: [root, ...selectedReplies.sort((left, right) => compareSlackTs(left.ts, right.ts))],
       complete,
     };
   }

--- a/src/triggers/slack/provider.test.ts
+++ b/src/triggers/slack/provider.test.ts
@@ -541,7 +541,7 @@ describe("Slack Phase 1 trigger provider", () => {
     assert.equal(context.slack.thread.messages.length, 1);
   });
 
-  it("caps Slack history traversal and retains the newest 50 messages oldest first", async () => {
+  it("caps Slack history traversal while retaining the root and newest 49 messages", async () => {
     const maximumPageCount = 10;
     const messagesPerPage = 100;
     let requests = 0;
@@ -597,7 +597,7 @@ describe("Slack Phase 1 trigger provider", () => {
     assert.equal(context.slack.thread.status, "incomplete");
     assert.deepEqual(
       context.slack.thread.messages.map((message) => message.content),
-      Array.from({ length: 50 }, (_, index) => `reply-${951 + index}`),
+      ["reply-1", ...Array.from({ length: 49 }, (_, index) => `reply-${952 + index}`)],
     );
   });
 


### PR DESCRIPTION
Discord and Slack thread context now always starts with the conversation's root message, so agents retain the request that established the thread even after history truncation.

## Goals

- Include the Discord starter message in materialized thread context.
- Preserve the Slack thread root across pagination and truncation.
- Keep context bounded to 50 messages: the root plus the newest 49 preceding replies.
- Fail context materialization instead of silently producing rootless context.

## Non-goals

- Change `${{ paseo.context }}` opt-in behavior or provider context schemas.
- Change trigger prompt parsing or reply routing.

## Why

Discord exposes a thread starter separately from the messages inside the thread, while Slack returns the root among paginated replies where the previous newest-50 truncation could evict it. The provider clients now own those API-specific details and expose one root-first invariant to the workflow layer.

## Verification

- `npx vitest run src/triggers/discord src/triggers/slack` — 101 passed, 1 real-service test skipped.
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- The repository-wide suite's runnable tests passed; PostgreSQL container suites could not start locally because no container runtime is available.

## Risk surface

This changes only thread-context selection and ordering. Long histories retain one fewer reply to reserve the existing 50-message budget for the root; missing upstream roots now make context unavailable instead of yielding incomplete evidence.
