### PR TITLE
Honor the configured Hub origin behind proxies

### DIFF
--- a/src/http/node-server.test.ts
+++ b/src/http/node-server.test.ts
@@ -36,6 +36,45 @@ describe("trusted request origin metadata", () => {
       "https://hub.example.test",
     );
   });
+
+  it("uses the configured public origin instead of caller-controlled proxy metadata", async () => {
+    assert.equal(
+      await observedOrigin(
+        {
+          trustedClientIpHeader: "fly-client-ip",
+          canonicalRequestOrigin: "https://hub.example.test/path",
+        },
+        {
+          host: "internal:3000",
+          "x-forwarded-host": "attacker.example.test",
+          "x-forwarded-proto": "https",
+        },
+      ),
+      "https://hub.example.test",
+    );
+    assert.equal(
+      await observedOrigin(
+        { canonicalRequestOrigin: "https://hub.example.test" },
+        { host: "internal:3000", "x-forwarded-proto": "https" },
+      ),
+      "https://hub.example.test",
+    );
+  });
+
+  it("rejects a non-HTTP or credential-bearing configured public URL at startup", () => {
+    const handler = () => new Response("ok");
+    assert.throws(
+      () => createFetchServer(handler, { canonicalRequestOrigin: "ftp://hub.example.test" }),
+      /invalid origin/u,
+    );
+    assert.throws(
+      () =>
+        createFetchServer(handler, {
+          canonicalRequestOrigin: "https://operator:secret@hub.example.test",
+        }),
+      /invalid origin/u,
+    );
+  });
 });
 
 describe("CLI authorization client address", () => {
@@ -291,7 +330,7 @@ function closeServer(server: ReturnType<typeof createFetchServer>): Promise<void
 }
 
 async function observedOrigin(
-  options: { trustedClientIpHeader?: string },
+  options: { trustedClientIpHeader?: string; canonicalRequestOrigin?: string },
   headers: Record<string, string>,
 ): Promise<string> {
   const server = createFetchServer(

--- a/src/http/node-server.ts
+++ b/src/http/node-server.ts
@@ -22,6 +22,8 @@ interface StreamingRequestInit extends RequestInit {
 
 interface FetchServerOptions {
   trustedClientIpHeader?: string;
+  /** Explicit public URL whose origin is authoritative over proxy request metadata. */
+  canonicalRequestOrigin?: string;
   /** Test and embedded adapters may terminate TLS directly; production normally uses its proxy. */
   tls?: { key: string; cert: string };
   logger?: Pick<Logger, "warn" | "error">;
@@ -31,12 +33,18 @@ export function createFetchServer(
   fetchHandler: FetchHandler,
   options: FetchServerOptions = {},
 ): Server {
-  const handler = (request: IncomingMessage, response: ServerResponse) => {
-    void forwardRequest(fetchHandler, request, response, options);
+  const resolvedOptions = {
+    ...options,
+    ...(options.canonicalRequestOrigin === undefined
+      ? {}
+      : { canonicalRequestOrigin: parseHttpOrigin(options.canonicalRequestOrigin) }),
   };
-  return options.tls === undefined
+  const handler = (request: IncomingMessage, response: ServerResponse) => {
+    void forwardRequest(fetchHandler, request, response, resolvedOptions);
+  };
+  return resolvedOptions.tls === undefined
     ? createServer(handler)
-    : createHttpsServer(options.tls, handler);
+    : createHttpsServer(resolvedOptions.tls, handler);
 }
 
 async function forwardRequest(
@@ -241,6 +249,7 @@ function requestHeaders(incoming: IncomingMessage): Headers {
 }
 
 function requestOrigin(incoming: IncomingMessage, options: FetchServerOptions): string {
+  if (options.canonicalRequestOrigin !== undefined) return options.canonicalRequestOrigin;
   const directProtocol = Reflect.get(incoming.socket, "encrypted") === true ? "https" : "http";
   const directHost = incoming.headers.host;
   if (options.trustedClientIpHeader === undefined) {
@@ -251,6 +260,13 @@ function requestOrigin(incoming: IncomingMessage, options: FetchServerOptions): 
   return forwardedProtocol === undefined || forwardedHost === undefined
     ? validatedOrigin(directProtocol, directHost)
     : validatedOrigin(forwardedProtocol, forwardedHost);
+}
+
+function parseHttpOrigin(value: string): string {
+  const url = new URL(value);
+  if (url.protocol !== "http:" && url.protocol !== "https:") throw new Error("invalid origin");
+  if (url.username !== "" || url.password !== "") throw new Error("invalid origin");
+  return url.origin;
 }
 
 function firstForwardedValue(value: string | string[] | undefined): string | undefined {

--- a/src/index.ts
+++ b/src/index.ts
@@ -288,12 +288,13 @@ async function main(): Promise<void> {
   await build.startProductionRuntime();
   const config = loadRuntimeConfig();
   const port = readPort();
-  const server = createFetchServer(
-    (request) => build.default.fetch(request),
-    config.trustedClientIpHeader === undefined
+  const canonicalRequestOrigin = nonEmptyEnvironment(process.env["PASEO_HUB_APP_URL"]);
+  const server = createFetchServer((request) => build.default.fetch(request), {
+    ...(config.trustedClientIpHeader === undefined
       ? {}
-      : { trustedClientIpHeader: config.trustedClientIpHeader },
-  );
+      : { trustedClientIpHeader: config.trustedClientIpHeader }),
+    ...(canonicalRequestOrigin === undefined ? {} : { canonicalRequestOrigin }),
+  });
   server.on("upgrade", (request, socket, head) => {
     void handleDaemonUpgradeRequest({
       request,


### PR DESCRIPTION
Hub now treats an explicitly configured public app URL as the authoritative browser origin at the HTTP adapter. Sign-in and other browser mutations continue to work when TLS terminates before Hub and proxy headers do not reconstruct the public URL.

## Goals

- Make browser authentication honor the explicit public Hub URL.
- Prevent caller-controlled forwarded-host metadata from overriding that configured origin.
- Preserve direct and reverse-proxied self-hosted deployments that omit the explicit URL.
- Validate configured origins once when the HTTP server starts.

## Non-goals

- Change proxy-origin discovery for deployments without an explicit app URL.
- Change authentication, session, or provider behavior beyond origin validation.

## Why

The HTTP adapter always replaced its internal trusted-origin header from request metadata. Some TLS-terminating proxy paths provide the public protocol without a forwarded host, so the adapter produced an internal HTTP origin and browser authentication rejected the real HTTPS origin before checking credentials. Configuration already knows the canonical public URL; stamping its origin at the adapter gives every downstream consumer one authoritative value without teaching auth about individual proxies.

## Related work

Fixes #67.

## Supersedes

- [PR #70 — Prefer explicit HTTPS app URL over downgraded trusted origin](https://github.com/getpaseo/hub/pull/70) — This PR takes over the same reverse-proxy workflow at the HTTP metadata producer, covers sign-in as well as cookie mutations, and preserves unconfigured proxy discovery explicitly.

## Verification

- Failing-first adapter regression: configured origin overrides missing or hostile forwarded-host metadata.
- `npx vitest run src/http/node-server.test.ts --bail=1` — 11 passed.
- Built-app reverse-proxy/PGlite journey — passed, covering the existing self-hosted setup with no explicit app URL.
- `npm run typecheck` — passed.
- `npm run lint` — passed.
- `npm run format:check` — passed.
- `npm run build` — passed.

## Risk surface

The changed path is the internal trusted-origin value attached by the Node HTTP adapter. Explicit app URLs now win for every consumer; deployments without one retain the previous direct and trusted-proxy behavior. CI remains responsible for the container-backed PostgreSQL and full browser suites.
