### PR TITLE
Add a trigger for pull request head updates

### DIFF
--- a/src/projects/activity-summary.test.ts
+++ b/src/projects/activity-summary.test.ts
@@ -77,6 +77,33 @@ describe("summarizeTrigger", () => {
     });
   });
 
+  it("summarizes a pull request head update", () => {
+    const summary = summarizeTrigger("github.pull_request_updated", {
+      id: "1",
+      type: "pull_request",
+      repo: "acme/widgets",
+      repositoryId: 1,
+      installationId: 1,
+      createdAt: new Date().toISOString(),
+      payload: {
+        action: "synchronize",
+        pull_request: {
+          number: 42,
+          title: "Address review feedback",
+          html_url: "https://github.com/acme/widgets/pull/42",
+        },
+        sender: { login: "alice" },
+      },
+    });
+
+    assert.deepEqual(summary, {
+      provider: "github",
+      headline: "Pull request #42 updated: Address review feedback",
+      actor: "alice",
+      externalUrl: "https://github.com/acme/widgets/pull/42",
+    });
+  });
+
   it("falls back to a generic headline when a valid envelope carries a malformed event payload", () => {
     const summary = summarizeTrigger("github.push", {
       id: "1",

--- a/src/projects/activity-summary.ts
+++ b/src/projects/activity-summary.ts
@@ -68,6 +68,17 @@ function summarizeGitHub(payload: unknown): TriggerSummary {
       externalUrl,
     };
   }
+  if (classified.semanticEvent === "github.pull_request_updated") {
+    return {
+      provider: "github",
+      headline:
+        classified.item?.number === null || classified.item === null
+          ? "Pull request updated"
+          : `Pull request #${String(classified.item.number)} updated${classified.item.title === null ? "" : `: ${classified.item.title}`}`,
+      actor: classified.actor.length === 0 ? null : classified.actor,
+      externalUrl,
+    };
+  }
   const { headline, actor } = summarizeGitHubEvent(event.data.type, event.data.payload);
   return { provider: "github", headline, actor, externalUrl };
 }

--- a/src/triggers/github/classification.ts
+++ b/src/triggers/github/classification.ts
@@ -10,6 +10,7 @@ import type { NormalizedGitHubEvent } from "../../auth/github-events.js";
 export const GITHUB_SEMANTIC_TRIGGER_EVENT_NAMES = [
   "github.issue_created",
   "github.pull_request_created",
+  "github.pull_request_updated",
   "github.issue_comment_created",
   "github.pull_request_comment_created",
   "github.issue_label_added",
@@ -139,6 +140,7 @@ function issueSemanticEvent(action: string | undefined): GitHubSemanticEvent | u
 
 function pullRequestSemanticEvent(action: string | undefined): GitHubSemanticEvent | undefined {
   if (action === "opened") return "github.pull_request_created";
+  if (action === "synchronize") return "github.pull_request_updated";
   if (action === "labeled") return "github.pull_request_label_added";
   return undefined;
 }

--- a/src/triggers/github/match.test.ts
+++ b/src/triggers/github/match.test.ts
@@ -39,6 +39,18 @@ describe("GitHub trigger matching", () => {
       expected: 0,
     },
     {
+      acceptance: "2: pull_request_updated accepts synchronized pull requests",
+      on: "github.pull_request_updated",
+      event: eventFor("pull_request", { action: "synchronize", pull_request: pullRequest() }),
+      expected: 1,
+    },
+    {
+      acceptance: "2: pull_request_updated does not match edited pull-request metadata",
+      on: "github.pull_request_updated",
+      event: eventFor("pull_request", { action: "edited", pull_request: pullRequest() }),
+      expected: 0,
+    },
+    {
       acceptance: "3: created issue comments are separate from pull-request comments",
       on: "github.issue_comment_created",
       event: eventFor("issue_comment", { action: "created", issue: issue(), comment: comment() }),

--- a/src/triggers/github/provider.test.ts
+++ b/src/triggers/github/provider.test.ts
@@ -120,6 +120,7 @@ describe("GitHub Phase 1 trigger provider", () => {
     ["issues", "opened", "github.issue_created", 211],
     ["issues", "labeled", "github.issue_label_added", 211],
     ["pull_request", "opened", "github.pull_request_created", 312],
+    ["pull_request", "synchronize", "github.pull_request_updated", 312],
     ["pull_request", "labeled", "github.pull_request_label_added", 312],
   ] as const)("derives an item reaction target for %s %s", async (type, action, source, number) => {
     const configuration = githubConfiguration();
@@ -547,7 +548,7 @@ function createEvent(
 
 function createItemEvent(
   type: "issues" | "pull_request",
-  action: "opened" | "labeled",
+  action: "opened" | "synchronize" | "labeled",
   number: number,
 ): NormalizedGitHubEvent {
   return {


### PR DESCRIPTION
Related discussion: [getpaseo/paseo#3924](https://github.com/getpaseo/paseo/discussions/3924)

> [!NOTE]
> This is a draft for feedback on the workflow, event semantics, and public event name. A companion public-docs PR will follow once those points are agreed.

Hub workflows can subscribe to the proposed `github.pull_request_updated` event when GitHub delivers `pull_request.synchronize`. Other pull request actions do not match this semantic event, and existing GitHub trigger behavior remains unchanged.

## Goals

- Expose `github.pull_request_updated` as a semantic GitHub trigger.
- Classify only `pull_request.synchronize` deliveries as pull request head updates.
- Preserve pull request item metadata for reaction targeting.
- Summarize updated pull requests in project activity.
- Add regression coverage at the matcher, provider, and activity-summary boundaries.

## Non-goals

- Treat all pull request mutations as head updates.
- Add triggers for other pull request actions.
- Change workflow configuration syntax or filtering behavior.
- Add webhook subscriptions, GitHub App permissions, or database migrations.

## Why

The raw `github.pull_request` source is already routed to the GitHub trigger provider. The semantic classifier handles opened and labeled pull requests, but does not represent the `synchronize` action used for pull request head updates.

This change adds that missing semantic classification without changing the underlying webhook boundary.

## Documentation

The companion public-docs PR is pending agreement on the event semantics and name in the linked discussion.

## Verification

- Targeted Vitest coverage for GitHub matching, provider behavior, and activity summaries: 3 files and 56 tests passed.
- `npm run release:check`: passed.
- Full repository integration checks will run in GitHub Actions.

## Risk surface

Limited to GitHub pull request semantic classification and the corresponding activity summary. Regression tests verify that `synchronize` matches the proposed event while metadata edits do not.
