### PR TITLE
hub: gate GitHub triggers by PR author

### DIFF
--- a/src/config/compiler.test.ts
+++ b/src/config/compiler.test.ts
@@ -163,6 +163,61 @@ describe("workflow compiler", () => {
     assert.throws(() => compileHubConfig(raw), /unrecognized key.*toolPolicy/iu);
   });
 
+  it("accepts exact PR-author filters and keeps authored and compiled filters strict", () => {
+    const trigger = configuration().triggers[0]!;
+    const compiled = compileHubConfig({
+      ...configuration(),
+      triggers: [
+        {
+          ...trigger,
+          filters: {
+            exact: "@paseo assurance start",
+            from_users: ["unicornz-code"],
+            pr_authors: ["unicornz-code", "cleverunicorn"],
+          },
+        },
+      ],
+    });
+
+    assert.deepEqual(compiled.triggers[0]?.filters, {
+      exact: "@paseo assurance start",
+      from_users: ["unicornz-code"],
+      pr_authors: ["unicornz-code", "cleverunicorn"],
+    });
+    assert.deepEqual(parseCompiledHubConfig(compiled), compiled);
+
+    for (const filters of [
+      { exact: 42, from_users: ["unicornz-code"] },
+      { from_users: ["unicornz-code"], pr_authors: [] },
+      { from_users: ["unicornz-code"], pr_authors: [""] },
+      {
+        exact: "@paseo assurance start",
+        from_users: ["unicornz-code"],
+        pr_author: ["unicornz-code"],
+      },
+    ]) {
+      assert.throws(() =>
+        compileHubConfig({
+          ...configuration(),
+          triggers: [{ ...trigger, filters }],
+        }),
+      );
+    }
+
+    const compiledTrigger = compiled.triggers[0];
+    assert.throws(() =>
+      parseCompiledHubConfig({
+        ...compiled,
+        triggers: [
+          {
+            ...compiledTrigger,
+            filters: { ...compiledTrigger.filters, pr_author: ["unicornz-code"] },
+          },
+        ],
+      }),
+    );
+  });
+
   it("compiles the complete multi-step contract and freezes it", () => {
     const compiled = compileHubConfig({
       ...configuration(),

--- a/src/config/compiler.ts
+++ b/src/config/compiler.ts
@@ -84,6 +84,7 @@ const AuthoredTriggerFilterSchema = z
   .object({
     pattern: z.string().optional(),
     contains: z.string().optional(),
+    exact: z.string().optional(),
     label: z.string().min(1).optional(),
     labels: z.array(z.string().min(1)).min(1).optional(),
     repo: z.string().min(1).optional(),
@@ -91,6 +92,7 @@ const AuthoredTriggerFilterSchema = z
     workspace: z.string().min(1).optional(),
     channels: z.array(z.string().min(1)).optional(),
     from_users: z.array(z.string().min(1)).optional(),
+    pr_authors: z.array(z.string().min(1)).min(1).optional(),
     inputs: z.record(z.string(), InputValueSchema).optional(),
     connection: z
       .string()
@@ -245,9 +247,10 @@ export interface CompiledStep {
 export type CompiledSteps = readonly CompiledStep[];
 
 export type CompiledTriggerFilter = Readonly<
-  Omit<AuthoredTriggerFilter, "channels" | "from_users"> & {
+  Omit<AuthoredTriggerFilter, "channels" | "from_users" | "pr_authors"> & {
     channels?: readonly string[] | undefined;
     from_users?: readonly string[] | undefined;
+    pr_authors?: readonly string[] | undefined;
     inputs?: Readonly<Record<string, JsonPrimitive>> | undefined;
     connectionId?: string | undefined;
     resourceId?: string | undefined;

--- a/src/triggers/github/match.test.ts
+++ b/src/triggers/github/match.test.ts
@@ -306,6 +306,177 @@ describe("GitHub trigger matching", () => {
     );
   });
 
+  it.each([
+    {
+      acceptance: "allows an exact PR comment from an approved PR author",
+      on: "github.pull_request_comment_created",
+      filters: { exact: "@paseo assurance start" },
+      event: eventFor("issue_comment", {
+        action: "created",
+        issue: {
+          ...issue({ user: { login: "unicornz-code" } }),
+          pull_request: {},
+        },
+        comment: comment({ body: "@paseo assurance start" }),
+      }),
+      expected: 1,
+    },
+    {
+      acceptance: "rejects a PR comment whose exact invocation has a suffix",
+      on: "github.pull_request_comment_created",
+      filters: { exact: "@paseo assurance start" },
+      event: eventFor("issue_comment", {
+        action: "created",
+        issue: {
+          ...issue({ user: { login: "unicornz-code" } }),
+          pull_request: {},
+        },
+        comment: comment({ body: "@paseo assurance start now" }),
+      }),
+      expected: 0,
+    },
+    {
+      acceptance: "rejects a PR comment whose exact invocation has a prefix",
+      on: "github.pull_request_comment_created",
+      filters: { exact: "@paseo assurance start" },
+      event: eventFor("issue_comment", {
+        action: "created",
+        issue: {
+          ...issue({ user: { login: "unicornz-code" } }),
+          pull_request: {},
+        },
+        comment: comment({ body: "please @paseo assurance start" }),
+      }),
+      expected: 0,
+    },
+    {
+      acceptance: "rejects a PR comment from a denied PR author",
+      on: "github.pull_request_comment_created",
+      filters: {},
+      event: eventFor("issue_comment", {
+        action: "created",
+        issue: {
+          ...issue({ user: { login: "someone-else" } }),
+          pull_request: {},
+        },
+        comment: comment(),
+      }),
+      expected: 0,
+    },
+    {
+      acceptance: "rejects a PR comment with a missing PR author",
+      on: "github.pull_request_comment_created",
+      filters: {},
+      event: eventFor("issue_comment", {
+        action: "created",
+        issue: {
+          ...issue({ user: undefined }),
+          pull_request: {},
+        },
+        comment: comment(),
+      }),
+      expected: 0,
+    },
+    {
+      acceptance: "rejects a bot-authored PR when the bot is omitted from the author allowlist",
+      on: "github.pull_request_comment_created",
+      filters: {},
+      event: eventFor("issue_comment", {
+        action: "created",
+        issue: {
+          ...issue({ user: { login: "clever-unicorn-paseo-hub[bot]" } }),
+          pull_request: {},
+        },
+        comment: comment(),
+      }),
+      expected: 0,
+    },
+    {
+      acceptance: "allows a PR label event from an approved PR author",
+      on: "github.pull_request_label_added",
+      filters: { label: "assurance" },
+      event: eventFor("pull_request", {
+        action: "labeled",
+        pull_request: pullRequest({ user: { login: "cleverunicorn" } }),
+        label: { name: "assurance" },
+      }),
+      expected: 1,
+    },
+    {
+      acceptance: "rejects a PR label event from a denied PR author",
+      on: "github.pull_request_label_added",
+      filters: { label: "assurance" },
+      event: eventFor("pull_request", {
+        action: "labeled",
+        pull_request: pullRequest({ user: { login: "someone-else" } }),
+        label: { name: "assurance" },
+      }),
+      expected: 0,
+    },
+    {
+      acceptance: "rejects a PR label event with a missing PR author",
+      on: "github.pull_request_label_added",
+      filters: { label: "assurance" },
+      event: eventFor("pull_request", {
+        action: "labeled",
+        pull_request: pullRequest({ user: undefined }),
+        label: { name: "assurance" },
+      }),
+      expected: 0,
+    },
+    {
+      acceptance: "rejects an issue even when its author is approved",
+      on: "github.issue_comment_created",
+      filters: {},
+      event: eventFor("issue_comment", {
+        action: "created",
+        issue: issue({ user: { login: "unicornz-code" } }),
+        comment: comment(),
+      }),
+      expected: 0,
+    },
+  ])("$acceptance", ({ on, filters, event, expected }) => {
+    const config = configFor({
+      from_users: ["boudra"],
+      pr_authors: ["unicornz-code", "cleverunicorn"],
+      ...filters,
+    });
+    const trigger = config.triggers[0]!;
+    const configured = { ...config, triggers: [{ ...trigger, on }] };
+
+    assert.equal(matchTriggers(configured, event).length, expected);
+  });
+
+  it("keeps PR authors independent from the event actor allowlist", () => {
+    const bot = "clever-unicorn-paseo-hub[bot]";
+    const config = configFor({
+      exact: "@paseo assurance continue",
+      from_users: ["unicornz-code", "cleverunicorn", bot],
+      pr_authors: ["unicornz-code", "cleverunicorn"],
+    });
+    const trigger = config.triggers[0]!;
+    const configured = {
+      ...config,
+      triggers: [{ ...trigger, on: "github.pull_request_comment_created" }],
+    };
+    const event = eventFor("issue_comment", {
+      action: "created",
+      issue: {
+        ...issue({ user: { login: "unicornz-code" } }),
+        pull_request: {},
+      },
+      comment: comment({ body: "@paseo assurance continue", user: { login: bot } }),
+    });
+
+    assert.equal(
+      matchTriggers(configured, {
+        ...event,
+        payload: { ...event.payload, sender: { login: bot } },
+      }).length,
+      1,
+    );
+  });
+
   it("applies the same security filters to pull-request review comments", () => {
     const config = compileHubConfig({
       environments: [{ name: "runner", kind: "daemon", daemon: "runner", cwd: "/repo" }],

--- a/src/triggers/github/match.ts
+++ b/src/triggers/github/match.ts
@@ -3,7 +3,7 @@ import type {
   TriggerFilter,
 } from "../../config/index.js";
 import type { NormalizedGitHubEvent } from "../../auth/github-events.js";
-import { classifyGitHubEvent } from "./classification.js";
+import { classifyGitHubEvent, type GitHubClassifiedEvent } from "./classification.js";
 
 type MatchedTriggerDefinition = Pick<CompiledTrigger, "name" | "on" | "filters">;
 
@@ -61,7 +61,7 @@ export function matchTriggers(
 }
 
 function matchesFilter(
-  classified: ReturnType<typeof classifyGitHubEvent>,
+  classified: GitHubClassifiedEvent,
   filter: TriggerFilter | undefined,
   event: NormalizedGitHubEvent,
   connectionId?: string | null,
@@ -85,6 +85,10 @@ function matchesFilter(
 
   const resourceId = filter["resourceId"];
   if (typeof resourceId === "string" && resourceId !== String(event.repositoryId)) {
+    return false;
+  }
+
+  if (!matchesExactAndPrAuthor(classified, filter)) {
     return false;
   }
 
@@ -116,6 +120,24 @@ function matchesFilter(
   }
 
   return true;
+}
+
+function matchesExactAndPrAuthor(
+  classified: GitHubClassifiedEvent,
+  filter: TriggerFilter,
+): boolean {
+  const exact = filter.exact;
+  if (exact !== undefined && classified.text !== exact) {
+    return false;
+  }
+
+  const prAuthors = filter.pr_authors;
+  return (
+    prAuthors === undefined ||
+    (classified.item?.type === "pull_request" &&
+      classified.item.author !== null &&
+      prAuthors.includes(classified.item.author.login))
+  );
 }
 
 function readStringFilter(


### PR DESCRIPTION
## Change

Add two fail-closed GitHub trigger filters:

- `exact`: full classified invocation-text equality
- `pr_authors`: non-empty allowlist requiring a classified pull-request item with an allowed GitHub-authenticated author login

Existing `from_users` continues to gate the event actor independently. This supports human-only campaign starts and autonomous bot continuations without admitting external- or bot-authored pull requests.

## Proof

- typecheck: clean
- lint: 0 findings
- targeted compiler/matcher tests: 81 passed
- full Hub tests: 1002 passed, 15 skipped

The change is backward compatible; existing trigger configurations are unchanged.