### PR TITLE
fix(configuration): resolve Discord guild and Slack workspace filters by id

### DIFF
--- a/src/configuration/store.test.ts
+++ b/src/configuration/store.test.ts
@@ -87,6 +87,31 @@ describe("ProjectConfigurationStore resource compilation", () => {
     assert.deepEqual(storedAgent.options, options);
   });
 
+  it("accepts a Discord guild id as documented in filters.guild", async () => {
+    const database = createMemoryDatabase();
+    await enrollTestDaemon(database);
+    database.organizationConnectionUsage = () =>
+      Promise.resolve({ github: [], slack: [], discord: [primary] });
+    const project = await database.createProject({
+      organizationId: "org_1",
+      name: "Guild id project",
+      slug: "guild-id-project",
+      createdByUserId: "user-1",
+    });
+    const store = new ProjectConfigurationStore(database, project.id);
+
+    const revision = await store.insertManualBundleRevision({
+      files: configurationBundleFixture(dump(discordConfiguration({ guild: primary.guildId }))),
+      userId: "user-1",
+    });
+
+    assert.equal(revision.validationErrors, null);
+    const active = await store.activate(revision.id);
+    assert.equal(active.configuration.triggers[0]?.filters?.guild, primary.guildId);
+    assert.equal(active.configuration.triggers[0]?.filters?.connectionId, primary.id);
+    assert.equal(active.configuration.triggers[0]?.filters?.resourceId, primary.guildId);
+  });
+
   it("accepts guild and scopes an authored resource to an optional connection slug", async () => {
     const database = createMemoryDatabase();
     await enrollTestDaemon(database);

--- a/src/configuration/store.ts
+++ b/src/configuration/store.ts
@@ -685,14 +685,16 @@ async function resolveResource(
   }
   if (provider === "slack") {
     const connection = (await database.organizationConnectionUsage(organizationId)).slack.find(
-      ({ id, slug }) => slug === resource && allowedConnectionIds.has(id),
+      ({ id, slug, teamId }) =>
+        (teamId === resource || slug === resource) && allowedConnectionIds.has(id),
     );
     return connection === undefined
       ? undefined
       : { connectionId: connection.id, resourceId: connection.teamId };
   }
   const connection = (await database.organizationConnectionUsage(organizationId)).discord.find(
-    ({ id, slug }) => slug === resource && allowedConnectionIds.has(id),
+    ({ id, slug, guildId }) =>
+      (guildId === resource || slug === resource) && allowedConnectionIds.has(id),
   );
   return connection === undefined
     ? undefined


### PR DESCRIPTION
## Problem

`filters.guild` never matches a real Discord guild id. Activation fails with a message that names the very connection that owns the guild:

```
.paseo/workflows/discord-help.yml: filters.guild: "100000000000000000" does not match any Discord connection (connected: example-discord "Example")
```

The organization has a connection for exactly that guild:

```
      slug      |      guild_id      | guild_name
----------------+--------------------+------------
 example-discord| 100000000000000000 | Example
```

## Cause

`resolveResource` looks the connection up by **slug** but returns the **resource id**, so the lookup key and the resolved value disagree:

```ts
const connection = (await database.organizationConnectionUsage(organizationId)).discord.find(
  ({ id, slug }) => slug === resource && allowedConnectionIds.has(id),
);
return connection === undefined
  ? undefined
  : { connectionId: connection.id, resourceId: connection.guildId };
```

`resource` is `filters.guild` (via `readAuthoredResource`), so a snowflake id is compared to a slug such as `"example-discord"` and can never match. The Slack branch has the same shape with `teamId`. The GitHub branch above matches on the resource (`repository.fullName`) and is unaffected.

This contradicts the public docs, which state:

> Discord filters use IDs, not server names, display names, or Hub connection slugs.

and instruct users to obtain the value via **Copy Server ID**.

## Fix

Match on the resource id, while still accepting the connection slug:

```ts
({ id, slug, guildId }) =>
  (guildId === resource || slug === resource) && allowedConnectionIds.has(id),
```

I kept the slug arm deliberately. `store.test.ts` has a passing test that authors `guild: "discord-primary"` (a slug) and expects activation to succeed, and existing self-hosted configurations may rely on that. Dropping it would be a breaking change beyond the scope of this bug. Happy to cut it if you would rather take the hard change per `AGENTS.md`.

## Tests

Added `accepts a Discord guild id as documented in filters.guild`, which asserts the authored guild id activates and compiles to the right `connectionId`/`resourceId`.

Verified it is a real regression test: on `main` it fails at `assert.equal(revision.validationErrors, null)`; with the fix it passes.

The existing rejection test still passes unchanged — its id (`1481169421832814616`) is not `primary.guildId` (`"100"`), so an unknown guild is still correctly rejected.

```
src/configuration + src/triggers:  208 passed | 1 skipped
npm run typecheck:                 clean
oxlint / oxfmt:                    clean
```

## Verification against a live instance

Same bundle, same database, only the image differs:

| Image | Result |
|---|---|
| `ghcr.io/getpaseo/hub:latest` (0.8.0) | `Error: ... does not match any Discord connection` |
| locally built with this patch | `PROJECT default · VALID true · WORKFLOWS 1` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
