### PR TITLE
Offer cardless Hosted trials

### DIFF
--- a/docs/billing.md
+++ b/docs/billing.md
@@ -44,14 +44,32 @@ boot sync racy right after a dashboard edit.
 `GET /api/billing/plans` is documented in docs/public-api.md — marketing copy and pricing only,
 never the entitlement template.
 
+## The offer, and the record that is not one
+
+The Stripe catalog carries a `free` product. It is not a tier Hub sells: it is where the
+entitlement floor is authored, so provisioning and cancellation have a real template to stamp
+instead of a constant in the code. Hosted Hub sells exactly one plan today — Paseo Hub, per user,
+per month.
+
+`BillingRuntime.publicCatalog` is the boundary that keeps those two apart. It withholds the free
+record and every plan the sync deactivated, so "the catalog" and "the offer" are the same thing to
+every consumer — the plans endpoint, the billing overview, the picker. `subscriptionSnapshot` is
+the other half: an organization stamped with the free record reports **no plan**, which is why the
+billing page reads as a paywall rather than advertising a zero-execution tier as the customer's
+own. No consumer knows the slug exists, and none should learn it.
+
+Nothing about this is hardcoded to one plan. Publish a second product in Stripe and the picker
+lays out two columns; publish an annual price and the interval switch appears. What is fixed is
+that a customer only ever sees what Stripe says is for sale.
+
 ## Free-tier provisioning
 
-A hosted organization is provisioned with the Free plan's template resolved from the mirror
+A hosted organization is provisioned with the free record's template resolved from the mirror
 (`BillingRuntime.provisioningEntitlement`), not the unlimited default self-hosted gets. If the
-mirror has no active Free plan yet — first boot before sync, or a Stripe account missing the
+mirror has no active free record yet — first boot before sync, or a Stripe account missing the
 product — provisioning falls back to `FREE_TIER_FALLBACK`. The fallback fails closed rather than
 open to unlimited and logs loudly so the gap gets noticed; every organization stamped from it
-re-stamps to the real Free plan the moment it subscribes.
+re-stamps to the real template the moment it subscribes.
 
 The billing view derives the current plan from what the organization was last _stamped_ with, not
 from a copied Stripe subscription. It reads Stripe only for the billing page, through a short,
@@ -67,7 +85,8 @@ plan-picker dialog and a "Manage billing" button — payment methods, invoices, 
 stay in the Stripe portal.
 
 Inside `src/billing/ui/`, `panel.tsx` owns the page, `plan-dialog.tsx` owns the picker, and
-`presentation.tsx` owns every user-facing string either of them renders. Copy lives there and
+`presentation.tsx` owns every user-facing string either of them renders. None of them knows which
+plans are for sale — that is settled before the view, in `public-catalog.ts`. Copy lives there and
 nowhere else because it is the only part of the surface worth unit-testing: a button label has to
 stay short enough for a narrow plan column while its accessible name still identifies the plan,
 and a catalog published monthly-only has to collapse the interval switch rather than price a
@@ -84,7 +103,7 @@ The subscription webhook (`BillingRuntime.handleWebhook`) reconciles rather than
 only the subscription id from the event, then — under a per-organization advisory lock that
 serializes across processes — re-reads the subscription's live state and converges the
 organization onto it: resolve the price to a plan (resyncing the catalog once when a subscription
-webhook beat its own price webhook), then stamp the plan's template, or stamp Free on a terminal
+webhook beat its own price webhook), then stamp the plan's template, or stamp the free floor on a terminal
 cancellation so paid entitlements never outlive the subscription. The subscription mirror and the
 entitlement stamp commit in one transaction (`Database.reconcileOrganizationSubscription`), so the
 two can never disagree across a crash. Re-reading current state under the lock is what stops an
@@ -96,7 +115,7 @@ state nothing would revisit.
 `organization_billing_customers` is the sole durable Stripe identity link. It deliberately does
 not copy subscription status, price, cancellation, or period timestamps; Stripe remains the owner
 of that lifecycle. `trialing` and `active` stamp Hosted access; `canceled`, `incomplete_expired`,
-and `unpaid` stamp Free; `past_due` retains the last stamp during Stripe's retry window.
+and `unpaid` stamp the free floor; `past_due` retains the last stamp during Stripe's retry window.
 
 ## Seats
 
@@ -107,7 +126,7 @@ to `BillingRuntime.reportSeatUsage`. The reporter reads the live count and write
 when it differs from what the subscription is currently billed for — so the resulting
 `customer.subscription.updated` echo carries no delta and cannot ping-pong with reconciliation.
 Reconciliation re-checks the count on every subscription webhook, the durable backstop if a
-post-commit report is lost. Only paid plans report; the Free plan caps seats instead
+post-commit report is lost. Only paid plans report; the free floor caps seats instead
 (`ent_seats_max=1`, `ent_can_invite=false`).
 
 ### Why not `@better-auth/stripe`

--- a/docs/billing.md
+++ b/docs/billing.md
@@ -63,8 +63,15 @@ single-flight in-memory cache; execution and workflow paths read the local entit
 `src/billing/stripe-catalog-source.ts`) are narrow ports: production wires the real Stripe SDK
 (`src/billing/stripe-client.ts`), the E2E harness wires a fixture, and a caller never learns
 which. Checkout and the billing portal are Stripe-hosted; Hub's own dashboard surface is a
-plan-picker dialog and a "Manage billing" link — payment methods, invoices, and cancellation stay
-in the Stripe portal.
+plan-picker dialog and a "Manage billing" button — payment methods, invoices, and cancellation
+stay in the Stripe portal.
+
+Inside `src/billing/ui/`, `panel.tsx` owns the page, `plan-dialog.tsx` owns the picker, and
+`presentation.tsx` owns every user-facing string either of them renders. Copy lives there and
+nowhere else because it is the only part of the surface worth unit-testing: a button label has to
+stay short enough for a narrow plan column while its accessible name still identifies the plan,
+and a catalog published monthly-only has to collapse the interval switch rather than price a
+column at "—".
 
 The first subscribe starts a Stripe-owned 14-day trial: Checkout uses
 `payment_method_collection=if_required` and `trial_settings.end_behavior.missing_payment_method=cancel`,

--- a/docs/billing.md
+++ b/docs/billing.md
@@ -54,9 +54,8 @@ open to unlimited and logs loudly so the gap gets noticed; every organization st
 re-stamps to the real Free plan the moment it subscribes.
 
 The billing view derives the current plan from what the organization was last _stamped_ with, not
-from a Stripe subscription (`BillingRuntime.subscriptionSnapshot`) — so a provisioned Free
-organization reads "Free" rather than "No active plan", and a canceled one reads Free again. The
-subscription mirror only decides whether there is a live subscription to manage.
+from a copied Stripe subscription. It reads Stripe only for the billing page, through a short,
+single-flight in-memory cache; execution and workflow paths read the local entitlement stamp only.
 
 ## Checkout, portal, subscriptions
 
@@ -67,12 +66,12 @@ which. Checkout and the billing portal are Stripe-hosted; Hub's own dashboard su
 plan-picker dialog and a "Manage billing" link — payment methods, invoices, and cancellation stay
 in the Stripe portal.
 
-The first subscribe and a plan change are two different Stripe operations, and
-`BillingRuntime.createCheckout` picks the right one: with no subscription yet it opens a Checkout
-Session; once one exists, a change updates that single subscription's item in place
-(`changeSubscriptionPrice`) rather than opening a second checkout or a second subscription. Stripe
-models a plan change as an update to the one subscription, so an organization holds exactly one
-for its lifetime.
+The first subscribe starts a Stripe-owned 14-day trial: Checkout uses
+`payment_method_collection=if_required` and `trial_settings.end_behavior.missing_payment_method=cancel`,
+so it collects no card. Stripe subscription history determines eligibility; any former
+subscription receives ordinary paid Checkout. Customer, Checkout, and subscription metadata carry
+the organization id, and idempotency keys collapse concurrent Checkout attempts. During a trial,
+the Stripe portal remains available to add a card voluntarily.
 
 The subscription webhook (`BillingRuntime.handleWebhook`) reconciles rather than applies. It takes
 only the subscription id from the event, then — under a per-organization advisory lock that
@@ -87,8 +86,10 @@ pure replay a no-op. When it cannot reconcile yet — a price still not in the m
 unreadable subscription — it returns a non-2xx so Stripe redelivers, rather than acknowledging a
 state nothing would revisit.
 
-`organization_subscriptions` (`src/db/schema.ts:1133`) is a table this repo owns and keys
-directly by `organization_id`, deliberately not part of Better Auth's schema.
+`organization_billing_customers` is the sole durable Stripe identity link. It deliberately does
+not copy subscription status, price, cancellation, or period timestamps; Stripe remains the owner
+of that lifecycle. `trialing` and `active` stamp Hosted access; `canceled`, `incomplete_expired`,
+and `unpaid` stamp Free; `past_due` retains the last stamp during Stripe's retry window.
 
 ## Seats
 

--- a/docs/billing.md
+++ b/docs/billing.md
@@ -88,9 +88,14 @@ Inside `src/billing/ui/`, `panel.tsx` owns the page, `plan-dialog.tsx` owns the 
 `presentation.tsx` owns every user-facing string either of them renders. None of them knows which
 plans are for sale — that is settled before the view, in `public-catalog.ts`. Copy lives there and
 nowhere else because it is the only part of the surface worth unit-testing: a button label has to
-stay short enough for a narrow plan column while its accessible name still identifies the plan,
-and a catalog published monthly-only has to collapse the interval switch rather than price a
-column at "—".
+stay short enough for a narrow plan column while its accessible name still identifies the plan.
+
+Both surfaces render the offer and nothing around it. The picker has no heading (its dialog title
+is read, not shown), no framing sentence, and no interval switch unless the catalog prices more
+than one interval. The page offers "Change plan" only when there is more than one public plan to
+change to; with one offer, the way out is Manage billing. Everything here is driven off the
+catalog, so a second product or an annual price restores the controls without a redesign — but
+nothing that has no meaning today is rendered today.
 
 The first subscribe starts a Stripe-owned 14-day trial: Checkout uses
 `payment_method_collection=if_required` and `trial_settings.end_behavior.missing_payment_method=cancel`,

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -45,23 +45,32 @@ entitlement template (`granted` caps/flags/meters); that stays internal to `src/
 `src/entitlements/`. This is the shape the marketing site (paseo.sh) fetches to render pricing;
 Hub itself has no pricing page.
 
+It returns the plans that are for sale. The catalog also carries the internal record that
+authors the no-subscription entitlement floor; that one is withheld here and everywhere else a
+customer can see. Today the hosted offer is one plan:
+
 ```json
 {
   "plans": [
     {
-      "slug": "solo",
-      "name": "Solo",
-      "marketingFeatures": ["Unlimited seats", "2,000 executions / month", "Email support"],
+      "slug": "hosted",
+      "name": "Paseo Hub",
+      "marketingFeatures": [
+        "Unlimited daemons",
+        "GitHub, Linear, Slack, and Discord triggers",
+        "Versioned workflows and activity",
+        "Bring your own agents and inference"
+      ],
       "prices": {
-        "monthly": { "unitAmount": 2900, "currency": "usd" },
-        "annual": { "unitAmount": 29000, "currency": "usd" }
+        "monthly": { "unitAmount": 1500, "currency": "eur" },
+        "annual": null
       }
     }
   ]
 }
 ```
 
-`unitAmount` is in the smallest currency unit (cents for `usd`), matching Stripe's own `Price`
+`unitAmount` is in the smallest currency unit (cents for `eur`), matching Stripe's own `Price`
 convention. An interval is `null` when the plan has no active price at that interval. A
 self-hosted instance without `STRIPE_SECRET_KEY` 404s this route rather than serving an empty
 catalog — the billing boundary means the route is never registered on an unconfigured instance.

--- a/drizzle/0041_parched_bucky.sql
+++ b/drizzle/0041_parched_bucky.sql
@@ -1,0 +1,10 @@
+ALTER TABLE "organization_subscriptions" RENAME TO "organization_billing_customers";--> statement-breakpoint
+ALTER TABLE "organization_billing_customers" DROP CONSTRAINT "organization_subscriptions_stripe_subscription_id_unique";--> statement-breakpoint
+ALTER TABLE "organization_billing_customers" DROP CONSTRAINT "organization_subscriptions_organization_id_organization_id_fk";
+--> statement-breakpoint
+ALTER TABLE "organization_billing_customers" ADD CONSTRAINT "organization_billing_customers_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "organization_billing_customers" DROP COLUMN "stripe_subscription_id";--> statement-breakpoint
+ALTER TABLE "organization_billing_customers" DROP COLUMN "plan_id";--> statement-breakpoint
+ALTER TABLE "organization_billing_customers" DROP COLUMN "status";--> statement-breakpoint
+ALTER TABLE "organization_billing_customers" DROP COLUMN "current_period_end";--> statement-breakpoint
+ALTER TABLE "organization_billing_customers" DROP COLUMN "cancel_at_period_end";

--- a/drizzle/meta/0041_snapshot.json
+++ b/drizzle/meta/0041_snapshot.json
@@ -1,0 +1,5373 @@
+{
+  "id": "4e5c800d-0d7b-4146-9291-e509a02551b0",
+  "prevId": "d33de8b2-34b6-45da-ae3f-35ae2b070c26",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_executions": {
+      "name": "agent_executions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "machine_id": {
+          "name": "machine_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_execution_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_by_agent_at": {
+          "name": "completed_by_agent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deadline_at": {
+          "name": "deadline_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idle_deadline_at": {
+          "name": "idle_deadline_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_context": {
+          "name": "trigger_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_context": {
+          "name": "output_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reaction_state": {
+          "name": "reaction_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "configuration_revision_id": {
+          "name": "configuration_revision_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completion_token_hash": {
+          "name": "completion_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_claimed_at": {
+          "name": "reply_claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_claim_count": {
+          "name": "reply_claim_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_emissions": {
+          "name": "output_emissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "output_delivery_attempts": {
+          "name": "output_delivery_attempts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "launch_intent": {
+          "name": "launch_intent",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daemon_id": {
+          "name": "daemon_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daemon_agent_id": {
+          "name": "daemon_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_step_run_id": {
+          "name": "workflow_step_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hub_action": {
+          "name": "hub_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hub_action_completed_at": {
+          "name": "hub_action_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hub_action_ready_at": {
+          "name": "hub_action_ready_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hub_action_acknowledgements": {
+          "name": "hub_action_acknowledgements",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"terminal_at\":null,\"idle_at\":null,\"finish_execution_call\":null}'::jsonb"
+        }
+      },
+      "indexes": {
+        "agent_executions_machine_id_idx": {
+          "name": "agent_executions_machine_id_idx",
+          "columns": [
+            {
+              "expression": "machine_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_executions_project_started_at_idx": {
+          "name": "agent_executions_project_started_at_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_executions_status_idx": {
+          "name": "agent_executions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_executions_project_organization_fk": {
+          "name": "agent_executions_project_organization_fk",
+          "tableFrom": "agent_executions",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id", "organization_id"],
+          "columnsTo": ["id", "organization_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agent_executions_revision_project_organization_fk": {
+          "name": "agent_executions_revision_project_organization_fk",
+          "tableFrom": "agent_executions",
+          "tableTo": "project_configuration_revisions",
+          "columnsFrom": ["configuration_revision_id", "project_id", "organization_id"],
+          "columnsTo": ["id", "project_id", "organization_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agent_executions_machine_organization_fk": {
+          "name": "agent_executions_machine_organization_fk",
+          "tableFrom": "agent_executions",
+          "tableTo": "machines",
+          "columnsFrom": ["machine_id", "organization_id"],
+          "columnsTo": ["id", "org_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agent_executions_daemon_organization_fk": {
+          "name": "agent_executions_daemon_organization_fk",
+          "tableFrom": "agent_executions",
+          "tableTo": "daemons",
+          "columnsFrom": ["daemon_id", "organization_id"],
+          "columnsTo": ["id", "organization_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agent_executions_workflow_step_run_fk": {
+          "name": "agent_executions_workflow_step_run_fk",
+          "tableFrom": "agent_executions",
+          "tableTo": "workflow_step_runs",
+          "columnsFrom": ["workflow_step_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agent_executions_hub_action_check": {
+          "name": "agent_executions_hub_action_check",
+          "value": "\"agent_executions\".\"hub_action\" is null or \"agent_executions\".\"hub_action\" in ('interrupt', 'archive')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.attachment_capabilities": {
+      "name": "attachment_capabilities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider_event_receipt_id": {
+          "name": "provider_event_receipt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locator": {
+          "name": "locator",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "attachment_capabilities_receipt_provider_source_unique": {
+          "name": "attachment_capabilities_receipt_provider_source_unique",
+          "columns": [
+            {
+              "expression": "provider_event_receipt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attachment_capabilities_receipt_idx": {
+          "name": "attachment_capabilities_receipt_idx",
+          "columns": [
+            {
+              "expression": "provider_event_receipt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "attachment_capabilities_organization_id_organization_id_fk": {
+          "name": "attachment_capabilities_organization_id_organization_id_fk",
+          "tableFrom": "attachment_capabilities",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attachment_capabilities_receipt_organization_fk": {
+          "name": "attachment_capabilities_receipt_organization_fk",
+          "tableFrom": "attachment_capabilities",
+          "tableTo": "provider_event_receipts",
+          "columnsFrom": ["provider_event_receipt_id", "organization_id"],
+          "columnsTo": ["id", "organization_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "attachment_capabilities_provider_check": {
+          "name": "attachment_capabilities_provider_check",
+          "value": "\"attachment_capabilities\".\"provider\" in ('slack', 'discord')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_kind": {
+          "name": "actor_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_identity": {
+          "name": "actor_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_events_organization_created_idx": {
+          "name": "audit_events_organization_created_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_events_project_created_idx": {
+          "name": "audit_events_project_created_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_events_organization_id_organization_id_fk": {
+          "name": "audit_events_organization_id_organization_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audit_events_project_id_projects_id_fk": {
+          "name": "audit_events_project_id_projects_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audit_events_project_organization_fk": {
+          "name": "audit_events_project_organization_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id", "organization_id"],
+          "columnsTo": ["id", "organization_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "audit_events_actor_kind_check": {
+          "name": "audit_events_actor_kind_check",
+          "value": "\"audit_events\".\"actor_kind\" in ('user', 'github', 'system')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.billing_plan_prices": {
+      "name": "billing_plan_prices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lookup_key": {
+          "name": "lookup_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interval": {
+          "name": "interval",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_amount": {
+          "name": "unit_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "billing_plan_prices_plan_id_idx": {
+          "name": "billing_plan_prices_plan_id_idx",
+          "columns": [
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "billing_plan_prices_plan_id_billing_plans_id_fk": {
+          "name": "billing_plan_prices_plan_id_billing_plans_id_fk",
+          "tableFrom": "billing_plan_prices",
+          "tableTo": "billing_plans",
+          "columnsFrom": ["plan_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "billing_plan_prices_interval_check": {
+          "name": "billing_plan_prices_interval_check",
+          "value": "\"billing_plan_prices\".\"interval\" in ('monthly', 'annual')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.billing_plans": {
+      "name": "billing_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template": {
+          "name": "template",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_hash": {
+          "name": "template_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "marketing": {
+          "name": "marketing",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "billing_plans_slug_unique": {
+          "name": "billing_plans_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cli_authorizations": {
+      "name": "cli_authorizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_verifier": {
+          "name": "device_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code_verifier": {
+          "name": "user_code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint_verifier": {
+          "name": "fingerprint_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "poll_interval_seconds": {
+          "name": "poll_interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_poll_at": {
+          "name": "next_poll_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_organization_id": {
+          "name": "approved_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by_user_id": {
+          "name": "approved_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "cli_authorizations_fingerprint_idx": {
+          "name": "cli_authorizations_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "fingerprint_verifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cli_authorizations_status_expiry_idx": {
+          "name": "cli_authorizations_status_expiry_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cli_authorizations_device_verifier_unique": {
+          "name": "cli_authorizations_device_verifier_unique",
+          "nullsNotDistinct": false,
+          "columns": ["device_verifier"]
+        },
+        "cli_authorizations_user_code_verifier_unique": {
+          "name": "cli_authorizations_user_code_verifier_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_code_verifier"]
+        },
+        "cli_authorizations_credential_id_unique": {
+          "name": "cli_authorizations_credential_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["credential_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "cli_authorizations_status_check": {
+          "name": "cli_authorizations_status_check",
+          "value": "\"cli_authorizations\".\"status\" in ('pending', 'approved', 'denied', 'expired', 'disclosed')"
+        },
+        "cli_authorizations_poll_interval_check": {
+          "name": "cli_authorizations_poll_interval_check",
+          "value": "\"cli_authorizations\".\"poll_interval_seconds\" >= 5"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.configuration_sync_attempts": {
+      "name": "configuration_sync_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_connection_id": {
+          "name": "github_connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_repository_id": {
+          "name": "github_repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_delivery_id": {
+          "name": "webhook_delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "configuration_sync_attempts_project_created_idx": {
+          "name": "configuration_sync_attempts_project_created_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "configuration_sync_attempts_project_organization_fk": {
+          "name": "configuration_sync_attempts_project_organization_fk",
+          "tableFrom": "configuration_sync_attempts",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id", "organization_id"],
+          "columnsTo": ["id", "organization_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "configuration_sync_attempts_github_connection_organization_fk": {
+          "name": "configuration_sync_attempts_github_connection_organization_fk",
+          "tableFrom": "configuration_sync_attempts",
+          "tableTo": "github_connections",
+          "columnsFrom": ["github_connection_id", "organization_id"],
+          "columnsTo": ["id", "organization_id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daemon_enrollment_tokens": {
+      "name": "daemon_enrollment_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "verifier": {
+          "name": "verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_by_api_key_id": {
+          "name": "issued_by_api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_by_cli_credential_id": {
+          "name": "issued_by_cli_credential_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "daemon_enrollment_tokens_issued_by_cli_credential_id_organization_cli_credentials_id_fk": {
+          "name": "daemon_enrollment_tokens_issued_by_cli_credential_id_organization_cli_credentials_id_fk",
+          "tableFrom": "daemon_enrollment_tokens",
+          "tableTo": "organization_cli_credentials",
+          "columnsFrom": ["issued_by_cli_credential_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "daemon_enrollment_tokens_verifier_unique": {
+          "name": "daemon_enrollment_tokens_verifier_unique",
+          "nullsNotDistinct": false,
+          "columns": ["verifier"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daemons": {
+      "name": "daemons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enrollment_verifier": {
+          "name": "enrollment_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "machine_id": {
+          "name": "machine_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "daemon_public_key": {
+          "name": "daemon_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_verifier": {
+          "name": "credential_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registered_by_api_key_id": {
+          "name": "registered_by_api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registered_by_cli_credential_id": {
+          "name": "registered_by_cli_credential_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "presence": {
+          "name": "presence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'offline'"
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disconnected_at": {
+          "name": "disconnected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "daemons_machine_id_unique": {
+          "name": "daemons_machine_id_unique",
+          "columns": [
+            {
+              "expression": "machine_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "daemons_id_organization_unique": {
+          "name": "daemons_id_organization_unique",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "daemons_organization_slug_unique": {
+          "name": "daemons_organization_slug_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daemons_registered_by_cli_credential_id_organization_cli_credentials_id_fk": {
+          "name": "daemons_registered_by_cli_credential_id_organization_cli_credentials_id_fk",
+          "tableFrom": "daemons",
+          "tableTo": "organization_cli_credentials",
+          "columnsFrom": ["registered_by_cli_credential_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "daemons_machine_organization_fk": {
+          "name": "daemons_machine_organization_fk",
+          "tableFrom": "daemons",
+          "tableTo": "machines",
+          "columnsFrom": ["machine_id", "organization_id"],
+          "columnsTo": ["id", "org_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "daemons_idempotency_key_unique": {
+          "name": "daemons_idempotency_key_unique",
+          "nullsNotDistinct": false,
+          "columns": ["idempotency_key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "daemons_status_check": {
+          "name": "daemons_status_check",
+          "value": "\"daemons\".\"status\" in ('active', 'revoked')"
+        },
+        "daemons_presence_check": {
+          "name": "daemons_presence_check",
+          "value": "\"daemons\".\"presence\" in ('offline', 'connected')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.discord_connections": {
+      "name": "discord_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_application_id": {
+          "name": "provider_application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guild_name": {
+          "name": "guild_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connected_by_user_id": {
+          "name": "connected_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discord_connections_id_organization_unique": {
+          "name": "discord_connections_id_organization_unique",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discord_connections_organization_slug_unique": {
+          "name": "discord_connections_organization_slug_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_connections_organization_id_organization_id_fk": {
+          "name": "discord_connections_organization_id_organization_id_fk",
+          "tableFrom": "discord_connections",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "discord_connections_connected_by_user_id_user_id_fk": {
+          "name": "discord_connections_connected_by_user_id_user_id_fk",
+          "tableFrom": "discord_connections",
+          "tableTo": "user",
+          "columnsFrom": ["connected_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discord_connections_guild_id_unique": {
+          "name": "discord_connections_guild_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["guild_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entitlement_changes": {
+      "name": "entitlement_changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "before": {
+          "name": "before",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after": {
+          "name": "after",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "entitlement_changes_organization_created_idx": {
+          "name": "entitlement_changes_organization_created_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entitlement_changes_organization_id_organization_id_fk": {
+          "name": "entitlement_changes_organization_id_organization_id_fk",
+          "tableFrom": "entitlement_changes",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "entitlement_changes_source_check": {
+          "name": "entitlement_changes_source_check",
+          "value": "\"entitlement_changes\".\"source\" in ('provisioning', 'plan_stamp', 'override')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.github_connections": {
+      "name": "github_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_application_id": {
+          "name": "provider_application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connected_by_user_id": {
+          "name": "connected_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "github_connections_installation_unique": {
+          "name": "github_connections_installation_unique",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_connections_organization_slug_unique": {
+          "name": "github_connections_organization_slug_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_connections_id_organization_unique": {
+          "name": "github_connections_id_organization_unique",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_connections_organization_idx": {
+          "name": "github_connections_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_connections_organization_id_organization_id_fk": {
+          "name": "github_connections_organization_id_organization_id_fk",
+          "tableFrom": "github_connections",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_connections_connected_by_user_id_user_id_fk": {
+          "name": "github_connections_connected_by_user_id_user_id_fk",
+          "tableFrom": "github_connections",
+          "tableTo": "user",
+          "columnsFrom": ["connected_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "github_connections_installation_id_unique": {
+          "name": "github_connections_installation_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["installation_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "github_connections_status_check": {
+          "name": "github_connections_status_check",
+          "value": "\"github_connections\".\"status\" in ('active', 'suspended')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.github_repositories": {
+      "name": "github_repositories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discovered_at": {
+          "name": "discovered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_repositories_connection_repository_unique": {
+          "name": "github_repositories_connection_repository_unique",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_repositories_organization_idx": {
+          "name": "github_repositories_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_repositories_connection_organization_fk": {
+          "name": "github_repositories_connection_organization_fk",
+          "tableFrom": "github_repositories",
+          "tableTo": "github_connections",
+          "columnsFrom": ["connection_id", "organization_id"],
+          "columnsTo": ["id", "organization_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instance_bootstrap": {
+      "name": "instance_bootstrap",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "app_onboarding_completed_at": {
+          "name": "app_onboarding_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "instance_bootstrap_organization_id_organization_id_fk": {
+          "name": "instance_bootstrap_organization_id_organization_id_fk",
+          "tableFrom": "instance_bootstrap",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "instance_bootstrap_owner_user_id_user_id_fk": {
+          "name": "instance_bootstrap_owner_user_id_user_id_fk",
+          "tableFrom": "instance_bootstrap",
+          "tableTo": "user",
+          "columnsFrom": ["owner_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "instance_bootstrap_completion_check": {
+          "name": "instance_bootstrap_completion_check",
+          "value": "\"instance_bootstrap\".\"completed_at\" is null or (\"instance_bootstrap\".\"organization_id\" is not null and \"instance_bootstrap\".\"owner_user_id\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitations_organization_status_idx": {
+          "name": "invitations_organization_status_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitations_pending_organization_email_unique": {
+          "name": "invitations_pending_organization_email_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invitation\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": ["inviter_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "invitations_role_check": {
+          "name": "invitations_role_check",
+          "value": "\"invitation\".\"role\" in ('admin', 'member')"
+        },
+        "invitations_status_check": {
+          "name": "invitations_status_check",
+          "value": "\"invitation\".\"status\" in ('pending', 'accepted', 'rejected', 'canceled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.linear_connections": {
+      "name": "linear_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linear_organization_id": {
+          "name": "linear_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_application_id": {
+          "name": "provider_application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linear_organization_name": {
+          "name": "linear_organization_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_user_id": {
+          "name": "app_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "connected_by_user_id": {
+          "name": "connected_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "linear_connections_id_organization_unique": {
+          "name": "linear_connections_id_organization_unique",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "linear_connections_organization_slug_unique": {
+          "name": "linear_connections_organization_slug_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "linear_connections_organization_external_unique": {
+          "name": "linear_connections_organization_external_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "linear_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "linear_connections_organization_id_organization_id_fk": {
+          "name": "linear_connections_organization_id_organization_id_fk",
+          "tableFrom": "linear_connections",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "linear_connections_connected_by_user_id_user_id_fk": {
+          "name": "linear_connections_connected_by_user_id_user_id_fk",
+          "tableFrom": "linear_connections",
+          "tableTo": "user",
+          "columnsFrom": ["connected_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "linear_connections_linear_organization_id_unique": {
+          "name": "linear_connections_linear_organization_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["linear_organization_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.machines": {
+      "name": "machines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "machine_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "terminated_at": {
+          "name": "terminated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shutdown_reason": {
+          "name": "shutdown_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_name": {
+          "name": "trigger_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_context": {
+          "name": "trigger_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "specs": {
+          "name": "specs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "machines_id_org_id_unique": {
+          "name": "machines_id_org_id_unique",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "machines_org_id_idx": {
+          "name": "machines_org_id_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "machines_status_idx": {
+          "name": "machines_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "members_organization_user_unique": {
+          "name": "members_organization_user_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "members_user_id_idx": {
+          "name": "members_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "members_organization_id_idx": {
+          "name": "members_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "members_role_check": {
+          "name": "members_role_check",
+          "value": "\"member\".\"role\" in ('owner', 'admin', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_api_keys": {
+      "name": "organization_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verifier": {
+          "name": "verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "organization_api_keys_prefix_unique": {
+          "name": "organization_api_keys_prefix_unique",
+          "columns": [
+            {
+              "expression": "prefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organization_api_keys_organization_created_idx": {
+          "name": "organization_api_keys_organization_created_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_api_keys_organization_id_organization_id_fk": {
+          "name": "organization_api_keys_organization_id_organization_id_fk",
+          "tableFrom": "organization_api_keys",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_api_keys_created_by_user_id_user_id_fk": {
+          "name": "organization_api_keys_created_by_user_id_user_id_fk",
+          "tableFrom": "organization_api_keys",
+          "tableTo": "user",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "organization_api_keys_scopes_check": {
+          "name": "organization_api_keys_scopes_check",
+          "value": "\"organization_api_keys\".\"scopes\" <@ ARRAY['projects:read', 'configuration:validate', 'configuration:install', 'runs:dispatch', 'daemons:enroll']::text[] and cardinality(\"organization_api_keys\".\"scopes\") > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_billing_customers": {
+      "name": "organization_billing_customers",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_billing_customers_organization_id_organization_id_fk": {
+          "name": "organization_billing_customers_organization_id_organization_id_fk",
+          "tableFrom": "organization_billing_customers",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_cli_credentials": {
+      "name": "organization_cli_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verifier": {
+          "name": "verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "organization_cli_credentials_prefix_unique": {
+          "name": "organization_cli_credentials_prefix_unique",
+          "columns": [
+            {
+              "expression": "prefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organization_cli_credentials_organization_created_idx": {
+          "name": "organization_cli_credentials_organization_created_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_cli_credentials_organization_id_organization_id_fk": {
+          "name": "organization_cli_credentials_organization_id_organization_id_fk",
+          "tableFrom": "organization_cli_credentials",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_cli_credentials_created_by_user_id_user_id_fk": {
+          "name": "organization_cli_credentials_created_by_user_id_user_id_fk",
+          "tableFrom": "organization_cli_credentials",
+          "tableTo": "user",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_connection_attempts": {
+      "name": "organization_connection_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_verifier": {
+          "name": "state_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "return_route": {
+          "name": "return_route",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_external_id": {
+          "name": "candidate_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pkce_verifier": {
+          "name": "pkce_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "configuration_version": {
+          "name": "configuration_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_application_id": {
+          "name": "provider_application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "callback_origin": {
+          "name": "callback_origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configuration_snapshot": {
+          "name": "configuration_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_configuration_version": {
+          "name": "expected_configuration_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activate_configuration": {
+          "name": "activate_configuration",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "organization_connection_attempts_expiry_idx": {
+          "name": "organization_connection_attempts_expiry_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_connection_attempts_organization_id_organization_id_fk": {
+          "name": "organization_connection_attempts_organization_id_organization_id_fk",
+          "tableFrom": "organization_connection_attempts",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_connection_attempts_user_id_user_id_fk": {
+          "name": "organization_connection_attempts_user_id_user_id_fk",
+          "tableFrom": "organization_connection_attempts",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_connection_attempts_session_id_session_id_fk": {
+          "name": "organization_connection_attempts_session_id_session_id_fk",
+          "tableFrom": "organization_connection_attempts",
+          "tableTo": "session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_connection_attempts_state_verifier_unique": {
+          "name": "organization_connection_attempts_state_verifier_unique",
+          "nullsNotDistinct": false,
+          "columns": ["state_verifier"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "organization_connection_attempts_provider_check": {
+          "name": "organization_connection_attempts_provider_check",
+          "value": "\"organization_connection_attempts\".\"provider\" in ('github', 'discord', 'slack', 'linear')"
+        },
+        "organization_connection_attempts_phase_check": {
+          "name": "organization_connection_attempts_phase_check",
+          "value": "\"organization_connection_attempts\".\"phase\" in ('github_setup', 'github_user_authorization', 'discord_authorization', 'slack_authorization', 'linear_authorization')"
+        },
+        "organization_connection_attempts_shape_check": {
+          "name": "organization_connection_attempts_shape_check",
+          "value": "(\"organization_connection_attempts\".\"phase\" = 'github_setup' and \"organization_connection_attempts\".\"provider\" = 'github' and \"organization_connection_attempts\".\"candidate_external_id\" is null and \"organization_connection_attempts\".\"pkce_verifier\" is null)\n        or (\"organization_connection_attempts\".\"phase\" = 'github_user_authorization' and \"organization_connection_attempts\".\"provider\" = 'github' and \"organization_connection_attempts\".\"candidate_external_id\" is not null and (\"organization_connection_attempts\".\"pkce_verifier\" is not null or \"organization_connection_attempts\".\"consumed_at\" is not null))\n        or (\"organization_connection_attempts\".\"phase\" = 'discord_authorization' and \"organization_connection_attempts\".\"provider\" = 'discord' and \"organization_connection_attempts\".\"candidate_external_id\" is null and \"organization_connection_attempts\".\"pkce_verifier\" is null)\n        or (\"organization_connection_attempts\".\"phase\" = 'slack_authorization' and \"organization_connection_attempts\".\"provider\" = 'slack' and \"organization_connection_attempts\".\"candidate_external_id\" is null and \"organization_connection_attempts\".\"pkce_verifier\" is null)\n        or (\"organization_connection_attempts\".\"phase\" = 'linear_authorization' and \"organization_connection_attempts\".\"provider\" = 'linear' and \"organization_connection_attempts\".\"candidate_external_id\" is null and \"organization_connection_attempts\".\"pkce_verifier\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_entitlements": {
+      "name": "organization_entitlements",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "granted": {
+          "name": "granted",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overrides": {
+          "name": "overrides",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_version": {
+          "name": "plan_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stamped_at": {
+          "name": "stamped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_entitlements_organization_id_organization_id_fk": {
+          "name": "organization_entitlements_organization_id_organization_id_fk",
+          "tableFrom": "organization_entitlements",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_usage": {
+      "name": "organization_usage",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meter": {
+          "name": "meter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used": {
+          "name": "used",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "organization_usage_organization_meter_idx": {
+          "name": "organization_usage_organization_meter_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "meter",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_usage_organization_id_organization_id_fk": {
+          "name": "organization_usage_organization_id_organization_id_fk",
+          "tableFrom": "organization_usage",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "organization_usage_organization_id_meter_period_start_pk": {
+          "name": "organization_usage_organization_id_meter_period_start_pk",
+          "columns": ["organization_id", "meter", "period_start"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "organization_usage_used_non_negative": {
+          "name": "organization_usage_used_non_negative",
+          "value": "\"organization_usage\".\"used\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_configuration_revisions": {
+      "name": "project_configuration_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_evidence": {
+          "name": "source_evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_yaml": {
+          "name": "raw_yaml",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "normalized_configuration": {
+          "name": "normalized_configuration",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "validation_errors": {
+          "name": "validation_errors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_repository_id": {
+          "name": "github_repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_repository_full_name": {
+          "name": "github_repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_commit_sha": {
+          "name": "github_commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_commit_url": {
+          "name": "github_commit_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_ref": {
+          "name": "github_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_webhook_delivery_id": {
+          "name": "github_webhook_delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_sender": {
+          "name": "github_sender",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_author": {
+          "name": "github_author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_committer": {
+          "name": "github_committer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "validated_at": {
+          "name": "validated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "project_configuration_revisions_project_version_unique": {
+          "name": "project_configuration_revisions_project_version_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_configuration_revisions_id_project_organization_unique": {
+          "name": "project_configuration_revisions_id_project_organization_unique",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_configuration_revisions_project_created_idx": {
+          "name": "project_configuration_revisions_project_created_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_configuration_revisions_created_by_user_id_user_id_fk": {
+          "name": "project_configuration_revisions_created_by_user_id_user_id_fk",
+          "tableFrom": "project_configuration_revisions",
+          "tableTo": "user",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "project_configuration_revisions_project_organization_fk": {
+          "name": "project_configuration_revisions_project_organization_fk",
+          "tableFrom": "project_configuration_revisions",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id", "organization_id"],
+          "columnsTo": ["id", "organization_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "project_configuration_revisions_source_kind_check": {
+          "name": "project_configuration_revisions_source_kind_check",
+          "value": "\"project_configuration_revisions\".\"source_kind\" in ('github', 'manual')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_configuration_sources": {
+      "name": "project_configuration_sources",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_connection_id": {
+          "name": "github_connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_repository_id": {
+          "name": "github_repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_repository_full_name": {
+          "name": "github_repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_default_branch": {
+          "name": "github_default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "automatic_deployment_enabled": {
+          "name": "automatic_deployment_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "selected_by_user_id": {
+          "name": "selected_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_configuration_sources_selected_by_user_id_user_id_fk": {
+          "name": "project_configuration_sources_selected_by_user_id_user_id_fk",
+          "tableFrom": "project_configuration_sources",
+          "tableTo": "user",
+          "columnsFrom": ["selected_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "project_configuration_sources_project_organization_fk": {
+          "name": "project_configuration_sources_project_organization_fk",
+          "tableFrom": "project_configuration_sources",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id", "organization_id"],
+          "columnsTo": ["id", "organization_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_configuration_sources_github_connection_organization_fk": {
+          "name": "project_configuration_sources_github_connection_organization_fk",
+          "tableFrom": "project_configuration_sources",
+          "tableTo": "github_connections",
+          "columnsFrom": ["github_connection_id", "organization_id"],
+          "columnsTo": ["id", "organization_id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "project_configuration_sources_authority_shape_check": {
+          "name": "project_configuration_sources_authority_shape_check",
+          "value": "(\"project_configuration_sources\".\"kind\" = 'manual' and \"project_configuration_sources\".\"github_connection_id\" is null and \"project_configuration_sources\".\"github_repository_id\" is null and not \"project_configuration_sources\".\"automatic_deployment_enabled\") or (\"project_configuration_sources\".\"kind\" = 'github' and \"project_configuration_sources\".\"github_connection_id\" is not null and \"project_configuration_sources\".\"github_repository_id\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_trigger_routes": {
+      "name": "project_trigger_routes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configuration_revision_id": {
+          "name": "configuration_revision_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_name": {
+          "name": "trigger_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "project_trigger_routes_shape_unique": {
+          "name": "project_trigger_routes_shape_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "configuration_revision_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trigger_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_trigger_routes_resource_idx": {
+          "name": "project_trigger_routes_resource_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_trigger_routes_project_organization_fk": {
+          "name": "project_trigger_routes_project_organization_fk",
+          "tableFrom": "project_trigger_routes",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id", "organization_id"],
+          "columnsTo": ["id", "organization_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_trigger_routes_revision_project_organization_fk": {
+          "name": "project_trigger_routes_revision_project_organization_fk",
+          "tableFrom": "project_trigger_routes",
+          "tableTo": "project_configuration_revisions",
+          "columnsFrom": ["configuration_revision_id", "project_id", "organization_id"],
+          "columnsTo": ["id", "project_id", "organization_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "project_trigger_routes_provider_check": {
+          "name": "project_trigger_routes_provider_check",
+          "value": "\"project_trigger_routes\".\"provider\" in ('github', 'slack', 'discord', 'linear')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_configuration_revision_id": {
+          "name": "active_configuration_revision_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "projects_organization_slug_unique": {
+          "name": "projects_organization_slug_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_id_organization_unique": {
+          "name": "projects_id_organization_unique",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_organization_status_idx": {
+          "name": "projects_organization_status_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_organization_id_organization_id_fk": {
+          "name": "projects_organization_id_organization_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "projects_created_by_user_id_user_id_fk": {
+          "name": "projects_created_by_user_id_user_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "user",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "projects_active_configuration_revision_id_project_configuration_revisions_id_fk": {
+          "name": "projects_active_configuration_revision_id_project_configuration_revisions_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "project_configuration_revisions",
+          "columnsFrom": ["active_configuration_revision_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "projects_status_check": {
+          "name": "projects_status_check",
+          "value": "\"projects\".\"status\" in ('active', 'archived')"
+        },
+        "projects_archive_shape_check": {
+          "name": "projects_archive_shape_check",
+          "value": "(\"projects\".\"status\" = 'active' and \"projects\".\"archived_at\" is null) or (\"projects\".\"status\" = 'archived' and \"projects\".\"archived_at\" is not null and \"projects\".\"active_configuration_revision_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.provider_event_receipts": {
+      "name": "provider_event_receipts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signature_hash": {
+          "name": "signature_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_application_id": {
+          "name": "provider_application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_configuration_version": {
+          "name": "provider_configuration_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "dropped_reason": {
+          "name": "dropped_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_routes": {
+          "name": "accepted_routes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "provider_event_receipts_id_organization_unique": {
+          "name": "provider_event_receipts_id_organization_unique",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "provider_event_receipts_organization_delivery_unique": {
+          "name": "provider_event_receipts_organization_delivery_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "delivery_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "provider_event_receipts_signature_unique": {
+          "name": "provider_event_receipts_signature_unique",
+          "columns": [
+            {
+              "expression": "signature_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"provider_event_receipts\".\"signature_hash\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "provider_event_receipts_organization_received_idx": {
+          "name": "provider_event_receipts_organization_received_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "provider_event_receipts_resource_idx": {
+          "name": "provider_event_receipts_resource_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provider_event_receipts_organization_id_organization_id_fk": {
+          "name": "provider_event_receipts_organization_id_organization_id_fk",
+          "tableFrom": "provider_event_receipts",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "provider_event_receipts_provider_check": {
+          "name": "provider_event_receipts_provider_check",
+          "value": "\"provider_event_receipts\".\"provider\" in ('github', 'slack', 'discord', 'linear', 'manual')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.runtime_configuration": {
+      "name": "runtime_configuration",
+      "schema": "",
+      "columns": {
+        "singleton": {
+          "name": "singleton",
+          "type": "boolean",
+          "primaryKey": true,
+          "notNull": true,
+          "default": true
+        },
+        "auth_secret": {
+          "name": "auth_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "runtime_configuration_singleton_check": {
+          "name": "runtime_configuration_singleton_check",
+          "value": "\"runtime_configuration\".\"singleton\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.runtime_provider_activation": {
+      "name": "runtime_provider_activation",
+      "schema": "",
+      "columns": {
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_application_id": {
+          "name": "provider_application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configuration_version": {
+          "name": "configuration_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "runtime_provider_activation_provider_check": {
+          "name": "runtime_provider_activation_provider_check",
+          "value": "\"runtime_provider_activation\".\"provider\" in ('github', 'slack', 'discord', 'linear')"
+        },
+        "runtime_provider_activation_version_check": {
+          "name": "runtime_provider_activation_version_check",
+          "value": "\"runtime_provider_activation\".\"configuration_version\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.runtime_provider_configuration": {
+      "name": "runtime_provider_configuration",
+      "schema": "",
+      "columns": {
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "configuration": {
+          "name": "configuration",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified_external_identity": {
+          "name": "verified_external_identity",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "runtime_provider_configuration_updated_by_user_id_user_id_fk": {
+          "name": "runtime_provider_configuration_updated_by_user_id_user_id_fk",
+          "tableFrom": "runtime_provider_configuration",
+          "tableTo": "user",
+          "columnsFrom": ["updated_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "runtime_provider_configuration_provider_check": {
+          "name": "runtime_provider_configuration_provider_check",
+          "value": "\"runtime_provider_configuration\".\"provider\" in ('github', 'slack', 'discord', 'linear')"
+        },
+        "runtime_provider_configuration_version_check": {
+          "name": "runtime_provider_configuration_version_check",
+          "value": "\"runtime_provider_configuration\".\"version\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sessions_active_organization_id_idx": {
+          "name": "sessions_active_organization_id_idx",
+          "columns": [
+            {
+              "expression": "active_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_connections": {
+      "name": "slack_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_application_id": {
+          "name": "provider_application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_name": {
+          "name": "team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_access_token": {
+          "name": "bot_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "connected_by_user_id": {
+          "name": "connected_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "slack_connections_id_organization_unique": {
+          "name": "slack_connections_id_organization_unique",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "slack_connections_organization_slug_unique": {
+          "name": "slack_connections_organization_slug_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_connections_organization_id_organization_id_fk": {
+          "name": "slack_connections_organization_id_organization_id_fk",
+          "tableFrom": "slack_connections",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slack_connections_connected_by_user_id_user_id_fk": {
+          "name": "slack_connections_connected_by_user_id_user_id_fk",
+          "tableFrom": "slack_connections",
+          "tableTo": "user",
+          "columnsFrom": ["connected_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "slack_connections_team_id_unique": {
+          "name": "slack_connections_team_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["team_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trigger_runs": {
+      "name": "trigger_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configuration_revision_id": {
+          "name": "configuration_revision_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_event_receipt_id": {
+          "name": "provider_event_receipt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configured_trigger_name": {
+          "name": "configured_trigger_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'accepted'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inputs": {
+          "name": "inputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "values": {
+          "name": "values",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "trigger_context": {
+          "name": "trigger_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "output_context": {
+          "name": "output_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "deadline_at": {
+          "name": "deadline_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deadline_kind": {
+          "name": "deadline_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reaction_state": {
+          "name": "reaction_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_notification_pending_at": {
+          "name": "terminal_notification_pending_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_notification_delivered_at": {
+          "name": "terminal_notification_delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_notification_lease_expires_at": {
+          "name": "terminal_notification_lease_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection": {
+          "name": "rejection",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "trigger_runs_receipt_project_configured_unique": {
+          "name": "trigger_runs_receipt_project_configured_unique",
+          "columns": [
+            {
+              "expression": "provider_event_receipt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "configured_trigger_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trigger_runs_status_deadline_idx": {
+          "name": "trigger_runs_status_deadline_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deadline_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trigger_runs_project_created_idx": {
+          "name": "trigger_runs_project_created_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trigger_runs_terminal_notification_idx": {
+          "name": "trigger_runs_terminal_notification_idx",
+          "columns": [
+            {
+              "expression": "terminal_notification_delivered_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "terminal_notification_lease_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trigger_runs_organization_fk": {
+          "name": "trigger_runs_organization_fk",
+          "tableFrom": "trigger_runs",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trigger_runs_project_organization_fk": {
+          "name": "trigger_runs_project_organization_fk",
+          "tableFrom": "trigger_runs",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id", "organization_id"],
+          "columnsTo": ["id", "organization_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trigger_runs_revision_project_organization_fk": {
+          "name": "trigger_runs_revision_project_organization_fk",
+          "tableFrom": "trigger_runs",
+          "tableTo": "project_configuration_revisions",
+          "columnsFrom": ["configuration_revision_id", "project_id", "organization_id"],
+          "columnsTo": ["id", "project_id", "organization_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "trigger_runs_receipt_organization_fk": {
+          "name": "trigger_runs_receipt_organization_fk",
+          "tableFrom": "trigger_runs",
+          "tableTo": "provider_event_receipts",
+          "columnsFrom": ["provider_event_receipt_id", "organization_id"],
+          "columnsTo": ["id", "organization_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "trigger_runs_status_check": {
+          "name": "trigger_runs_status_check",
+          "value": "\"trigger_runs\".\"status\" in ('running', 'succeeded', 'failed', 'timed_out', 'rejected')"
+        },
+        "trigger_runs_outcome_check": {
+          "name": "trigger_runs_outcome_check",
+          "value": "(\"trigger_runs\".\"outcome\" = 'accepted' and \"trigger_runs\".\"status\" <> 'rejected' and \"trigger_runs\".\"rejection\" is null)\n        or (\"trigger_runs\".\"outcome\" = 'rejected' and \"trigger_runs\".\"status\" = 'rejected' and \"trigger_runs\".\"rejection\" is not null)"
+        },
+        "trigger_runs_deadline_kind_check": {
+          "name": "trigger_runs_deadline_kind_check",
+          "value": "\"trigger_runs\".\"deadline_kind\" is null or \"trigger_runs\".\"deadline_kind\" in ('step_hard', 'step_idle', 'whole_run')"
+        },
+        "trigger_runs_deadline_shape_check": {
+          "name": "trigger_runs_deadline_shape_check",
+          "value": "(\"trigger_runs\".\"outcome\" = 'accepted' and \"trigger_runs\".\"deadline_at\" is not null)\n        or (\"trigger_runs\".\"outcome\" = 'rejected' and \"trigger_runs\".\"deadline_at\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "must_change_password": {
+          "name": "must_change_password",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_instance_operator": {
+          "name": "is_instance_operator",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_step_runs": {
+      "name": "workflow_step_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trigger_run_id": {
+          "name": "trigger_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_id": {
+          "name": "step_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_execution_id": {
+          "name": "agent_execution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deadline_kind": {
+          "name": "deadline_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deadline_at": {
+          "name": "deadline_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idle_deadline_at": {
+          "name": "idle_deadline_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatch_intent": {
+          "name": "dispatch_intent",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflow_step_runs_trigger_ordinal_unique": {
+          "name": "workflow_step_runs_trigger_ordinal_unique",
+          "columns": [
+            {
+              "expression": "trigger_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ordinal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_step_runs_trigger_step_unique": {
+          "name": "workflow_step_runs_trigger_step_unique",
+          "columns": [
+            {
+              "expression": "trigger_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "step_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_step_runs_agent_execution_unique": {
+          "name": "workflow_step_runs_agent_execution_unique",
+          "columns": [
+            {
+              "expression": "agent_execution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workflow_step_runs\".\"agent_execution_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_step_runs_trigger_status_idx": {
+          "name": "workflow_step_runs_trigger_status_idx",
+          "columns": [
+            {
+              "expression": "trigger_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_step_runs_trigger_run_fk": {
+          "name": "workflow_step_runs_trigger_run_fk",
+          "tableFrom": "workflow_step_runs",
+          "tableTo": "trigger_runs",
+          "columnsFrom": ["trigger_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_step_runs_status_check": {
+          "name": "workflow_step_runs_status_check",
+          "value": "\"workflow_step_runs\".\"status\" in ('pending', 'running', 'succeeded', 'skipped', 'failed', 'timed_out')"
+        },
+        "workflow_step_runs_deadline_kind_check": {
+          "name": "workflow_step_runs_deadline_kind_check",
+          "value": "\"workflow_step_runs\".\"deadline_kind\" is null or \"workflow_step_runs\".\"deadline_kind\" in ('step_hard', 'step_idle', 'whole_run')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_wakeups": {
+      "name": "workflow_wakeups",
+      "schema": "",
+      "columns": {
+        "trigger_run_id": {
+          "name": "trigger_run_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "available_at": {
+          "name": "available_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflow_wakeups_available_lease_idx": {
+          "name": "workflow_wakeups_available_lease_idx",
+          "columns": [
+            {
+              "expression": "available_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lease_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_wakeups_trigger_run_fk": {
+          "name": "workflow_wakeups_trigger_run_fk",
+          "tableFrom": "workflow_wakeups",
+          "tableTo": "trigger_runs",
+          "columnsFrom": ["trigger_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.agent_execution_status": {
+      "name": "agent_execution_status",
+      "schema": "public",
+      "values": ["spawning", "running", "succeeded", "failed"]
+    },
+    "public.machine_status": {
+      "name": "machine_status",
+      "schema": "public",
+      "values": ["spawning", "alive", "terminated"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -288,6 +288,13 @@
       "when": 1787443895467,
       "tag": "0040_cultured_punisher",
       "breakpoints": true
+    },
+    {
+      "idx": 41,
+      "version": "7",
+      "when": 1787949616226,
+      "tag": "0041_parched_bucky",
+      "breakpoints": true
     }
   ]
 }

--- a/e2e/billing-downgrade.spec.ts
+++ b/e2e/billing-downgrade.spec.ts
@@ -1,17 +1,19 @@
 import { test } from "./app.js";
 
-// Slice 7: downgrade, over-limit, and provenance.
+// Slice 7: losing a plan, over-limit, and provenance.
 //
-// A downgrade stamps the lower plan's template. It never deletes members or invitations to fit
-// the smaller plan — existing seats are grandfathered — but it blocks growth past the new cap and
-// surfaces a banner. The granted/overrides split is proven directly: a manual override survives a
-// plan change while everything the admin did not touch is re-stamped, and clearing the override
-// hands that value back to the plan.
+// Hub sells one plan, so the downgrade a customer can actually reach is cancellation: enforcement
+// drops from the plan's template to the internal free floor. That drop never deletes members or
+// invitations to fit the smaller cap — existing seats are grandfathered — but it blocks growth
+// past the new cap and surfaces a banner. The granted/overrides split is proven directly: a manual
+// override survives a plan change while everything the admin did not touch is re-stamped, and
+// clearing the override hands that value back to the plan.
 //
 // No Stripe account and no network: the fixture stands in for checkout, and each subscription
 // webhook is HMAC-signed with a known secret so signature verification is real.
 
 const DIR = "e2e/screenshots/slice-7";
+const PLAN = "Paseo Hub";
 
 test.use({ billing: true });
 
@@ -20,7 +22,7 @@ const downgradeOwner = {
   email: "priya-downgrade@example.com",
   password: "priya-downgrade-password",
 };
-const teamInvitees = [
+const invitees = [
   "one-downgrade@example.com",
   "two-downgrade@example.com",
   "three-downgrade@example.com",
@@ -28,37 +30,36 @@ const teamInvitees = [
 ];
 const sixthInvitee = "five-downgrade@example.com";
 
-test("a downgrade keeps every seat, warns that the org is over its limit, and blocks a new invite", async ({
+test("losing the plan keeps every seat, warns that the org is over its limit, and blocks a new invite", async ({
   hub,
   page,
 }) => {
-  await test.step("create an organization and put it on the team plan", async () => {
+  await test.step("create an organization and subscribe it to the plan", async () => {
     await hub.signUpAs("owner", downgradeOwner);
     await hub.createOrganization("owner", "Acme");
-    await hub.subscribeToPlan("owner", { plan: "Team", interval: "Monthly" });
+    await hub.subscribeToPlan("owner", PLAN);
     await hub.deliverSubscriptionWebhook("owner");
-    await hub.expectCurrentPlan("owner", "Team");
+    await hub.expectCurrentPlan("owner", PLAN);
   });
 
   await test.step("fill five seats: the owner plus four invited members", async () => {
-    await hub.inviteMembers("owner", teamInvitees);
-    await hub.expectPendingInvitationsRetained("owner", teamInvitees);
-    await page.screenshot({ path: `${DIR}/01-team-five-seats.png`, fullPage: true });
+    await hub.inviteMembers("owner", invitees);
+    await hub.expectPendingInvitationsRetained("owner", invitees);
+    await page.screenshot({ path: `${DIR}/01-five-seats.png`, fullPage: true });
   });
 
-  await test.step("downgrade to the free plan, which caps seats at one", async () => {
-    await hub.subscribeToPlan("owner", { plan: "Free", interval: "Monthly" });
-    await hub.deliverSubscriptionWebhook("owner");
-    await hub.expectCurrentPlan("owner", "Free");
+  await test.step("cancel the subscription, which drops the org to the one-seat floor", async () => {
+    await hub.cancelSubscription("owner");
+    await hub.expectNoSubscription("owner");
   });
 
   await test.step("all five seats are grandfathered and an over-limit banner explains the state", async () => {
-    await hub.expectPendingInvitationsRetained("owner", teamInvitees);
+    await hub.expectPendingInvitationsRetained("owner", invitees);
     await hub.expectOverLimitBanner("owner", { used: 5, limit: 1 });
     await page.screenshot({ path: `${DIR}/02-over-limit-banner.png`, fullPage: true });
   });
 
-  await test.step("a sixth invite is refused — the downgrade blocks growth past the cap", async () => {
+  await test.step("a sixth invite is refused — the floor blocks growth past the cap", async () => {
     await hub.expectInviteBlockedByPlan("owner", sixthInvitee);
     await page.screenshot({ path: `${DIR}/03-invite-blocked.png`, fullPage: true });
   });
@@ -76,12 +77,10 @@ test("a manual override survives a plan change while the rest re-stamps, and cle
   hub,
   page,
 }) => {
-  await test.step("put the organization on the solo plan and become an operator", async () => {
+  await test.step("start from an unsubscribed organization and become an operator", async () => {
     await hub.signUpAs("owner", overrideOwner);
     await hub.createOrganization("owner", "Globex");
-    await hub.subscribeToPlan("owner", { plan: "Solo", interval: "Monthly" });
-    await hub.deliverSubscriptionWebhook("owner");
-    await hub.expectCurrentPlan("owner", "Solo");
+    await hub.expectNoSubscription("owner");
     // Overrides are operator-only now; the owner is granted the flag to hand-set the deal.
     await hub.grantOperator("owner");
   });
@@ -90,29 +89,29 @@ test("a manual override survives a plan change while the rest re-stamps, and cle
     await hub.openSeatOverrideEditor("owner", { org: "Globex", max: 3, reason: seatReason });
     await hub.saveSeatOverride("owner", 3);
     await hub.expectEntitlementCells("owner", "Globex", "Seats", {
-      granted: "Unlimited",
+      granted: "1",
       override: "3",
       effective: "3",
     });
     await hub.expectEntitlementCells("owner", "Globex", "Executions this month", {
-      granted: "2000",
+      granted: "0",
       override: "—",
-      effective: "2000",
+      effective: "0",
     });
-    await page.screenshot({ path: `${DIR}/04-solo-override.png`, fullPage: true });
+    await page.screenshot({ path: `${DIR}/04-floor-override.png`, fullPage: true });
   });
 
-  await test.step("change to the team plan: the override holds, the untouched values re-stamp", async () => {
-    await hub.subscribeToPlan("owner", { plan: "Team", interval: "Monthly" });
+  await test.step("subscribe to the plan: the override holds, the untouched values re-stamp", async () => {
+    await hub.subscribeToPlan("owner", PLAN);
     await hub.deliverSubscriptionWebhook("owner");
-    await hub.expectCurrentPlan("owner", "Team");
+    await hub.expectCurrentPlan("owner", PLAN);
     // Seats: plan re-stamped to unlimited, but the hand-set override still wins.
     await hub.expectEntitlementCells("owner", "Globex", "Seats", {
       granted: "Unlimited",
       override: "3",
       effective: "3",
     });
-    // Executions: never overridden, so it re-stamps from Solo's 2000 to Team's unlimited.
+    // Executions: never overridden, so it re-stamps from the floor's 0 to the plan's unlimited.
     await hub.expectEntitlementCells("owner", "Globex", "Executions this month", {
       granted: "Unlimited",
       override: "—",
@@ -121,7 +120,7 @@ test("a manual override survives a plan change while the rest re-stamps, and cle
     await page.screenshot({ path: `${DIR}/05-override-survives-restamp.png`, fullPage: true });
   });
 
-  await test.step("clear the override: the team plan's unlimited seats take over, and the reset is audited", async () => {
+  await test.step("clear the override: the plan's unlimited seats take over, and the reset is audited", async () => {
     await hub.clearSeatOverride("owner", {
       org: "Globex",
       reason: clearReason,

--- a/e2e/billing-mobile.spec.ts
+++ b/e2e/billing-mobile.spec.ts
@@ -25,7 +25,7 @@ test("the cardless trial can be started and read on a phone", async ({ hub, page
   });
 
   await test.step("starting the trial leaves a readable trial card behind", async () => {
-    await hub.choosePlan("owner", { plan: "Solo", interval: "Monthly" });
+    await hub.choosePlan("owner", "Paseo Hub");
     await hub.deliverSubscriptionWebhook("owner");
     await hub.expectActiveTrial("owner");
     await page.screenshot({ path: `${SCREENSHOT_DIR}/02-active-trial.png`, fullPage: true });

--- a/e2e/billing-mobile.spec.ts
+++ b/e2e/billing-mobile.spec.ts
@@ -1,0 +1,33 @@
+import { test } from "./app.js";
+
+// The paywall is the one surface a customer meets before they have decided to trust the product,
+// and on a phone it is a modal inside a modal-shaped shell. This journey locks the two things
+// that break there: the picker must not push the page sideways, and the paid plan's call to
+// action must be reachable and accessible at phone width — not stranded below three tall cards.
+
+const owner = {
+  name: "Nadia",
+  email: "nadia-mobile-billing@example.com",
+  password: "nadia-mobile-billing-password",
+};
+
+const SCREENSHOT_DIR = "e2e/screenshots/billing-mobile";
+
+test.use({ billing: true });
+
+test("the cardless trial can be started and read on a phone", async ({ hub, page }) => {
+  await hub.signUpAs("owner", owner);
+  await hub.createOrganization("owner", "Acme");
+
+  await test.step("the plan picker fits the viewport and offers the trial", async () => {
+    await hub.expectPlanPickerFitsPhone("owner");
+    await page.screenshot({ path: `${SCREENSHOT_DIR}/01-plan-picker.png`, fullPage: true });
+  });
+
+  await test.step("starting the trial leaves a readable trial card behind", async () => {
+    await hub.choosePlan("owner", { plan: "Solo", interval: "Monthly" });
+    await hub.deliverSubscriptionWebhook("owner");
+    await hub.expectActiveTrial("owner");
+    await page.screenshot({ path: `${SCREENSHOT_DIR}/02-active-trial.png`, fullPage: true });
+  });
+});

--- a/e2e/billing-subscription.spec.ts
+++ b/e2e/billing-subscription.spec.ts
@@ -72,6 +72,12 @@ test("subscribing lifts a free org's invite limit, and replaying the webhook cha
     // canceled state and stamps Free, so paid entitlements do not outlive the subscription.
     await hub.cancelSubscription("owner");
     await hub.expectInviteBlockedByPlan("owner", afterCancelInvitee);
+    await hub.expectCurrentPlan("owner", "Free");
     await page.screenshot({ path: `${SLICE_6_DIR}/06-cancel-reverts-to-free.png`, fullPage: true });
+    // The trial was consumed by the cancelled subscription, so the paywall now sells the plan
+    // instead of promising another 14 free days.
+    await hub.expectNoSecondTrialOffer("owner");
+    await hub.openPlanDialog("owner");
+    await page.screenshot({ path: `${SLICE_6_DIR}/07-paid-paywall.png`, fullPage: true });
   });
 });

--- a/e2e/billing-subscription.spec.ts
+++ b/e2e/billing-subscription.spec.ts
@@ -39,7 +39,7 @@ test("subscribing lifts a free org's invite limit, and replaying the webhook cha
   });
 
   await test.step("open the upgrade dialog and choose a paid plan", async () => {
-    await hub.openPlanDialog("owner");
+    await hub.expectCardlessTrialOffer("owner");
     await page.screenshot({ path: `${SLICE_6_DIR}/03-upgrade-dialog.png`, fullPage: true });
     await hub.choosePlan("owner", { plan: "Solo", interval: "Monthly" });
   });
@@ -47,6 +47,7 @@ test("subscribing lifts a free org's invite limit, and replaying the webhook cha
   await test.step("the subscription webhook stamps the paid plan and bills for one seat", async () => {
     await hub.deliverSubscriptionWebhook("owner");
     await hub.expectCurrentPlan("owner", "Solo");
+    await hub.expectActiveTrial("owner");
     // Post-paid seats: with only the owner, Stripe is billed for one seat.
     await hub.expectReportedSeatQuantity("owner", 1);
     await page.screenshot({ path: `${SLICE_6_DIR}/04-solo-plan.png`, fullPage: true });

--- a/e2e/billing-subscription.spec.ts
+++ b/e2e/billing-subscription.spec.ts
@@ -1,8 +1,9 @@
 import { test } from "./app.js";
 
-// The money test: the proof of the whole decoupled design. A free organization cannot invite;
-// a subscription webhook stamps a paid plan onto the organization; enforcement then reads the
-// organization's own record and the same invite succeeds. Replaying the webhook changes nothing.
+// The money test: the proof of the whole decoupled design. An organization with no subscription
+// cannot invite; a subscription webhook stamps the paid plan onto the organization; enforcement
+// then reads the organization's own record and the same invite succeeds. Replaying the webhook
+// changes nothing.
 //
 // No Stripe account and no network — the fixture Stripe client stands in for checkout, and the
 // subscription webhook is HMAC-signed with a known secret so signature verification is real.
@@ -19,21 +20,21 @@ const SLICE_6_DIR = "e2e/screenshots/slice-6";
 
 test.use({ billing: true });
 
-test("subscribing lifts a free org's invite limit, and replaying the webhook changes nothing", async ({
+test("subscribing lifts an unsubscribed org's invite limit, and replaying the webhook changes nothing", async ({
   hub,
   page,
 }) => {
-  await test.step("sign up and create an organization provisioned on the free plan", async () => {
+  await test.step("sign up and create an organization with nothing to bill", async () => {
     await hub.signUpAs("owner", owner);
     await hub.createOrganization("owner", "Acme");
-    // Hosted provisioning stamps the mirrored Free plan; there is no Stripe subscription yet. The
-    // billing view derives the plan from that stamp, so a provisioned org reads "Free", not
-    // "No active plan" — the provisioning path now has real coverage instead of being skipped.
-    await hub.expectCurrentPlan("owner", "Free");
-    await page.screenshot({ path: `${SLICE_6_DIR}/01-free-plan.png`, fullPage: true });
+    // Hosted provisioning stamps the internal free entitlement record and there is no Stripe
+    // subscription. That record is enforcement, not an offer, so the billing page reads as a
+    // paywall — it never advertises the zero-execution floor as the customer's plan.
+    await hub.expectNoSubscription("owner");
+    await page.screenshot({ path: `${SLICE_6_DIR}/01-no-subscription.png`, fullPage: true });
   });
 
-  await test.step("a free organization with one seat cannot invite", async () => {
+  await test.step("an organization on the one-seat floor cannot invite", async () => {
     await hub.expectInviteBlockedByPlan("owner", invitee);
     await page.screenshot({ path: `${SLICE_6_DIR}/02-invite-blocked.png`, fullPage: true });
   });
@@ -41,16 +42,16 @@ test("subscribing lifts a free org's invite limit, and replaying the webhook cha
   await test.step("open the upgrade dialog and choose a paid plan", async () => {
     await hub.expectCardlessTrialOffer("owner");
     await page.screenshot({ path: `${SLICE_6_DIR}/03-upgrade-dialog.png`, fullPage: true });
-    await hub.choosePlan("owner", { plan: "Solo", interval: "Monthly" });
+    await hub.choosePlan("owner", "Paseo Hub");
   });
 
   await test.step("the subscription webhook stamps the paid plan and bills for one seat", async () => {
     await hub.deliverSubscriptionWebhook("owner");
-    await hub.expectCurrentPlan("owner", "Solo");
+    await hub.expectCurrentPlan("owner", "Paseo Hub");
     await hub.expectActiveTrial("owner");
     // Post-paid seats: with only the owner, Stripe is billed for one seat.
     await hub.expectReportedSeatQuantity("owner", 1);
-    await page.screenshot({ path: `${SLICE_6_DIR}/04-solo-plan.png`, fullPage: true });
+    await page.screenshot({ path: `${SLICE_6_DIR}/04-hosted-plan.png`, fullPage: true });
   });
 
   await test.step("the same invite now succeeds and the second seat is reported to Stripe", async () => {
@@ -63,17 +64,20 @@ test("subscribing lifts a free org's invite limit, and replaying the webhook cha
 
   await test.step("replaying the subscription webhook changes nothing", async () => {
     await hub.deliverSubscriptionWebhook("owner");
-    await hub.expectCurrentPlan("owner", "Solo");
+    await hub.expectCurrentPlan("owner", "Paseo Hub");
     await hub.expectPendingInvitation("owner", invitee);
   });
 
-  await test.step("canceling the subscription reverts entitlements to Free and blocks inviting again", async () => {
+  await test.step("canceling the subscription reverts entitlements and blocks inviting again", async () => {
     // A portal cancellation delivers customer.subscription.deleted; reconciliation reads the
-    // canceled state and stamps Free, so paid entitlements do not outlive the subscription.
+    // canceled state and stamps the free floor, so paid entitlements do not outlive the
+    // subscription.
     await hub.cancelSubscription("owner");
     await hub.expectInviteBlockedByPlan("owner", afterCancelInvitee);
-    await hub.expectCurrentPlan("owner", "Free");
-    await page.screenshot({ path: `${SLICE_6_DIR}/06-cancel-reverts-to-free.png`, fullPage: true });
+    // Enforcement reverts to the zero-execution floor; the customer-facing page says only that
+    // there is no subscription, and offers the plan again.
+    await hub.expectNoSubscription("owner");
+    await page.screenshot({ path: `${SLICE_6_DIR}/06-cancel-reverts.png`, fullPage: true });
     // The trial was consumed by the cancelled subscription, so the paywall now sells the plan
     // instead of promising another 14 free days.
     await hub.expectNoSecondTrialOffer("owner");

--- a/e2e/helpers/hub.ts
+++ b/e2e/helpers/hub.ts
@@ -992,6 +992,10 @@ export class PaseoHub {
     await this.requireUser(alias).openPlanDialog();
   }
 
+  async expectCardlessTrialOffer(alias: string): Promise<void> {
+    await this.requireUser(alias).expectCardlessTrialOffer();
+  }
+
   async choosePlan(
     alias: string,
     plan: { plan: string; interval: "Monthly" | "Annual" },
@@ -1001,6 +1005,10 @@ export class PaseoHub {
 
   async expectCurrentPlan(alias: string, plan: string): Promise<void> {
     await this.requireUser(alias).expectCurrentPlan(plan);
+  }
+
+  async expectActiveTrial(alias: string): Promise<void> {
+    await this.requireUser(alias).expectActiveTrial();
   }
 
   async expectInviteBlockedByPlan(alias: string, email: string): Promise<void> {
@@ -3942,7 +3950,9 @@ class HubUser {
     const dialog = this.page.getByRole("dialog");
     await dialog.getByRole("button", { name: interval, exact: true }).click();
     // Choosing a plan redirects through the fixture checkout back to the billing page.
-    await dialog.getByRole("button", { name: `Choose ${plan}`, exact: true }).click();
+    await dialog
+      .getByRole("button", { name: new RegExp(`^(Start 14-day trial with|Choose) ${plan}$`, "u") })
+      .click();
     await expect(
       this.page.getByRole("heading", { name: "Billing", exact: true, level: 1 }),
     ).toBeVisible();
@@ -3965,6 +3975,26 @@ class HubUser {
       .filter({ has: this.page.getByRole("heading", { name: "Plan", exact: true }) });
     await expect(planSection.getByText(plan, { exact: true })).toBeVisible();
     await expectAccessible(this.page);
+  }
+
+  async expectCardlessTrialOffer(): Promise<void> {
+    await this.openPlanDialog();
+    const dialog = this.page.getByRole("dialog");
+    await expect(dialog).toContainText("Start with 14 days free — no card required.");
+    await expect(
+      dialog.getByRole("button", { name: "Start 14-day trial with Solo" }),
+    ).toBeVisible();
+  }
+
+  async expectActiveTrial(): Promise<void> {
+    await this.openOrganizationSection("Billing");
+    await this.page.reload();
+    const plan = this.page
+      .locator("section")
+      .filter({ has: this.page.getByRole("heading", { name: "Plan", exact: true }) });
+    await expect(plan.getByText("Trialing", { exact: true })).toBeVisible();
+    await expect(plan.getByText(/^Trial ends /u)).toBeVisible();
+    await expect(plan.getByRole("button", { name: "Manage billing" })).toBeVisible();
   }
 
   async expectInviteBlockedByPlan(email: string): Promise<void> {

--- a/e2e/helpers/hub.ts
+++ b/e2e/helpers/hub.ts
@@ -1011,6 +1011,14 @@ export class PaseoHub {
     await this.requireUser(alias).expectActiveTrial();
   }
 
+  async expectNoSecondTrialOffer(alias: string): Promise<void> {
+    await this.requireUser(alias).expectNoSecondTrialOffer();
+  }
+
+  async expectPlanPickerFitsPhone(alias: string): Promise<void> {
+    await this.requireUser(alias).expectPlanPickerFitsPhone();
+  }
+
   async expectInviteBlockedByPlan(alias: string, email: string): Promise<void> {
     await this.requireUser(alias).expectInviteBlockedByPlan(email);
   }
@@ -3942,16 +3950,23 @@ class HubUser {
     await this.openOrganizationSection("Billing");
     await this.page.getByRole("button", { name: /^(Choose a plan|Change plan)$/u }).click();
     await expect(
-      this.page.getByRole("dialog").getByRole("heading", { name: "Choose a plan" }),
+      this.page.getByRole("dialog").getByRole("heading", { name: "Choose your plan" }),
     ).toBeVisible();
   }
 
   async choosePlan(plan: string, interval: "Monthly" | "Annual"): Promise<void> {
     const dialog = this.page.getByRole("dialog");
-    await dialog.getByRole("button", { name: interval, exact: true }).click();
-    // Choosing a plan redirects through the fixture checkout back to the billing page.
     await dialog
-      .getByRole("button", { name: new RegExp(`^(Start 14-day trial with|Choose) ${plan}$`, "u") })
+      .getByRole("group", { name: "Billing interval" })
+      .getByRole("button", {
+        name: interval,
+        exact: true,
+      })
+      .click();
+    // Each plan's button carries the plan in its accessible name even when the visible label is
+    // the short "Start free trial", so a plan is always addressable by name.
+    await dialog
+      .getByRole("button", { name: new RegExp(`^(Start free trial with|Choose) ${plan}$`, "u") })
       .click();
     await expect(
       this.page.getByRole("heading", { name: "Billing", exact: true, level: 1 }),
@@ -3980,10 +3995,13 @@ class HubUser {
   async expectCardlessTrialOffer(): Promise<void> {
     await this.openPlanDialog();
     const dialog = this.page.getByRole("dialog");
-    await expect(dialog).toContainText("Start with 14 days free — no card required.");
-    await expect(
-      dialog.getByRole("button", { name: "Start 14-day trial with Solo" }),
-    ).toBeVisible();
+    await expect(dialog).toContainText("14 days free · No card required");
+    await expect(dialog.getByRole("button", { name: "Start free trial with Solo" })).toBeVisible();
+    // The paid plan spells out what happens when the free days run out; the plan the
+    // organization is already on is named as such and cannot be re-chosen.
+    await expect(dialog).toContainText("14 days free, then $29 per user each month.");
+    await expect(dialog.getByRole("button", { name: "Current plan: Free" })).toBeDisabled();
+    await expectAccessible(this.page);
   }
 
   async expectActiveTrial(): Promise<void> {
@@ -3995,6 +4013,44 @@ class HubUser {
     await expect(plan.getByText("Trialing", { exact: true })).toBeVisible();
     await expect(plan.getByText(/^Trial ends /u)).toBeVisible();
     await expect(plan.getByRole("button", { name: "Manage billing" })).toBeVisible();
+    // The card states what the trial actually entitles the organization to, not just its dates.
+    await expect(plan.getByRole("heading", { name: "What's included" })).toBeVisible();
+    await expectAccessible(this.page);
+  }
+
+  /**
+   * A former subscriber is never promised a second free trial: the picker drops the cardless
+   * offer and falls back to ordinary paid Checkout. Escape closes it, so the paywall is
+   * dismissible from the keyboard alone.
+   */
+  async expectNoSecondTrialOffer(): Promise<void> {
+    await this.openPlanDialog();
+    const dialog = this.page.getByRole("dialog");
+    await expect(dialog).not.toContainText("No card required");
+    await expect(dialog.getByRole("button", { name: /^Start free trial/u })).toHaveCount(0);
+    await expect(dialog.getByRole("button", { name: "Choose Solo" })).toBeVisible();
+    await expectAccessible(this.page);
+    await this.page.keyboard.press("Escape");
+    await expect(dialog).toHaveCount(0);
+  }
+
+  /**
+   * The picker at phone width: it never pushes the page sideways, and the paid plan's call to
+   * action is reachable by scrolling the dialog rather than stranded under three tall cards.
+   */
+  async expectPlanPickerFitsPhone(): Promise<void> {
+    await this.openPlanDialog();
+    const viewport = this.page.viewportSize();
+    expect(viewport).not.toBeNull();
+    expect(
+      await this.page.evaluate(() => document.documentElement.scrollWidth),
+    ).toBeLessThanOrEqual(viewport!.width);
+    const trial = this.page
+      .getByRole("dialog")
+      .getByRole("button", { name: "Start free trial with Solo" });
+    await trial.scrollIntoViewIfNeeded();
+    await expect(trial).toBeInViewport();
+    await expectAccessible(this.page);
   }
 
   async expectInviteBlockedByPlan(email: string): Promise<void> {

--- a/e2e/helpers/hub.ts
+++ b/e2e/helpers/hub.ts
@@ -4983,7 +4983,7 @@ const FIXTURE_BILLING_PLAN_EXPECTATIONS: readonly PublicBillingPlanExpectation[]
   {
     slug: "free",
     name: "Free",
-    marketingFeatures: ["1 seat", "100 executions / month", "Community support"],
+    marketingFeatures: ["1 seat", "0 executions / month", "Community support"],
     prices: {
       monthly: { unitAmount: 0, currency: "usd" },
       annual: { unitAmount: 0, currency: "usd" },

--- a/e2e/helpers/hub.ts
+++ b/e2e/helpers/hub.ts
@@ -19,7 +19,10 @@ import type { HubBundleFile } from "../../src/config/bundle.js";
 import type { BrowserDiscordEvent } from "../../src/e2e/harness/browser-providers.js";
 import type { BrowserProviderScenario } from "../../src/e2e/harness/browser-providers.js";
 import type { FixtureBillingProduct } from "../../src/e2e/harness/browser-billing.js";
-import { fixtureSubscriptionId } from "../../src/e2e/harness/browser-billing.js";
+import {
+  FIXTURE_BILLING_PRODUCTS,
+  fixtureSubscriptionId,
+} from "../../src/e2e/harness/browser-billing.js";
 import { configurationBundleFixture } from "../../src/test-utils/configuration-bundle.js";
 import { slugify } from "../../src/slug.js";
 import { AppSetupSurface, allowClipboard } from "./apps.js";
@@ -94,7 +97,8 @@ export interface BuiltApplicationOptions {
     ownerEmail: string;
     ownerPassword: string;
   };
-  /** Configures billing with the fixture Stripe catalog (Free/Solo/Team). Default: unconfigured. */
+  /** Configures billing with the fixture Stripe catalog (internal free record plus the one
+   * purchasable Paseo Hub plan). Default: unconfigured. */
   billing?: boolean;
 }
 
@@ -851,48 +855,57 @@ export class PaseoHub {
   }
 
   /**
-   * Starts a second, billing-configured application serving the fixture Free/Solo/Team
-   * catalog, verifies the public plans endpoint mirrors it, then simulates a Stripe dashboard
-   * typo (invalid `ent_seats_max`) on the Team product and delivers a real HMAC-signed
-   * `product.updated` webhook. The catalog sync must reject that one product, log loudly, and
-   * leave the previously synced row untouched — the other two plans are unaffected throughout.
+   * Starts a second, billing-configured application and walks the plan catalog mirror through
+   * three states. First: the public endpoint serves the one purchasable plan and withholds the
+   * internal free entitlement record, which is in the same Stripe catalog. Second: a Stripe
+   * dashboard typo (invalid `ent_seats_max`) delivered as a real HMAC-signed `product.updated`
+   * is rejected by the sync, logged loudly, and leaves the previously synced row serving. Third:
+   * a product that loses its `paseo_plan` tag is deactivated by the reconciled snapshot, so the
+   * catalog stops offering it rather than leaving a removed plan selectable — and what is left is
+   * an empty offer, never the free record promoted into one. Re-tagging restores it, because the
+   * mirror is a reconciled snapshot rather than a one-way delete.
    */
   async proveStripePlanCatalogMirror(): Promise<string> {
     const application = await this.startApplication({ databaseProfile: "fresh", billing: true });
     await this.expectPublicBillingPlans(application, FIXTURE_BILLING_PLAN_EXPECTATIONS);
 
     await application.setBillingProduct({
-      id: "prod_fixture_team",
-      name: "Team",
+      id: "prod_fixture_hosted",
+      name: "Paseo Hub",
       active: true,
       metadata: {
         paseo_plan: "true",
-        paseo_plan_slug: "team",
+        paseo_plan_slug: "hosted",
         ent_seats_max: "not-a-number",
         ent_can_invite: "true",
         ent_executions_monthly_limit: "unlimited",
       },
-      marketingFeatures: ["Unlimited seats", "Unlimited executions", "Priority support"],
+      marketingFeatures: [],
     });
-    await this.deliverBillingWebhook(application, "product.updated", "prod_fixture_team");
+    await this.deliverBillingWebhook(application, "product.updated", "prod_fixture_hosted");
 
     await expect
       .poll(() => application.logs())
       .toContain("billing.catalog.product.validate failed");
     await this.expectPublicBillingPlans(application, FIXTURE_BILLING_PLAN_EXPECTATIONS);
 
-    // A product that loses its paseo_plan tag drops out of the reconciled snapshot: the sync
-    // deactivates its mirrored row, so the public catalog stops serving it rather than leaving a
-    // removed plan selectable. Free and Solo are unaffected.
     await application.setBillingProduct({
-      id: "prod_fixture_team",
-      name: "Team",
+      id: "prod_fixture_hosted",
+      name: "Paseo Hub",
       active: true,
       metadata: { paseo_plan: "false" },
       marketingFeatures: [],
     });
-    await this.deliverBillingWebhook(application, "product.updated", "prod_fixture_team");
-    await this.expectPublicBillingPlans(application, FIXTURE_BILLING_PLAN_EXPECTATIONS.slice(0, 2));
+    await this.deliverBillingWebhook(application, "product.updated", "prod_fixture_hosted");
+    // Nothing left to sell. The free record is still mirrored for entitlement stamping, so an
+    // empty offer here is also the proof that it never gets promoted into one.
+    await this.expectPublicBillingPlans(application, []);
+
+    // Re-tagging in Stripe brings the plan back: the mirror is a reconciled snapshot, not a
+    // one-way delete.
+    await application.setBillingProduct(FIXTURE_BILLING_PRODUCTS[1]!);
+    await this.deliverBillingWebhook(application, "product.updated", "prod_fixture_hosted");
+    await this.expectPublicBillingPlans(application, FIXTURE_BILLING_PLAN_EXPECTATIONS);
     return application.origin;
   }
 
@@ -981,11 +994,8 @@ export class PaseoHub {
     await expect.poll(() => this.primary.reportedSeatQuantity(organizationId)).toBe(quantity);
   }
 
-  async subscribeToPlan(
-    alias: string,
-    plan: { plan: string; interval: "Monthly" | "Annual" },
-  ): Promise<void> {
-    await this.requireUser(alias).subscribeToPlan(plan.plan, plan.interval);
+  async subscribeToPlan(alias: string, plan: string): Promise<void> {
+    await this.requireUser(alias).subscribeToPlan(plan);
   }
 
   async openPlanDialog(alias: string): Promise<void> {
@@ -996,11 +1006,8 @@ export class PaseoHub {
     await this.requireUser(alias).expectCardlessTrialOffer();
   }
 
-  async choosePlan(
-    alias: string,
-    plan: { plan: string; interval: "Monthly" | "Annual" },
-  ): Promise<void> {
-    await this.requireUser(alias).choosePlan(plan.plan, plan.interval);
+  async choosePlan(alias: string, plan: string): Promise<void> {
+    await this.requireUser(alias).choosePlan(plan);
   }
 
   async expectCurrentPlan(alias: string, plan: string): Promise<void> {
@@ -1009,6 +1016,10 @@ export class PaseoHub {
 
   async expectActiveTrial(alias: string): Promise<void> {
     await this.requireUser(alias).expectActiveTrial();
+  }
+
+  async expectNoSubscription(alias: string): Promise<void> {
+    await this.requireUser(alias).expectNoSubscription();
   }
 
   async expectNoSecondTrialOffer(alias: string): Promise<void> {
@@ -3954,18 +3965,11 @@ class HubUser {
     ).toBeVisible();
   }
 
-  async choosePlan(plan: string, interval: "Monthly" | "Annual"): Promise<void> {
-    const dialog = this.page.getByRole("dialog");
-    await dialog
-      .getByRole("group", { name: "Billing interval" })
-      .getByRole("button", {
-        name: interval,
-        exact: true,
-      })
-      .click();
+  async choosePlan(plan: string): Promise<void> {
     // Each plan's button carries the plan in its accessible name even when the visible label is
     // the short "Start free trial", so a plan is always addressable by name.
-    await dialog
+    await this.page
+      .getByRole("dialog")
       .getByRole("button", { name: new RegExp(`^(Start free trial with|Choose) ${plan}$`, "u") })
       .click();
     await expect(
@@ -3973,9 +3977,9 @@ class HubUser {
     ).toBeVisible();
   }
 
-  async subscribeToPlan(plan: string, interval: "Monthly" | "Annual"): Promise<void> {
+  async subscribeToPlan(plan: string): Promise<void> {
     await this.openPlanDialog();
-    await this.choosePlan(plan, interval);
+    await this.choosePlan(plan);
   }
 
   async expectCurrentPlan(plan: string): Promise<void> {
@@ -3984,11 +3988,23 @@ class HubUser {
     await expect(
       this.page.getByRole("heading", { name: "Billing", exact: true, level: 1 }),
     ).toBeVisible();
-    // Scope to the Plan section: a plan name like "Team" also names a settings tab.
-    const planSection = this.page
-      .locator("section")
-      .filter({ has: this.page.getByRole("heading", { name: "Plan", exact: true }) });
-    await expect(planSection.getByText(plan, { exact: true })).toBeVisible();
+    await expect(this.planSection().getByText(plan, { exact: true })).toBeVisible();
+    await expectAccessible(this.page);
+  }
+
+  /**
+   * The billing page for an organization with nothing to bill. It is a paywall: it names no plan,
+   * and it never dresses the zero-execution enforcement floor up as a tier the customer is on.
+   */
+  async expectNoSubscription(): Promise<void> {
+    await this.openOrganizationSection("Billing");
+    await this.page.reload();
+    const plan = this.planSection();
+    await expect(plan.getByText("No subscription", { exact: true })).toBeVisible();
+    await expect(plan).not.toContainText("0 executions");
+    await expect(plan.getByText("Free", { exact: true })).toHaveCount(0);
+    await expect(plan.getByRole("button", { name: "Manage billing" })).toHaveCount(0);
+    await expect(plan.getByRole("button", { name: "Choose a plan" })).toBeVisible();
     await expectAccessible(this.page);
   }
 
@@ -3996,20 +4012,38 @@ class HubUser {
     await this.openPlanDialog();
     const dialog = this.page.getByRole("dialog");
     await expect(dialog).toContainText("14 days free · No card required");
-    await expect(dialog.getByRole("button", { name: "Start free trial with Solo" })).toBeVisible();
-    // The paid plan spells out what happens when the free days run out; the plan the
-    // organization is already on is named as such and cannot be re-chosen.
-    await expect(dialog).toContainText("14 days free, then $29 per user each month.");
-    await expect(dialog.getByRole("button", { name: "Current plan: Free" })).toBeDisabled();
+    await expect(
+      dialog.getByRole("button", { name: `Start free trial with ${HOSTED_PLAN_NAME}` }),
+    ).toBeVisible();
+    // The plan spells out what happens when the free days run out, at the price Stripe carries.
+    await expect(dialog).toContainText("14 days free, then €15 per user each month.");
+    await this.expectPickerShowsOnlyTheOffer(dialog);
     await expectAccessible(this.page);
+  }
+
+  /**
+   * The picker only ever shows what Hub sells. The internal free entitlement record is in the same
+   * Stripe catalog, so its absence here is the visible half of the public-catalog boundary; the
+   * interval switch is absent because the catalog prices one interval.
+   */
+  private async expectPickerShowsOnlyTheOffer(dialog: Locator): Promise<void> {
+    await expect(dialog.getByRole("heading", { level: 3 })).toHaveText([HOSTED_PLAN_NAME]);
+    await expect(dialog).not.toContainText("0 executions");
+    await expect(dialog.getByRole("group", { name: "Billing interval" })).toHaveCount(0);
+  }
+
+  /** Scoped to the Plan section: a plan name could otherwise collide with a settings tab. */
+  private planSection(): Locator {
+    return this.page
+      .locator("section")
+      .filter({ has: this.page.getByRole("heading", { name: "Plan", exact: true }) });
   }
 
   async expectActiveTrial(): Promise<void> {
     await this.openOrganizationSection("Billing");
     await this.page.reload();
-    const plan = this.page
-      .locator("section")
-      .filter({ has: this.page.getByRole("heading", { name: "Plan", exact: true }) });
+    const plan = this.planSection();
+    await expect(plan.getByText(HOSTED_PLAN_NAME, { exact: true })).toBeVisible();
     await expect(plan.getByText("Trialing", { exact: true })).toBeVisible();
     await expect(plan.getByText(/^Trial ends /u)).toBeVisible();
     await expect(plan.getByRole("button", { name: "Manage billing" })).toBeVisible();
@@ -4028,15 +4062,16 @@ class HubUser {
     const dialog = this.page.getByRole("dialog");
     await expect(dialog).not.toContainText("No card required");
     await expect(dialog.getByRole("button", { name: /^Start free trial/u })).toHaveCount(0);
-    await expect(dialog.getByRole("button", { name: "Choose Solo" })).toBeVisible();
+    await expect(dialog.getByRole("button", { name: `Choose ${HOSTED_PLAN_NAME}` })).toBeVisible();
+    await this.expectPickerShowsOnlyTheOffer(dialog);
     await expectAccessible(this.page);
     await this.page.keyboard.press("Escape");
     await expect(dialog).toHaveCount(0);
   }
 
   /**
-   * The picker at phone width: it never pushes the page sideways, and the paid plan's call to
-   * action is reachable by scrolling the dialog rather than stranded under three tall cards.
+   * The picker at phone width: it never pushes the page sideways, and the plan's call to action
+   * is reachable by scrolling the dialog rather than stranded below the fold.
    */
   async expectPlanPickerFitsPhone(): Promise<void> {
     await this.openPlanDialog();
@@ -4047,7 +4082,7 @@ class HubUser {
     ).toBeLessThanOrEqual(viewport!.width);
     const trial = this.page
       .getByRole("dialog")
-      .getByRole("button", { name: "Start free trial with Solo" });
+      .getByRole("button", { name: `Start free trial with ${HOSTED_PLAN_NAME}` });
     await trial.scrollIntoViewIfNeeded();
     await expect(trial).toBeInViewport();
     await expectAccessible(this.page);
@@ -5034,36 +5069,26 @@ interface PublicBillingPlanExpectation {
   };
 }
 
-// Mirrors src/e2e/harness/browser-billing.ts's FIXTURE_BILLING_PRODUCTS/FIXTURE_BILLING_PRICES.
+/**
+ * What `/api/billing/plans` serves for the fixture catalog in `browser-billing.ts`: the one plan
+ * Hub sells. The `free` product is in that catalog too — it carries the entitlement floor — but it
+ * is not an offer, and billing withholds it from every public response.
+ */
 const FIXTURE_BILLING_PLAN_EXPECTATIONS: readonly PublicBillingPlanExpectation[] = [
   {
-    slug: "free",
-    name: "Free",
-    marketingFeatures: ["1 seat", "0 executions / month", "Community support"],
-    prices: {
-      monthly: { unitAmount: 0, currency: "usd" },
-      annual: { unitAmount: 0, currency: "usd" },
-    },
-  },
-  {
-    slug: "solo",
-    name: "Solo",
-    marketingFeatures: ["Unlimited seats", "2,000 executions / month", "Email support"],
-    prices: {
-      monthly: { unitAmount: 2900, currency: "usd" },
-      annual: { unitAmount: 29000, currency: "usd" },
-    },
-  },
-  {
-    slug: "team",
-    name: "Team",
-    marketingFeatures: ["Unlimited seats", "Unlimited executions", "Priority support"],
-    prices: {
-      monthly: { unitAmount: 9900, currency: "usd" },
-      annual: { unitAmount: 99000, currency: "usd" },
-    },
+    slug: "hosted",
+    name: "Paseo Hub",
+    marketingFeatures: [
+      "Unlimited daemons",
+      "GitHub, Linear, Slack, and Discord triggers",
+      "Versioned workflows and activity",
+      "Bring your own agents and inference",
+    ],
+    prices: { monthly: { unitAmount: 1500, currency: "eur" }, annual: null },
   },
 ];
+/** The one plan the fixture catalog — and the live Stripe catalog — publishes. */
+const HOSTED_PLAN_NAME = "Paseo Hub";
 const HOSTILE_ORIGIN = "https://hostile.invalid";
 const JSON_TYPE = "application/json";
 const PROBLEM_TYPE = "application/problem+json";

--- a/e2e/helpers/hub.ts
+++ b/e2e/helpers/hub.ts
@@ -3959,10 +3959,8 @@ class HubUser {
 
   async openPlanDialog(): Promise<void> {
     await this.openOrganizationSection("Billing");
-    await this.page.getByRole("button", { name: /^(Choose a plan|Change plan)$/u }).click();
-    await expect(
-      this.page.getByRole("dialog").getByRole("heading", { name: "Choose your plan" }),
-    ).toBeVisible();
+    await this.page.getByRole("button", { name: /^(Subscribe|Change plan)$/u }).click();
+    await expect(this.page.getByRole("dialog")).toBeVisible();
   }
 
   async choosePlan(plan: string): Promise<void> {
@@ -3970,7 +3968,9 @@ class HubUser {
     // the short "Start free trial", so a plan is always addressable by name.
     await this.page
       .getByRole("dialog")
-      .getByRole("button", { name: new RegExp(`^(Start free trial with|Choose) ${plan}$`, "u") })
+      .getByRole("button", {
+        name: new RegExp(`^(Start free trial with|Subscribe to) ${plan}$`, "u"),
+      })
       .click();
     await expect(
       this.page.getByRole("heading", { name: "Billing", exact: true, level: 1 }),
@@ -3993,43 +3993,59 @@ class HubUser {
   }
 
   /**
-   * The billing page for an organization with nothing to bill. It is a paywall: it names no plan,
-   * and it never dresses the zero-execution enforcement floor up as a tier the customer is on.
+   * The billing page for an organization with nothing to bill: the fact, and the one thing to do
+   * about it. Nothing dresses the zero-execution enforcement floor up as a tier the customer is
+   * on, and nothing argues for the plan — that is what the picker is for.
    */
   async expectNoSubscription(): Promise<void> {
     await this.openOrganizationSection("Billing");
     await this.page.reload();
     const plan = this.planSection();
     await expect(plan.getByText("No subscription", { exact: true })).toBeVisible();
+    await expect(plan.getByRole("button", { name: "Subscribe", exact: true })).toBeVisible();
     await expect(plan).not.toContainText("0 executions");
     await expect(plan.getByText("Free", { exact: true })).toHaveCount(0);
     await expect(plan.getByRole("button", { name: "Manage billing" })).toHaveCount(0);
-    await expect(plan.getByRole("button", { name: "Choose a plan" })).toBeVisible();
+    await expect(plan.getByRole("button", { name: "Choose a plan" })).toHaveCount(0);
+    await expect(plan).not.toContainText("run workflows");
     await expectAccessible(this.page);
   }
 
+  /** The picker offering the cardless trial, exactly: a badge, the offer, and the action. */
   async expectCardlessTrialOffer(): Promise<void> {
     await this.openPlanDialog();
     const dialog = this.page.getByRole("dialog");
     await expect(dialog).toContainText("14 days free · No card required");
     await expect(
       dialog.getByRole("button", { name: `Start free trial with ${HOSTED_PLAN_NAME}` }),
-    ).toBeVisible();
-    // The plan spells out what happens when the free days run out, at the price Stripe carries.
-    await expect(dialog).toContainText("14 days free, then €15 per user each month.");
+    ).toHaveText("Start free trial");
     await this.expectPickerShowsOnlyTheOffer(dialog);
+    // Nothing frames or hedges the offer: no heading, no sales sentence, no post-trial footnote.
+    await expect(dialog).not.toContainText("14 days free, then");
+    await expect(dialog).not.toContainText("Nothing is charged");
     await expectAccessible(this.page);
   }
 
   /**
-   * The picker only ever shows what Hub sells. The internal free entitlement record is in the same
-   * Stripe catalog, so its absence here is the visible half of the public-catalog boundary; the
-   * interval switch is absent because the catalog prices one interval.
+   * The picker only ever shows what Hub sells, and only what it takes to accept it. The internal
+   * free entitlement record is in the same Stripe catalog, so its absence here is the visible half
+   * of the public-catalog boundary. The interval switch is absent because the catalog prices one
+   * interval, and there is no visible heading — the dialog's accessible name is enough.
    */
   private async expectPickerShowsOnlyTheOffer(dialog: Locator): Promise<void> {
     await expect(dialog.getByRole("heading", { level: 3 })).toHaveText([HOSTED_PLAN_NAME]);
+    await expect(dialog).toContainText("€15");
+    await expect(dialog).toContainText("per user / month");
     await expect(dialog).not.toContainText("0 executions");
+    await expect(dialog).not.toContainText("Choose your plan");
+    await expect(dialog).not.toContainText("Recommended");
     await expect(dialog.getByRole("group", { name: "Billing interval" })).toHaveCount(0);
+    await expect(dialog.getByRole("button", { name: /^(Monthly|Annual)$/u })).toHaveCount(0);
+    // A dialog still has to announce itself, so its title exists for assistive technology and
+    // takes no space on screen.
+    const title = dialog.getByRole("heading", { level: 2 });
+    await expect(title).toHaveCount(1);
+    expect((await title.boundingBox())?.height ?? 0).toBeLessThanOrEqual(1);
   }
 
   /** Scoped to the Plan section: a plan name could otherwise collide with a settings tab. */
@@ -4047,8 +4063,17 @@ class HubUser {
     await expect(plan.getByText("Trialing", { exact: true })).toBeVisible();
     await expect(plan.getByText(/^Trial ends /u)).toBeVisible();
     await expect(plan.getByRole("button", { name: "Manage billing" })).toBeVisible();
-    // The card states what the trial actually entitles the organization to, not just its dates.
-    await expect(plan.getByRole("heading", { name: "What's included" })).toBeVisible();
+    // The card states what the trial entitles the organization to, unlabelled — the plan name
+    // above it is the label.
+    await expect(plan.getByRole("listitem")).toHaveText([
+      "Unlimited daemons",
+      "GitHub, Linear, Slack, and Discord triggers",
+      "Versioned workflows and activity",
+      "Bring your own agents and inference",
+    ]);
+    // One public offer means nothing to change to, so the picker has no entry point here.
+    await expect(plan.getByRole("button", { name: "Change plan" })).toHaveCount(0);
+    await expect(plan).not.toContainText("Stripe billing portal");
     await expectAccessible(this.page);
   }
 
@@ -4062,7 +4087,9 @@ class HubUser {
     const dialog = this.page.getByRole("dialog");
     await expect(dialog).not.toContainText("No card required");
     await expect(dialog.getByRole("button", { name: /^Start free trial/u })).toHaveCount(0);
-    await expect(dialog.getByRole("button", { name: `Choose ${HOSTED_PLAN_NAME}` })).toBeVisible();
+    await expect(
+      dialog.getByRole("button", { name: `Subscribe to ${HOSTED_PLAN_NAME}` }),
+    ).toHaveText("Subscribe");
     await this.expectPickerShowsOnlyTheOffer(dialog);
     await expectAccessible(this.page);
     await this.page.keyboard.press("Escape");

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
     {
       name: "desktop-chromium",
       testIgnore:
-        /(dashboard-mobile|dashboard-navigation-mobile|phase-two-mobile|phase-three-mobile|projects-mobile|apps-mobile)\.spec\.ts/u,
+        /(dashboard-mobile|dashboard-navigation-mobile|phase-two-mobile|phase-three-mobile|projects-mobile|apps-mobile|billing-mobile)\.spec\.ts/u,
       use: {
         ...devices["Desktop Chrome"],
         trace: "retain-on-failure",
@@ -21,7 +21,7 @@ export default defineConfig({
     {
       name: "mobile-chromium",
       testMatch:
-        /(dashboard-mobile|dashboard-navigation-mobile|projects-mobile|apps-mobile)\.spec\.ts/u,
+        /(dashboard-mobile|dashboard-navigation-mobile|projects-mobile|apps-mobile|billing-mobile)\.spec\.ts/u,
       use: {
         ...devices["Pixel 7"],
         trace: "retain-on-failure",

--- a/src/application-runtime.ts
+++ b/src/application-runtime.ts
@@ -1,10 +1,8 @@
-import { z } from "zod";
 import { createHubApplication } from "./app.js";
 import type { AuthServer } from "./auth/server.js";
-import { selectActivePlanPrice, type BillingRuntime } from "./billing/index.js";
-import { reportFailure } from "./failures/index.js";
+import type { BillingRuntime } from "./billing/index.js";
 import type { ConnectionResolver } from "./config/connections.js";
-import type { BillingPlanPriceInterval, BillingPlanRecord, Database } from "./db/types.js";
+import type { Database } from "./db/types.js";
 import { resolveRouteTenant } from "./projects/access.js";
 import { capabilitiesFor } from "./auth/organization-policy.js";
 import type { DaemonDispatchLifecycleOptions } from "./daemons/lifecycle.js";
@@ -24,7 +22,6 @@ import {
   type ApplicationRuntime,
   type BillingCheckoutInput,
   type BillingOverviewView,
-  type PublicBillingPlan,
 } from "./server/runtime.js";
 import { ProjectDashboard } from "./projects/dashboard.js";
 import { CompositionResources } from "./composition-resources.js";
@@ -250,8 +247,7 @@ async function createOwnedApplicationRuntime(
       // catalog endpoint does not exist rather than serving an empty list. Null tells the route
       // to answer 404 — see the plan's "no config means billing routes are never registered".
       if (options.billing === null || options.database === null) return null;
-      const plans = await options.database.listBillingPlans();
-      return plans.filter((plan) => plan.active).map(publicBillingPlan);
+      return options.billing.publicCatalog();
     },
     billingConfigured: () => options.billing !== null,
     billingOverview: async (request, organizationSlug): Promise<BillingOverviewView> => {
@@ -261,7 +257,7 @@ async function createOwnedApplicationRuntime(
       });
       const [subscription, plans] = await Promise.all([
         billing.subscriptionSnapshot(tenant.organization.id),
-        database.listBillingPlans(),
+        billing.publicCatalog(),
       ]);
       return {
         organization: {
@@ -270,7 +266,7 @@ async function createOwnedApplicationRuntime(
         },
         canManage: capabilitiesFor(tenant.membership.role).manageResources,
         subscription,
-        plans: plans.filter((plan) => plan.active).map(publicBillingPlan),
+        plans,
       };
     },
     billingCheckout: async (request, input: BillingCheckoutInput) => {
@@ -433,42 +429,4 @@ function billingReturnUrl(
 ): string {
   const base = options.publicBaseUrl ?? new URL(request.url).origin;
   return new URL(`/o/${organizationSlug ?? fallbackSlug}/settings/billing`, base).toString();
-}
-
-const billingPlanMarketingSchema = z.object({ features: z.array(z.string()) });
-
-/**
- * Strips everything but marketing copy and pricing — the entitlement template never leaves
- * this function. See the plan's public plans endpoint section for why.
- */
-function publicBillingPlan(record: BillingPlanRecord): PublicBillingPlan {
-  return {
-    slug: record.slug,
-    name: record.name,
-    marketingFeatures: billingPlanMarketingSchema.parse(record.marketing).features,
-    prices: {
-      monthly: activePriceForInterval(record, "monthly"),
-      annual: activePriceForInterval(record, "annual"),
-    },
-  };
-}
-
-function activePriceForInterval(
-  record: BillingPlanRecord,
-  interval: BillingPlanPriceInterval,
-): PublicBillingPlan["prices"][BillingPlanPriceInterval] {
-  // Exact `{slug}_{interval}` lookup-key identity, matching checkout. Ambiguous pricing (two active
-  // prices for one key) is surfaced as "unavailable" and logged, never displayed as an arbitrary
-  // amount the customer might not be charged.
-  try {
-    const price = selectActivePlanPrice(record.prices, record.slug, interval);
-    return price === undefined ? null : { unitAmount: price.unitAmount, currency: price.currency };
-  } catch (error) {
-    reportFailure(
-      error,
-      { operation: "billing.catalog.price.select", component: "billing", provider: "stripe" },
-      { kind: "conflict", diagnostic: { planSlug: record.slug, interval } },
-    );
-    return null;
-  }
 }

--- a/src/billing/index.ts
+++ b/src/billing/index.ts
@@ -134,6 +134,7 @@ export interface CurrentSubscriptionView {
   cancelAtPeriodEnd: boolean;
   currentPeriodEnd: string | null;
   trialEnd: string | null;
+  trialEligible: boolean;
   /** True when a subscription exists, so "Manage billing" (the Stripe portal) can be opened. */
   manageable: boolean;
 }
@@ -310,12 +311,11 @@ export class BillingRuntime {
       this.database.getOrganizationEntitlements(organizationId),
     ]);
     const stampedPlan = plans.find((plan) => plan.id === entitlements?.planId);
-    const subscription =
-      customer === undefined
-        ? undefined
-        : (await this.customerSubscriptions(customer.stripeCustomerId)).find(
-            (candidate) => !TERMINAL_SUBSCRIPTION_STATUSES.has(candidate.status),
-          );
+    const subscriptions =
+      customer === undefined ? [] : await this.customerSubscriptions(customer.stripeCustomerId);
+    const subscription = subscriptions.find(
+      (candidate) => !TERMINAL_SUBSCRIPTION_STATUSES.has(candidate.status),
+    );
     const live = subscription !== undefined;
     return {
       planSlug: stampedPlan?.slug ?? null,
@@ -324,6 +324,7 @@ export class BillingRuntime {
       cancelAtPeriodEnd: live ? subscription.cancelAtPeriodEnd : false,
       currentPeriodEnd: live ? (subscription.currentPeriodEnd?.toISOString() ?? null) : null,
       trialEnd: live ? (subscription.trialEnd?.toISOString() ?? null) : null,
+      trialEligible: subscriptions.length === 0,
       manageable: live,
     };
   }

--- a/src/billing/index.ts
+++ b/src/billing/index.ts
@@ -19,6 +19,7 @@ import type { StripeCatalogSource } from "./stripe-catalog-source.js";
 import type { BillingPlanPriceInterval } from "../db/types.js";
 import type { StripeBillingClient, StripeSubscriptionState } from "./stripe-billing-client.js";
 import { selectActivePlanPrice } from "./plan-prices.js";
+import { publicBillingPlans, type PublicBillingPlan } from "./public-catalog.js";
 
 /** The organization's live seat count (members + pending invitations). Injected by the
  * composition root — the count reads Better Auth tables the `Database` interface does not model,
@@ -35,6 +36,7 @@ export type {
 } from "./stripe-catalog-source.js";
 export type { StripeBillingClient, StripeSubscriptionState } from "./stripe-billing-client.js";
 export { selectActivePlanPrice, AmbiguousPlanPriceError } from "./plan-prices.js";
+export type { PublicBillingPlan, PublicBillingPlanPrice } from "./public-catalog.js";
 
 /**
  * The four Stripe events that mean "the plan catalog may have changed" — see the plan's
@@ -80,9 +82,15 @@ function billingLockKey(organizationId: string): string {
 }
 
 /**
- * The plan a hosted organization gets before it pays. Identified by its `paseo_plan_slug`
- * metadata, mirrored as `billing_plans.slug` — so which product is "free" is set in the Stripe
- * dashboard, not hardcoded here (the plan's "Stripe is the source of truth" rule).
+ * The internal entitlement record a hosted organization is stamped with before it pays and again
+ * after it cancels. Identified by its `paseo_plan_slug` metadata, mirrored as `billing_plans.slug`
+ * — so which product carries the floor is set in the Stripe dashboard, not hardcoded here (the
+ * plan's "Stripe is the source of truth" rule).
+ *
+ * It is not an offer. Nothing customer-facing may present it as the organization's plan or as
+ * something to buy: `publicCatalog` withholds it from the catalog, and `subscriptionSnapshot`
+ * reports an organization stamped with it as having no plan. Enforcing both here is what keeps
+ * consumers from having to know this slug exists.
  */
 const FREE_PLAN_SLUG = "free";
 
@@ -182,6 +190,15 @@ export class BillingRuntime {
 
   async syncCatalog(): Promise<void> {
     await syncBillingCatalog(this.catalogSource, this.database);
+  }
+
+  /**
+   * The plans a customer may buy, derived from the catalog mirror. Everything that renders an
+   * offer — the public plans endpoint, the billing overview, the picker — reads this and nothing
+   * else, so "what Hub sells" is decided once, here.
+   */
+  async publicCatalog(): Promise<PublicBillingPlan[]> {
+    return publicBillingPlans(await this.database.listBillingPlans(), FREE_PLAN_SLUG);
   }
 
   /**
@@ -300,9 +317,13 @@ export class BillingRuntime {
   /**
    * The organization's current plan and subscription status, for the billing section. The plan
    * shown is the plan enforced: it is derived from what the organization was last *stamped* with
-   * (its entitlements provenance), not from the Stripe subscription — so a provisioned Free
-   * organization reads "Free" rather than "No active plan", and a canceled one reads Free again.
-   * The subscription mirror only decides whether there is a live subscription to manage.
+   * (its entitlements provenance), not from the Stripe subscription, so a trialing organization
+   * reads the plan it is trialing. The subscription mirror only decides whether there is a live
+   * subscription to manage.
+   *
+   * A stamp of the internal free record is not a plan. An organization that has not subscribed —
+   * or has cancelled back down to it — reports no plan at all, which is what makes the billing
+   * page a paywall rather than an advert for a tier nobody sells.
    */
   async subscriptionSnapshot(organizationId: string): Promise<CurrentSubscriptionView> {
     const [customer, plans, entitlements] = await Promise.all([
@@ -310,7 +331,8 @@ export class BillingRuntime {
       this.database.listBillingPlans(),
       this.database.getOrganizationEntitlements(organizationId),
     ]);
-    const stampedPlan = plans.find((plan) => plan.id === entitlements?.planId);
+    const stamped = plans.find((plan) => plan.id === entitlements?.planId);
+    const purchased = stamped?.slug === FREE_PLAN_SLUG ? undefined : stamped;
     const subscriptions =
       customer === undefined ? [] : await this.customerSubscriptions(customer.stripeCustomerId);
     const subscription = subscriptions.find(
@@ -318,8 +340,8 @@ export class BillingRuntime {
     );
     const live = subscription !== undefined;
     return {
-      planSlug: stampedPlan?.slug ?? null,
-      planName: stampedPlan?.name ?? null,
+      planSlug: purchased?.slug ?? null,
+      planName: purchased?.name ?? null,
       status: live ? subscription.status : null,
       cancelAtPeriodEnd: live ? subscription.cancelAtPeriodEnd : false,
       currentPeriodEnd: live ? (subscription.currentPeriodEnd?.toISOString() ?? null) : null,

--- a/src/billing/index.ts
+++ b/src/billing/index.ts
@@ -65,7 +65,7 @@ const STAMPABLE_SUBSCRIPTION_STATUSES = new Set(["active", "trialing"]);
 
 /** Terminal statuses: the subscription is over. Reconciliation stamps Free so a customer who
  * cancels through the portal cannot keep paid entitlements. */
-const TERMINAL_SUBSCRIPTION_STATUSES = new Set(["canceled", "incomplete_expired"]);
+const TERMINAL_SUBSCRIPTION_STATUSES = new Set(["canceled", "incomplete_expired", "unpaid"]);
 
 /** Whether a subscription webhook could be reconciled now, or Stripe should retry it later. */
 type ReconcileOutcome = "reconciled" | "retry";
@@ -97,7 +97,7 @@ const FREE_PLAN_SLUG = "free";
 const FREE_TIER_FALLBACK: EntitlementTemplate = {
   seats: { max: 1 },
   canInviteMembers: false,
-  meters: { "executions.monthly": { limit: 100 } },
+  meters: { "executions.monthly": { limit: 0 } },
 };
 
 export interface ComposeBillingOptions {
@@ -133,6 +133,7 @@ export interface CurrentSubscriptionView {
   status: string | null;
   cancelAtPeriodEnd: boolean;
   currentPeriodEnd: string | null;
+  trialEnd: string | null;
   /** True when a subscription exists, so "Manage billing" (the Stripe portal) can be opened. */
   manageable: boolean;
 }
@@ -159,6 +160,14 @@ export class BillingRequestError extends Error {
 export class BillingRuntime {
   /** Signature verification only — a fixture's plausible-but-fake secret works identically. */
   private readonly stripe: StripeSDK;
+  private readonly subscriptionCache = new Map<
+    string,
+    {
+      value: readonly StripeSubscriptionState[];
+      expiresAt: number;
+      pending?: Promise<readonly StripeSubscriptionState[]>;
+    }
+  >();
 
   constructor(
     private readonly config: BillingConfig,
@@ -217,18 +226,22 @@ export class BillingRuntime {
    */
   async createCheckout(input: CreateCheckoutInput): Promise<{ url: string }> {
     const price = await this.resolvePlanPrice(input.planSlug, input.interval);
-    const existing = await this.database.getOrganizationSubscription(input.organizationId);
+    const customerId = await this.resolveCustomer(input);
+    const subscriptions = await this.customerSubscriptions(customerId);
+    const existing = subscriptions.find(
+      (subscription) => !TERMINAL_SUBSCRIPTION_STATUSES.has(subscription.status),
+    );
     if (existing !== undefined) {
       await this.billingClient.changeSubscriptionPrice({
-        subscriptionId: existing.stripeSubscriptionId,
+        subscriptionId: existing.id,
         priceId: price.priceId,
       });
+      this.invalidateSubscriptions(customerId);
       // The change is immediate; Stripe fires a subscription webhook that re-stamps entitlements.
       // Return the caller straight back to the billing page rather than through checkout.
       return { url: input.successUrl };
     }
-    const customerId = await this.resolveCustomer(input);
-    return this.billingClient.createCheckoutSession({
+    const checkout = await this.billingClient.createCheckoutSession({
       organizationId: input.organizationId,
       customerId,
       priceId: price.priceId,
@@ -236,7 +249,10 @@ export class BillingRuntime {
       quantity: await this.seatUsage(input.organizationId),
       successUrl: input.successUrl,
       cancelUrl: input.cancelUrl,
+      trial: subscriptions.length === 0,
     });
+    this.invalidateSubscriptions(customerId);
+    return checkout;
   }
 
   /**
@@ -247,10 +263,14 @@ export class BillingRuntime {
    * to bill — a self-hosted or provisioned-Free organization returns immediately.
    */
   async reportSeatUsage(organizationId: string): Promise<void> {
-    const subscription = await this.database.getOrganizationSubscription(organizationId);
+    const customer = await this.database.getOrganizationBillingCustomer(organizationId);
+    if (customer === undefined) return;
+    const subscription = (await this.customerSubscriptions(customer.stripeCustomerId)).find(
+      (candidate) => !TERMINAL_SUBSCRIPTION_STATUSES.has(candidate.status),
+    );
     if (subscription === undefined) return;
     await this.database.withAdvisoryLock(billingLockKey(organizationId), async () => {
-      const state = await this.billingClient.getSubscription(subscription.stripeSubscriptionId);
+      const state = await this.billingClient.getSubscription(subscription.id);
       if (state !== undefined) await this.settleSeatQuantity(state);
     });
   }
@@ -268,10 +288,10 @@ export class BillingRuntime {
   /** Open the Stripe billing portal for the organization's customer, or undefined when it has
    * no subscription yet (nothing for the portal to manage). */
   async createPortal(input: CreatePortalInput): Promise<{ url: string } | undefined> {
-    const subscription = await this.database.getOrganizationSubscription(input.organizationId);
-    if (subscription === undefined) return undefined;
+    const customer = await this.database.getOrganizationBillingCustomer(input.organizationId);
+    if (customer === undefined) return undefined;
     return this.billingClient.createBillingPortalSession({
-      customerId: subscription.stripeCustomerId,
+      customerId: customer.stripeCustomerId,
       returnUrl: input.returnUrl,
     });
   }
@@ -284,20 +304,26 @@ export class BillingRuntime {
    * The subscription mirror only decides whether there is a live subscription to manage.
    */
   async subscriptionSnapshot(organizationId: string): Promise<CurrentSubscriptionView> {
-    const [subscription, plans, entitlements] = await Promise.all([
-      this.database.getOrganizationSubscription(organizationId),
+    const [customer, plans, entitlements] = await Promise.all([
+      this.database.getOrganizationBillingCustomer(organizationId),
       this.database.listBillingPlans(),
       this.database.getOrganizationEntitlements(organizationId),
     ]);
     const stampedPlan = plans.find((plan) => plan.id === entitlements?.planId);
-    const live =
-      subscription !== undefined && !TERMINAL_SUBSCRIPTION_STATUSES.has(subscription.status);
+    const subscription =
+      customer === undefined
+        ? undefined
+        : (await this.customerSubscriptions(customer.stripeCustomerId)).find(
+            (candidate) => !TERMINAL_SUBSCRIPTION_STATUSES.has(candidate.status),
+          );
+    const live = subscription !== undefined;
     return {
       planSlug: stampedPlan?.slug ?? null,
       planName: stampedPlan?.name ?? null,
       status: live ? subscription.status : null,
       cancelAtPeriodEnd: live ? subscription.cancelAtPeriodEnd : false,
       currentPeriodEnd: live ? (subscription.currentPeriodEnd?.toISOString() ?? null) : null,
+      trialEnd: live ? (subscription.trialEnd?.toISOString() ?? null) : null,
       manageable: live,
     };
   }
@@ -426,14 +452,10 @@ export class BillingRuntime {
       if (plan === undefined) return "retry";
     }
     const stamp = await this.resolveStamp(state.status, terminal, plan);
-    await this.database.reconcileOrganizationSubscription({
+    this.invalidateSubscriptions(state.customerId);
+    await this.database.reconcileOrganizationBilling({
       organizationId: state.organizationId,
       stripeCustomerId: state.customerId,
-      stripeSubscriptionId: state.id,
-      planId: plan?.id ?? null,
-      status: state.status,
-      currentPeriodEnd: state.currentPeriodEnd,
-      cancelAtPeriodEnd: state.cancelAtPeriodEnd,
       ...(stamp === undefined ? {} : { stamp }),
     });
     // Durable backstop for the membership-driven reporter: any subscription webhook re-reports the
@@ -457,13 +479,36 @@ export class BillingRuntime {
   }
 
   private async resolveCustomer(input: CreateCheckoutInput): Promise<string> {
-    const existing = await this.database.getOrganizationSubscription(input.organizationId);
+    const existing = await this.database.getOrganizationBillingCustomer(input.organizationId);
     if (existing !== undefined) return existing.stripeCustomerId;
     return this.billingClient.ensureCustomer({
       organizationId: input.organizationId,
       email: input.accountEmail,
       name: input.accountName,
     });
+  }
+
+  private customerSubscriptions(customerId: string): Promise<readonly StripeSubscriptionState[]> {
+    const now = Date.now();
+    const cached = this.subscriptionCache.get(customerId);
+    if (cached?.value !== undefined && cached.expiresAt > now) return Promise.resolve(cached.value);
+    if (cached?.pending !== undefined) return cached.pending;
+    const pending = this.billingClient
+      .listCustomerSubscriptions(customerId)
+      .then((value) => {
+        this.subscriptionCache.set(customerId, { value, expiresAt: Date.now() + 5_000 });
+        return value;
+      })
+      .catch((error: unknown) => {
+        this.subscriptionCache.delete(customerId);
+        throw error;
+      });
+    this.subscriptionCache.set(customerId, { value: cached?.value ?? [], expiresAt: 0, pending });
+    return pending;
+  }
+
+  private invalidateSubscriptions(customerId: string): void {
+    this.subscriptionCache.delete(customerId);
   }
 
   private async resolvePlanPrice(

--- a/src/billing/plan-prices.ts
+++ b/src/billing/plan-prices.ts
@@ -1,8 +1,8 @@
 import type { BillingPlanPriceInterval, BillingPlanPriceRecord } from "../db/types.js";
 
 /**
- * The lookup key a plan's price for an interval must carry: `{slug}_{interval}` — `solo_monthly`,
- * `team_annual`. This is catalog identity. Prices are selected by exact lookup key, never by "the
+ * The lookup key a plan's price for an interval must carry: `{slug}_{interval}` —
+ * `hosted_monthly`. This is catalog identity. Prices are selected by exact lookup key, never by "the
  * first active price for this interval", so a second active monthly price is a rejected ambiguity
  * rather than an arbitrary amount to charge or display.
  */

--- a/src/billing/plan-template.test.ts
+++ b/src/billing/plan-template.test.ts
@@ -39,6 +39,16 @@ describe("parsePlanMetadata", () => {
     );
   });
 
+  it("accepts zero for the Free plan's execution meter", () => {
+    const result = parsePlanMetadata({ ...VALID_METADATA, ent_executions_monthly_limit: "0" });
+
+    assert.equal(result.success, true);
+    assert.equal(
+      result.success ? result.data.template.meters["executions.monthly"].limit : undefined,
+      0,
+    );
+  });
+
   it("rejects a non-numeric, non-unlimited limit instead of storing a garbage template", () => {
     const result = parsePlanMetadata({ ...VALID_METADATA, ent_seats_max: "lots" });
     assert.equal(result.success, false);

--- a/src/billing/plan-template.ts
+++ b/src/billing/plan-template.ts
@@ -18,6 +18,16 @@ const positiveIntegerOrUnlimited = z.string().transform((value, ctx) => {
   return parsed;
 });
 
+const nonnegativeIntegerOrUnlimited = z.string().transform((value, ctx) => {
+  if (value === "unlimited") return null;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    ctx.addIssue({ code: "custom", message: `must be a nonnegative integer or "unlimited"` });
+    return z.NEVER;
+  }
+  return parsed;
+});
+
 const booleanFlag = z.enum(["true", "false"]).transform((value) => value === "true");
 
 /**
@@ -29,7 +39,7 @@ const planMetadataSchema = z.object({
   paseo_plan_slug: z.string().trim().min(1, "paseo_plan_slug must not be blank"),
   ent_seats_max: positiveIntegerOrUnlimited,
   ent_can_invite: booleanFlag,
-  ent_executions_monthly_limit: positiveIntegerOrUnlimited,
+  ent_executions_monthly_limit: nonnegativeIntegerOrUnlimited,
 });
 
 export interface ParsedPlanTemplate {

--- a/src/billing/provisioning-entitlement.test.ts
+++ b/src/billing/provisioning-entitlement.test.ts
@@ -13,6 +13,7 @@ const unusedCatalogSource: StripeCatalogSource = {
 };
 const unusedBillingClient: StripeBillingClient = {
   ensureCustomer: () => Promise.reject(new Error("unused")),
+  listCustomerSubscriptions: () => Promise.reject(new Error("unused")),
   createCheckoutSession: () => Promise.reject(new Error("unused")),
   changeSubscriptionPrice: () => Promise.reject(new Error("unused")),
   reportSeatQuantity: () => Promise.reject(new Error("unused")),

--- a/src/billing/provisioning-entitlement.test.ts
+++ b/src/billing/provisioning-entitlement.test.ts
@@ -40,7 +40,7 @@ function freePlan(overrides: Partial<SyncBillingPlanInput> = {}): SyncBillingPla
     template: {
       seats: { max: 1 },
       canInviteMembers: false,
-      meters: { "executions.monthly": { limit: 100 } },
+      meters: { "executions.monthly": { limit: 0 } },
     },
     templateHash: "hash-free",
     marketing: { features: ["1 seat"] },
@@ -61,7 +61,7 @@ describe("BillingRuntime.provisioningEntitlement", () => {
     assert.deepEqual(entitlement.granted, {
       seats: { max: 1 },
       canInviteMembers: false,
-      meters: { "executions.monthly": { limit: 100 } },
+      meters: { "executions.monthly": { limit: 0 } },
     });
   });
 

--- a/src/billing/public-catalog.test.ts
+++ b/src/billing/public-catalog.test.ts
@@ -1,0 +1,151 @@
+import assert from "node:assert/strict";
+import { describe, it } from "vitest";
+import { createMemoryDatabase } from "../db/memory.js";
+import type { Database, SyncBillingPlanInput } from "../db/types.js";
+import { composeBilling, type BillingRuntime } from "./index.js";
+import type { StripeCatalogSource } from "./stripe-catalog-source.js";
+import type { StripeBillingClient, StripeSubscriptionState } from "./stripe-billing-client.js";
+
+/**
+ * The public catalog boundary. `free` is an internal entitlement record — the template a hosted
+ * organization is stamped with before it pays and again after it cancels — not something a
+ * customer can buy. Billing commits to that distinction here, so no consumer (the plans endpoint,
+ * the billing overview, the picker) has to know the slug or re-derive the rule.
+ */
+
+const unusedCatalogSource: StripeCatalogSource = {
+  listProducts: () => Promise.reject(new Error("unused")),
+  listPrices: () => Promise.reject(new Error("unused")),
+};
+const unusedBillingClient: StripeBillingClient = {
+  ensureCustomer: () => Promise.reject(new Error("unused")),
+  listCustomerSubscriptions: () => Promise.reject(new Error("unused")),
+  createCheckoutSession: () => Promise.reject(new Error("unused")),
+  changeSubscriptionPrice: () => Promise.reject(new Error("unused")),
+  reportSeatQuantity: () => Promise.reject(new Error("unused")),
+  createBillingPortalSession: () => Promise.reject(new Error("unused")),
+  getSubscription: (): Promise<StripeSubscriptionState | undefined> =>
+    Promise.reject(new Error("unused")),
+};
+
+function billingOver(database: Database): BillingRuntime {
+  return composeBilling({
+    config: { stripeSecretKey: "sk_test_fake", stripeWebhookSecret: "whsec_fake" },
+    database,
+    catalogSource: unusedCatalogSource,
+    billingClient: unusedBillingClient,
+    seatUsage: () => Promise.resolve(0),
+  });
+}
+
+const internalFreePlan: SyncBillingPlanInput = {
+  id: "prod_free",
+  slug: "free",
+  name: "Free",
+  template: {
+    seats: { max: 1 },
+    canInviteMembers: false,
+    meters: { "executions.monthly": { limit: 0 } },
+  },
+  templateHash: "hash-free",
+  marketing: { features: ["0 executions / month"] },
+  active: true,
+  prices: [
+    {
+      id: "price_free_monthly",
+      lookupKey: "free_monthly",
+      interval: "monthly",
+      unitAmount: 0,
+      currency: "eur",
+      active: true,
+    },
+  ],
+};
+
+const hostedPlan: SyncBillingPlanInput = {
+  id: "prod_hosted",
+  slug: "hosted",
+  name: "Paseo Hub",
+  template: {
+    seats: { max: null },
+    canInviteMembers: true,
+    meters: { "executions.monthly": { limit: null } },
+  },
+  templateHash: "hash-hosted",
+  marketing: { features: ["Unlimited daemons"] },
+  active: true,
+  prices: [
+    {
+      id: "price_hosted_monthly",
+      lookupKey: "hosted_monthly",
+      interval: "monthly",
+      unitAmount: 1500,
+      currency: "eur",
+      active: true,
+    },
+  ],
+};
+
+describe("BillingRuntime.publicCatalog", () => {
+  it("publishes the purchasable plan and withholds the internal free record", async () => {
+    const database = createMemoryDatabase();
+    await database.syncBillingPlan(internalFreePlan);
+    await database.syncBillingPlan(hostedPlan);
+
+    const catalog = await billingOver(database).publicCatalog();
+
+    assert.deepEqual(catalog, [
+      {
+        slug: "hosted",
+        name: "Paseo Hub",
+        marketingFeatures: ["Unlimited daemons"],
+        prices: { monthly: { unitAmount: 1500, currency: "eur" }, annual: null },
+      },
+    ]);
+  });
+
+  it("publishes nothing when the catalog carries only the internal free record", async () => {
+    const database = createMemoryDatabase();
+    await database.syncBillingPlan(internalFreePlan);
+
+    assert.deepEqual(await billingOver(database).publicCatalog(), []);
+  });
+
+  it("withholds a plan the catalog sync deactivated", async () => {
+    const database = createMemoryDatabase();
+    await database.syncBillingPlan({ ...hostedPlan, active: false });
+
+    assert.deepEqual(await billingOver(database).publicCatalog(), []);
+  });
+
+  it("never carries the entitlement template off the boundary", async () => {
+    const database = createMemoryDatabase();
+    await database.syncBillingPlan(hostedPlan);
+
+    const [plan] = await billingOver(database).publicCatalog();
+
+    assert.notEqual(plan, undefined);
+    assert.deepEqual(Object.keys(plan!).sort(), ["marketingFeatures", "name", "prices", "slug"]);
+  });
+
+  it("prices an interval only from its exact lookup key, so a mismatched price reads unavailable", async () => {
+    const database = createMemoryDatabase();
+    await database.syncBillingPlan({
+      ...hostedPlan,
+      prices: [
+        {
+          id: "price_legacy",
+          lookupKey: "hub_monthly",
+          interval: "monthly",
+          unitAmount: 900,
+          currency: "eur",
+          active: true,
+        },
+      ],
+    });
+
+    const [plan] = await billingOver(database).publicCatalog();
+
+    assert.deepEqual(plan?.prices, { monthly: null, annual: null });
+  });
+});

--- a/src/billing/public-catalog.ts
+++ b/src/billing/public-catalog.ts
@@ -1,0 +1,69 @@
+import { z } from "zod";
+import { reportFailure } from "../failures/index.js";
+import type { BillingPlanPriceInterval, BillingPlanRecord } from "../db/types.js";
+import { selectActivePlanPrice } from "./plan-prices.js";
+
+/**
+ * The public plan catalog: name, slug, prices by interval, marketing bullets. The entitlement
+ * template never crosses this boundary — see the plan's public plans endpoint section.
+ */
+export interface PublicBillingPlan {
+  slug: string;
+  name: string;
+  marketingFeatures: readonly string[];
+  prices: Record<BillingPlanPriceInterval, PublicBillingPlanPrice | null>;
+}
+
+export interface PublicBillingPlanPrice {
+  unitAmount: number;
+  currency: string;
+}
+
+const billingPlanMarketingSchema = z.object({ features: z.array(z.string()) });
+
+/**
+ * Turns the catalog mirror into the plans a customer may buy. Two things are withheld: a plan the
+ * sync deactivated, and `excludeSlug` — the internal entitlement record (see `FREE_PLAN_SLUG`),
+ * which exists so provisioning and cancellation have a template to stamp, not so anyone can
+ * purchase it. Withholding it here is what lets every consumer treat "the catalog" as "the offer".
+ */
+export function publicBillingPlans(
+  records: readonly BillingPlanRecord[],
+  excludeSlug: string,
+): PublicBillingPlan[] {
+  return records
+    .filter((record) => record.active && record.slug !== excludeSlug)
+    .map(publicBillingPlan);
+}
+
+function publicBillingPlan(record: BillingPlanRecord): PublicBillingPlan {
+  return {
+    slug: record.slug,
+    name: record.name,
+    marketingFeatures: billingPlanMarketingSchema.parse(record.marketing).features,
+    prices: {
+      monthly: activePriceForInterval(record, "monthly"),
+      annual: activePriceForInterval(record, "annual"),
+    },
+  };
+}
+
+function activePriceForInterval(
+  record: BillingPlanRecord,
+  interval: BillingPlanPriceInterval,
+): PublicBillingPlanPrice | null {
+  // Exact `{slug}_{interval}` lookup-key identity, matching checkout. Ambiguous pricing (two active
+  // prices for one key) is surfaced as "unavailable" and logged, never displayed as an arbitrary
+  // amount the customer might not be charged.
+  try {
+    const price = selectActivePlanPrice(record.prices, record.slug, interval);
+    return price === undefined ? null : { unitAmount: price.unitAmount, currency: price.currency };
+  } catch (error) {
+    reportFailure(
+      error,
+      { operation: "billing.catalog.price.select", component: "billing", provider: "stripe" },
+      { kind: "conflict", diagnostic: { planSlug: record.slug, interval } },
+    );
+    return null;
+  }
+}

--- a/src/billing/reconcile.test.ts
+++ b/src/billing/reconcile.test.ts
@@ -41,7 +41,7 @@ const PRODUCTS: StripeCatalogProduct[] = [
       paseo_plan_slug: "free",
       ent_seats_max: "1",
       ent_can_invite: "false",
-      ent_executions_monthly_limit: "100",
+      ent_executions_monthly_limit: "0",
     },
     marketingFeatures: [],
   },

--- a/src/billing/reconcile.test.ts
+++ b/src/billing/reconcile.test.ts
@@ -21,6 +21,10 @@ import type {
 // entitlements onto the subscription's live state, idempotently, and stamps Free when it ends.
 // Signature verification runs for real (HMAC over `${timestamp}.${payload}` with the webhook
 // secret), the same scheme Stripe uses, so nothing here mocks the SDK.
+//
+// The three products below are synthetic: reconciliation has to converge across plan changes, and
+// Hub sells one plan today. The catalog a customer actually sees is fixed at the public boundary
+// (`public-catalog.test.ts`) and mirrored for E2E in `src/e2e/harness/browser-billing.ts`.
 
 const WEBHOOK_SECRET = "whsec_reconcile_test";
 
@@ -319,5 +323,56 @@ describe("subscription webhook reconciliation", () => {
     // reconciles without re-reporting — no ping-pong.
     await billing.handleWebhook(subscriptionWebhook("customer.subscription.updated", "sub_1"));
     assert.equal((await billingClient.getSubscription("sub_1"))?.quantity, 3);
+  });
+});
+
+/**
+ * What the billing page is handed after reconciliation. The free record is the enforcement floor,
+ * never an offer: an organization sitting on it has no plan to show, so the page reads as a
+ * paywall instead of advertising a tier that is not for sale.
+ */
+describe("customer-facing subscription view", () => {
+  it("names the plan an organization is trialing", async () => {
+    const { billingClient, billing } = await setup();
+    billingClient.setSubscription("sub_1", "org_1", SOLO_PRICE, "trialing");
+    await billing.handleWebhook(subscriptionWebhook("customer.subscription.created", "sub_1"));
+
+    const view = await billing.subscriptionSnapshot("org_1");
+
+    assert.equal(view.planSlug, "solo");
+    assert.equal(view.planName, "Solo");
+    assert.equal(view.status, "trialing");
+    assert.equal(view.manageable, true);
+    assert.equal(view.trialEligible, false);
+  });
+
+  it("reports no plan after cancellation instead of the free record it stamped", async () => {
+    const { database, billingClient, billing } = await setup();
+    billingClient.setSubscription("sub_1", "org_1", SOLO_PRICE);
+    await billing.handleWebhook(subscriptionWebhook("customer.subscription.created", "sub_1"));
+    billingClient.cancel("sub_1");
+    await billing.handleWebhook(subscriptionWebhook("customer.subscription.deleted", "sub_1"));
+    // The stamp really is Free — enforcement reverted — the customer view just does not show it.
+    assert.equal((await database.getOrganizationEntitlements("org_1"))?.planId, FREE_PRODUCT);
+
+    const view = await billing.subscriptionSnapshot("org_1");
+
+    assert.equal(view.planSlug, null);
+    assert.equal(view.planName, null);
+    assert.equal(view.status, null);
+    assert.equal(view.manageable, false);
+    // The cancelled subscription is still Stripe history, so no second free trial is offered.
+    assert.equal(view.trialEligible, false);
+  });
+
+  it("reports no plan for an organization that never subscribed, and offers it the trial", async () => {
+    const { billing } = await setup();
+
+    const view = await billing.subscriptionSnapshot("org_never");
+
+    assert.equal(view.planSlug, null);
+    assert.equal(view.planName, null);
+    assert.equal(view.trialEligible, true);
+    assert.equal(view.manageable, false);
   });
 });

--- a/src/billing/reconcile.test.ts
+++ b/src/billing/reconcile.test.ts
@@ -114,6 +114,7 @@ class FakeBillingClient implements StripeBillingClient {
       quantity: 1,
       status,
       currentPeriodEnd: new Date("2030-01-01T00:00:00Z"),
+      trialEnd: status === "trialing" ? new Date("2030-01-15T00:00:00Z") : null,
       cancelAtPeriodEnd: false,
     });
   }
@@ -123,8 +124,20 @@ class FakeBillingClient implements StripeBillingClient {
     if (state !== undefined) state.status = "canceled";
   }
 
+  setStatus(id: string, status: string): void {
+    const state = this.subscriptions.get(id);
+    if (state !== undefined) state.status = status;
+  }
+
   async ensureCustomer(): Promise<string> {
     throw new Error("unused");
+  }
+  async listCustomerSubscriptions(customerId: string): Promise<readonly StripeSubscriptionState[]> {
+    const result: StripeSubscriptionState[] = [];
+    for (const subscription of this.subscriptions.values()) {
+      if (subscription.customerId === customerId) result.push({ ...subscription });
+    }
+    return result;
   }
   async createCheckoutSession(): Promise<{ url: string }> {
     throw new Error("unused");
@@ -242,6 +255,25 @@ describe("subscription webhook reconciliation", () => {
     );
     assert.equal(deleted.status, 200);
     assert.equal(await grantedSeatsMax(database, "org_1"), 1); // Free caps seats
+    assert.equal((await database.getOrganizationEntitlements("org_1"))?.planId, FREE_PRODUCT);
+  });
+
+  it("grants trialing and active access, revokes canceled and unpaid access, and preserves past_due", async () => {
+    const { database, billingClient, billing } = await setup();
+    billingClient.setSubscription("sub_1", "org_1", SOLO_PRICE, "trialing");
+    await billing.handleWebhook(subscriptionWebhook("customer.subscription.created", "sub_1"));
+    assert.equal((await database.getOrganizationEntitlements("org_1"))?.planId, SOLO_PRODUCT);
+
+    billingClient.setStatus("sub_1", "active");
+    await billing.handleWebhook(subscriptionWebhook("customer.subscription.updated", "sub_1"));
+    assert.equal((await database.getOrganizationEntitlements("org_1"))?.planId, SOLO_PRODUCT);
+
+    billingClient.setStatus("sub_1", "past_due");
+    await billing.handleWebhook(subscriptionWebhook("customer.subscription.updated", "sub_1"));
+    assert.equal((await database.getOrganizationEntitlements("org_1"))?.planId, SOLO_PRODUCT);
+
+    billingClient.setStatus("sub_1", "unpaid");
+    await billing.handleWebhook(subscriptionWebhook("customer.subscription.updated", "sub_1"));
     assert.equal((await database.getOrganizationEntitlements("org_1"))?.planId, FREE_PRODUCT);
   });
 

--- a/src/billing/stripe-billing-client.ts
+++ b/src/billing/stripe-billing-client.ts
@@ -12,6 +12,7 @@
 export interface StripeBillingClient {
   /** The Stripe customer for an organization, created if it does not exist yet. */
   ensureCustomer(input: EnsureCustomerInput): Promise<string>;
+  listCustomerSubscriptions(customerId: string): Promise<readonly StripeSubscriptionState[]>;
   /** A Checkout Session for the organization's *first* subscription to `priceId`, carrying
    * `organizationId` in metadata so the subscription webhook can resolve the reference on re-read.
    * Only ever called when the organization has no subscription yet — a plan change goes through
@@ -48,6 +49,7 @@ export interface CreateCheckoutSessionInput {
   quantity: number;
   successUrl: string;
   cancelUrl: string;
+  trial: boolean;
 }
 
 export interface ChangeSubscriptionPriceInput {
@@ -77,5 +79,6 @@ export interface StripeSubscriptionState {
   /** Stripe's own status vocabulary, verbatim (`active`, `trialing`, `canceled`, …). */
   status: string;
   currentPeriodEnd: Date | null;
+  trialEnd: Date | null;
   cancelAtPeriodEnd: boolean;
 }

--- a/src/billing/stripe-client.ts
+++ b/src/billing/stripe-client.ts
@@ -90,19 +90,45 @@ export function createStripeBillingClient(stripeSecretKey: string): StripeBillin
       );
       return customer.id;
     },
+    async listCustomerSubscriptions(
+      customerId: string,
+    ): Promise<readonly StripeSubscriptionState[]> {
+      const result: StripeSubscriptionState[] = [];
+      for await (const subscription of stripe.subscriptions.list({
+        customer: customerId,
+        status: "all",
+        limit: LIST_PAGE_SIZE,
+      })) {
+        const organizationId = subscription.metadata[ORGANIZATION_REFERENCE_METADATA_KEY];
+        const item = subscription.items.data[0];
+        if (organizationId !== undefined && item !== undefined)
+          result.push(toSubscriptionState(subscription, organizationId, item));
+      }
+      return result;
+    },
     async createCheckoutSession(input: CreateCheckoutSessionInput): Promise<{ url: string }> {
-      const session = await stripe.checkout.sessions.create({
-        mode: "subscription",
-        customer: input.customerId,
-        line_items: [{ price: input.priceId, quantity: input.quantity }],
-        success_url: input.successUrl,
-        cancel_url: input.cancelUrl,
-        client_reference_id: input.organizationId,
-        subscription_data: {
+      const session = await stripe.checkout.sessions.create(
+        {
+          mode: "subscription",
+          customer: input.customerId,
+          line_items: [{ price: input.priceId, quantity: input.quantity }],
+          success_url: input.successUrl,
+          cancel_url: input.cancelUrl,
+          client_reference_id: input.organizationId,
           metadata: { [ORGANIZATION_REFERENCE_METADATA_KEY]: input.organizationId },
+          subscription_data: input.trial
+            ? {
+                trial_period_days: 14,
+                trial_settings: { end_behavior: { missing_payment_method: "cancel" } },
+                metadata: { [ORGANIZATION_REFERENCE_METADATA_KEY]: input.organizationId },
+              }
+            : { metadata: { [ORGANIZATION_REFERENCE_METADATA_KEY]: input.organizationId } },
+          ...(input.trial ? { payment_method_collection: "if_required" } : {}),
         },
-        metadata: { [ORGANIZATION_REFERENCE_METADATA_KEY]: input.organizationId },
-      });
+        {
+          idempotencyKey: `checkout:${input.organizationId}:${input.priceId}:${input.trial ? "trial" : "paid"}`,
+        },
+      );
       if (session.url === null) throw new Error("Stripe checkout session has no redirect URL");
       return { url: session.url };
     },
@@ -147,19 +173,26 @@ export function createStripeBillingClient(stripeSecretKey: string): StripeBillin
       const organizationId = subscription.metadata[ORGANIZATION_REFERENCE_METADATA_KEY];
       const item = subscription.items.data[0];
       if (organizationId === undefined || item === undefined) return undefined;
-      return {
-        id: subscription.id,
-        customerId:
-          typeof subscription.customer === "string"
-            ? subscription.customer
-            : subscription.customer.id,
-        organizationId,
-        priceId: item.price.id,
-        quantity: item.quantity ?? 1,
-        status: subscription.status,
-        currentPeriodEnd: new Date(item.current_period_end * 1000),
-        cancelAtPeriodEnd: subscription.cancel_at_period_end,
-      };
+      return toSubscriptionState(subscription, organizationId, item);
     },
+  };
+}
+
+function toSubscriptionState(
+  subscription: StripeSDK.Subscription,
+  organizationId: string,
+  item: StripeSDK.SubscriptionItem,
+): StripeSubscriptionState {
+  return {
+    id: subscription.id,
+    customerId:
+      typeof subscription.customer === "string" ? subscription.customer : subscription.customer.id,
+    organizationId,
+    priceId: item.price.id,
+    quantity: item.quantity ?? 1,
+    status: subscription.status,
+    currentPeriodEnd: new Date(item.current_period_end * 1000),
+    trialEnd: subscription.trial_end === null ? null : new Date(subscription.trial_end * 1000),
+    cancelAtPeriodEnd: subscription.cancel_at_period_end,
   };
 }

--- a/src/billing/ui/panel.tsx
+++ b/src/billing/ui/panel.tsx
@@ -14,7 +14,7 @@ import { useRouteTenant } from "../../projects/context.js";
 import type { BillingOverviewView, PublicBillingPlan } from "../../server/runtime.js";
 import { billingOverview, billingPortal } from "./functions.js";
 import { PlanDialog } from "./plan-dialog.js";
-import { subscriptionSummary, type SubscriptionSummary } from "./presentation.js";
+import { NO_SUBSCRIPTION, subscriptionSummary, type SubscriptionSummary } from "./presentation.js";
 
 type PortalResult = Awaited<ReturnType<typeof billingPortal>>;
 
@@ -111,7 +111,7 @@ function PlanIdentity({
           </div>
         )}
         <p className="text-2xl leading-tight font-semibold tracking-tight">
-          {summary.planName ?? "No plan yet"}
+          {summary.planName ?? NO_SUBSCRIPTION}
         </p>
         <p className="text-sm text-muted-foreground">{summary.detail}</p>
       </div>

--- a/src/billing/ui/panel.tsx
+++ b/src/billing/ui/panel.tsx
@@ -69,9 +69,8 @@ function BillingContent({ overview, slug }: { overview: BillingOverviewView; slu
         <div className="overflow-hidden rounded-xl border bg-card text-card-foreground">
           <PlanIdentity
             summary={summary}
-            canManage={canManage}
-            hasPlan={subscription.planSlug !== null}
-            onChangePlan={openDialog}
+            action={planPickerAction({ canManage, subscription, plans })}
+            onOpenPicker={openDialog}
           />
           {currentPlan !== undefined && <PlanIncludes plan={currentPlan} />}
           {canManage && subscription.manageable && <PortalBand slug={slug} />}
@@ -90,16 +89,34 @@ function BillingContent({ overview, slug }: { overview: BillingOverviewView; slu
   );
 }
 
+/**
+ * The button that opens the picker, or null when opening it would offer nothing. An organization
+ * with no subscription is offered the one thing there is to do; a subscribed one is offered a
+ * change only when the catalog publishes something to change to. Manage billing, in the band
+ * below, is the way to leave.
+ */
+function planPickerAction({
+  canManage,
+  subscription,
+  plans,
+}: {
+  canManage: boolean;
+  subscription: BillingOverviewView["subscription"];
+  plans: readonly PublicBillingPlan[];
+}): string | null {
+  if (!canManage) return null;
+  if (subscription.planSlug === null) return "Subscribe";
+  return plans.length > 1 ? "Change plan" : null;
+}
+
 function PlanIdentity({
   summary,
-  canManage,
-  hasPlan,
-  onChangePlan,
+  action,
+  onOpenPicker,
 }: {
   summary: SubscriptionSummary;
-  canManage: boolean;
-  hasPlan: boolean;
-  onChangePlan: () => void;
+  action: string | null;
+  onOpenPicker: () => void;
 }) {
   return (
     <div className="flex flex-wrap items-start justify-between gap-4 p-5 sm:p-6">
@@ -113,11 +130,13 @@ function PlanIdentity({
         <p className="text-2xl leading-tight font-semibold tracking-tight">
           {summary.planName ?? NO_SUBSCRIPTION}
         </p>
-        <p className="text-sm text-muted-foreground">{summary.detail}</p>
+        {summary.detail !== null && (
+          <p className="text-sm text-muted-foreground">{summary.detail}</p>
+        )}
       </div>
-      {canManage && (
-        <Button type="button" onClick={onChangePlan}>
-          {hasPlan ? "Change plan" : "Choose a plan"}
+      {action !== null && (
+        <Button type="button" onClick={onOpenPicker}>
+          {action}
         </Button>
       )}
     </div>
@@ -128,10 +147,7 @@ function PlanIdentity({
 function PlanIncludes({ plan }: { plan: PublicBillingPlan }) {
   if (plan.marketingFeatures.length === 0) return null;
   return (
-    <div className="grid gap-3 border-t bg-muted/20 p-5 sm:p-6">
-      <h3 className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
-        What's included
-      </h3>
+    <div className="border-t bg-muted/20 p-5 sm:p-6">
       <ul className="grid gap-2 text-sm sm:grid-cols-2 sm:gap-x-6">
         {plan.marketingFeatures.map((feature) => (
           <li key={feature} className="flex items-start gap-2">
@@ -157,15 +173,10 @@ function PortalBand({ slug }: { slug: string }) {
   const start = useCallback(() => open.mutate({ data: { organizationSlug: slug } }), [open, slug]);
 
   return (
-    <div className="grid gap-3 border-t p-5 sm:p-6">
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <p className="text-sm text-muted-foreground">
-          Payment methods, invoices, and cancellation live in the Stripe billing portal.
-        </p>
-        <Button type="button" variant="outline" size="sm" onClick={start} disabled={open.isPending}>
-          Manage billing
-        </Button>
-      </div>
+    <div className="grid justify-items-start gap-3 border-t p-5 sm:p-6">
+      <Button type="button" variant="outline" size="sm" onClick={start} disabled={open.isPending}>
+        Manage billing
+      </Button>
       {error !== undefined && (
         <Alert variant="destructive">
           <AlertDescription>{error}</AlertDescription>

--- a/src/billing/ui/panel.tsx
+++ b/src/billing/ui/panel.tsx
@@ -189,7 +189,8 @@ function PlanDialog({
         <DialogHeader>
           <DialogTitle>Choose a plan</DialogTitle>
           <DialogDescription>
-            Billed through Stripe. You can change or cancel your plan at any time.
+            Start with 14 days free — no card required. Billing and cancellation are managed by
+            Stripe.
           </DialogDescription>
         </DialogHeader>
         <div
@@ -296,7 +297,7 @@ function PlanCard({
           disabled={isCurrent || pending || price === null}
           onClick={choose}
         >
-          {isCurrent ? "Current plan" : `Choose ${plan.name}`}
+          {isCurrent ? "Current plan" : `Start 14-day trial with ${plan.name}`}
         </Button>
       </CardFooter>
     </Card>
@@ -324,6 +325,7 @@ function priceLabel(
 
 function subscriptionStatusLabel(subscription: BillingOverviewView["subscription"]): string {
   if (subscription.planName === null) return "You're not on a plan yet.";
+  if (subscription.trialEnd !== null) return `Trial ends ${formatDate(subscription.trialEnd)}.`;
   if (subscription.cancelAtPeriodEnd && subscription.currentPeriodEnd !== null) {
     return `Cancels on ${formatDate(subscription.currentPeriodEnd)}.`;
   }

--- a/src/billing/ui/panel.tsx
+++ b/src/billing/ui/panel.tsx
@@ -118,6 +118,7 @@ function BillingContent({ overview, slug }: { overview: BillingOverviewView; slu
           plans={plans}
           slug={slug}
           currentPlanSlug={subscription.planSlug}
+          trialEligible={subscription.trialEligible}
           onClose={closeDialog}
         />
       )}
@@ -155,11 +156,13 @@ function PlanDialog({
   plans,
   slug,
   currentPlanSlug,
+  trialEligible,
   onClose,
 }: {
   plans: readonly PublicBillingPlan[];
   slug: string;
   currentPlanSlug: string | null;
+  trialEligible: boolean;
   onClose: () => void;
 }) {
   const [interval, setInterval] = useState<BillingPlanPriceInterval>("monthly");
@@ -189,8 +192,9 @@ function PlanDialog({
         <DialogHeader>
           <DialogTitle>Choose a plan</DialogTitle>
           <DialogDescription>
-            Start with 14 days free — no card required. Billing and cancellation are managed by
-            Stripe.
+            {trialEligible
+              ? "Start with 14 days free — no card required."
+              : "Billing and cancellation are managed by Stripe."}
           </DialogDescription>
         </DialogHeader>
         <div
@@ -215,6 +219,7 @@ function PlanDialog({
               plan={plan}
               interval={interval}
               isCurrent={plan.slug === currentPlanSlug}
+              trialEligible={trialEligible}
               pending={checkout.isPending}
               onChoose={choose}
             />
@@ -259,12 +264,14 @@ function PlanCard({
   plan,
   interval,
   isCurrent,
+  trialEligible,
   pending,
   onChoose,
 }: {
   plan: PublicBillingPlan;
   interval: BillingPlanPriceInterval;
   isCurrent: boolean;
+  trialEligible: boolean;
   pending: boolean;
   onChoose: (planSlug: string) => void;
 }) {
@@ -297,7 +304,11 @@ function PlanCard({
           disabled={isCurrent || pending || price === null}
           onClick={choose}
         >
-          {isCurrent ? "Current plan" : `Start 14-day trial with ${plan.name}`}
+          {isCurrent
+            ? "Current plan"
+            : trialEligible
+              ? `Start 14-day trial with ${plan.name}`
+              : `Choose ${plan.name}`}
         </Button>
       </CardFooter>
     </Card>

--- a/src/billing/ui/panel.tsx
+++ b/src/billing/ui/panel.tsx
@@ -6,39 +6,17 @@ import { useServerFn } from "@tanstack/react-start";
 import { Check } from "lucide-react";
 import { PageHeader } from "../../components/app/page.js";
 import { Section } from "../../components/app/section.js";
-import { StatusPill, type StatusTone } from "../../components/app/status-pill.js";
+import { StatusPill } from "../../components/app/status-pill.js";
 import { Alert, AlertDescription, AlertTitle } from "../../components/ui/alert.js";
-import { Badge } from "../../components/ui/badge.js";
 import { Button } from "../../components/ui/button.js";
-import {
-  Card,
-  CardAction,
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from "../../components/ui/card.js";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from "../../components/ui/dialog.js";
 import { Skeleton } from "../../components/ui/skeleton.js";
 import { useRouteTenant } from "../../projects/context.js";
-import type { BillingPlanPriceInterval } from "../../db/types.js";
 import type { BillingOverviewView, PublicBillingPlan } from "../../server/runtime.js";
-import { billingCheckout, billingOverview, billingPortal } from "./functions.js";
+import { billingOverview, billingPortal } from "./functions.js";
+import { PlanDialog } from "./plan-dialog.js";
+import { subscriptionSummary, type SubscriptionSummary } from "./presentation.js";
 
-type CheckoutResult = Awaited<ReturnType<typeof billingCheckout>>;
 type PortalResult = Awaited<ReturnType<typeof billingPortal>>;
-
-const INTERVALS: readonly { value: BillingPlanPriceInterval; label: string }[] = [
-  { value: "monthly", label: "Monthly" },
-  { value: "annual", label: "Annual" },
-];
 
 export function BillingPanel() {
   const tenant = useRouteTenant();
@@ -64,54 +42,40 @@ export function BillingPanel() {
   return <BillingContent overview={query.data.data} slug={tenant.organization.slug} />;
 }
 
+/**
+ * One card, banded top to bottom: who you are on this plan, what the plan includes, and the way
+ * out to Stripe. The bands share a card so the page reads as a single object rather than a stack
+ * of unrelated boxes, and each band owns its own padding so nothing collides.
+ */
 function BillingContent({ overview, slug }: { overview: BillingOverviewView; slug: string }) {
   const { subscription, plans, canManage } = overview;
   const [dialogOpen, setDialogOpen] = useState(false);
   const openDialog = useCallback(() => setDialogOpen(true), []);
   const closeDialog = useCallback(() => setDialogOpen(false), []);
+  const summary = subscriptionSummary(subscription);
+  const currentPlan = plans.find((plan) => plan.slug === subscription.planSlug);
 
   return (
     <>
       <PageHeader
         title="Billing"
         description={`Plan and billing for ${overview.organization.name}.`}
-      />
-      <p className="text-sm text-muted-foreground">
-        Your limits and current usage live on the{" "}
-        <Link to={`/o/${slug}/settings/usage` as never} className="underline underline-offset-4">
-          Usage
-        </Link>{" "}
-        page.
-      </p>
-      <Section
-        title="Plan"
-        description="Payment methods, invoices, and cancellation live in the Stripe billing portal."
       >
-        <Card>
-          <CardHeader>
-            <CardTitle>{subscription.planName ?? "No active plan"}</CardTitle>
-            <CardDescription>{subscriptionStatusLabel(subscription)}</CardDescription>
-            {canManage && (
-              <CardAction>
-                <Button type="button" onClick={openDialog}>
-                  {subscription.planSlug === null ? "Choose a plan" : "Change plan"}
-                </Button>
-              </CardAction>
-            )}
-          </CardHeader>
-          {subscription.status !== null && (
-            <CardContent>
-              <StatusPill tone={statusTone(subscription.status)}>
-                {statusText(subscription.status)}
-              </StatusPill>
-            </CardContent>
-          )}
-          {canManage && subscription.manageable && (
-            <CardFooter>
-              <ManageBillingButton slug={slug} />
-            </CardFooter>
-          )}
-        </Card>
+        <Button variant="outline" size="sm" asChild>
+          <Link to={`/o/${slug}/settings/usage` as never}>View usage</Link>
+        </Button>
+      </PageHeader>
+      <Section title="Plan">
+        <div className="overflow-hidden rounded-xl border bg-card text-card-foreground">
+          <PlanIdentity
+            summary={summary}
+            canManage={canManage}
+            hasPlan={subscription.planSlug !== null}
+            onChangePlan={openDialog}
+          />
+          {currentPlan !== undefined && <PlanIncludes plan={currentPlan} />}
+          {canManage && subscription.manageable && <PortalBand slug={slug} />}
+        </div>
       </Section>
       {dialogOpen && (
         <PlanDialog
@@ -126,7 +90,61 @@ function BillingContent({ overview, slug }: { overview: BillingOverviewView; slu
   );
 }
 
-function ManageBillingButton({ slug }: { slug: string }) {
+function PlanIdentity({
+  summary,
+  canManage,
+  hasPlan,
+  onChangePlan,
+}: {
+  summary: SubscriptionSummary;
+  canManage: boolean;
+  hasPlan: boolean;
+  onChangePlan: () => void;
+}) {
+  return (
+    <div className="flex flex-wrap items-start justify-between gap-4 p-5 sm:p-6">
+      <div className="grid min-w-0 gap-2">
+        {/* The pill is wrapped because a bare inline-flex stretches to the full grid track. */}
+        {summary.status !== null && (
+          <div>
+            <StatusPill tone={summary.status.tone}>{summary.status.label}</StatusPill>
+          </div>
+        )}
+        <p className="text-2xl leading-tight font-semibold tracking-tight">
+          {summary.planName ?? "No plan yet"}
+        </p>
+        <p className="text-sm text-muted-foreground">{summary.detail}</p>
+      </div>
+      {canManage && (
+        <Button type="button" onClick={onChangePlan}>
+          {hasPlan ? "Change plan" : "Choose a plan"}
+        </Button>
+      )}
+    </div>
+  );
+}
+
+/** What the organization is actually entitled to right now, in the plan author's own words. */
+function PlanIncludes({ plan }: { plan: PublicBillingPlan }) {
+  if (plan.marketingFeatures.length === 0) return null;
+  return (
+    <div className="grid gap-3 border-t bg-muted/20 p-5 sm:p-6">
+      <h3 className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+        What's included
+      </h3>
+      <ul className="grid gap-2 text-sm sm:grid-cols-2 sm:gap-x-6">
+        {plan.marketingFeatures.map((feature) => (
+          <li key={feature} className="flex items-start gap-2">
+            <Check aria-hidden="true" className="mt-0.5 size-4 shrink-0 text-primary" />
+            <span>{feature}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function PortalBand({ slug }: { slug: string }) {
   const open = useMutation({
     mutationFn: useServerFn(billingPortal) as (
       input: Parameters<typeof billingPortal>[0],
@@ -139,10 +157,15 @@ function ManageBillingButton({ slug }: { slug: string }) {
   const start = useCallback(() => open.mutate({ data: { organizationSlug: slug } }), [open, slug]);
 
   return (
-    <div className="grid gap-2">
-      <Button type="button" variant="outline" onClick={start} disabled={open.isPending}>
-        Manage billing
-      </Button>
+    <div className="grid gap-3 border-t p-5 sm:p-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <p className="text-sm text-muted-foreground">
+          Payment methods, invoices, and cancellation live in the Stripe billing portal.
+        </p>
+        <Button type="button" variant="outline" size="sm" onClick={start} disabled={open.isPending}>
+          Manage billing
+        </Button>
+      </div>
       {error !== undefined && (
         <Alert variant="destructive">
           <AlertDescription>{error}</AlertDescription>
@@ -152,220 +175,9 @@ function ManageBillingButton({ slug }: { slug: string }) {
   );
 }
 
-function PlanDialog({
-  plans,
-  slug,
-  currentPlanSlug,
-  trialEligible,
-  onClose,
-}: {
-  plans: readonly PublicBillingPlan[];
-  slug: string;
-  currentPlanSlug: string | null;
-  trialEligible: boolean;
-  onClose: () => void;
-}) {
-  const [interval, setInterval] = useState<BillingPlanPriceInterval>("monthly");
-  const checkout = useMutation({
-    mutationFn: useServerFn(billingCheckout) as (
-      input: Parameters<typeof billingCheckout>[0],
-    ) => Promise<CheckoutResult>,
-    onSuccess: (result) => {
-      if (result.status === "ok") redirectTo(result.data.url);
-    },
-  });
-  const error = checkout.data?.status === "error" ? checkout.data.error.message : undefined;
-  const handleOpenChange = useCallback(
-    (open: boolean) => {
-      if (!open) onClose();
-    },
-    [onClose],
-  );
-  const choose = useCallback(
-    (planSlug: string) => checkout.mutate({ data: { organizationSlug: slug, planSlug, interval } }),
-    [checkout, interval, slug],
-  );
-
-  return (
-    <Dialog open onOpenChange={handleOpenChange}>
-      <DialogContent className="sm:max-w-2xl">
-        <DialogHeader>
-          <DialogTitle>Choose a plan</DialogTitle>
-          <DialogDescription>
-            {trialEligible
-              ? "Start with 14 days free — no card required."
-              : "Billing and cancellation are managed by Stripe."}
-          </DialogDescription>
-        </DialogHeader>
-        <div
-          role="group"
-          aria-label="Billing interval"
-          className="inline-flex gap-1 self-start rounded-md border p-1"
-        >
-          {INTERVALS.map((option) => (
-            <IntervalOption
-              key={option.value}
-              value={option.value}
-              label={option.label}
-              active={interval === option.value}
-              onSelect={setInterval}
-            />
-          ))}
-        </div>
-        <div className="grid gap-4 sm:grid-cols-3">
-          {plans.map((plan) => (
-            <PlanCard
-              key={plan.slug}
-              plan={plan}
-              interval={interval}
-              isCurrent={plan.slug === currentPlanSlug}
-              trialEligible={trialEligible}
-              pending={checkout.isPending}
-              onChoose={choose}
-            />
-          ))}
-        </div>
-        {error !== undefined && (
-          <Alert variant="destructive">
-            <AlertDescription>{error}</AlertDescription>
-          </Alert>
-        )}
-      </DialogContent>
-    </Dialog>
-  );
-}
-
-function IntervalOption({
-  value,
-  label,
-  active,
-  onSelect,
-}: {
-  value: BillingPlanPriceInterval;
-  label: string;
-  active: boolean;
-  onSelect: (value: BillingPlanPriceInterval) => void;
-}) {
-  const select = useCallback(() => onSelect(value), [onSelect, value]);
-  return (
-    <Button
-      type="button"
-      size="sm"
-      variant={active ? "default" : "ghost"}
-      aria-pressed={active}
-      onClick={select}
-    >
-      {label}
-    </Button>
-  );
-}
-
-function PlanCard({
-  plan,
-  interval,
-  isCurrent,
-  trialEligible,
-  pending,
-  onChoose,
-}: {
-  plan: PublicBillingPlan;
-  interval: BillingPlanPriceInterval;
-  isCurrent: boolean;
-  trialEligible: boolean;
-  pending: boolean;
-  onChoose: (planSlug: string) => void;
-}) {
-  const price = plan.prices[interval];
-  const choose = useCallback(() => onChoose(plan.slug), [onChoose, plan.slug]);
-  return (
-    <Card className="gap-4 py-4" aria-label={`${plan.name} plan`}>
-      <CardHeader className="gap-1">
-        <CardTitle className="flex items-center justify-between gap-2">
-          <span>{plan.name}</span>
-          {isCurrent && <Badge variant="secondary">Current</Badge>}
-        </CardTitle>
-        <CardDescription>{priceLabel(price, interval)}</CardDescription>
-      </CardHeader>
-      <CardContent className="grid gap-2">
-        <ul className="grid gap-1.5 text-sm text-muted-foreground">
-          {plan.marketingFeatures.map((feature) => (
-            <li key={feature} className="flex items-start gap-2">
-              <Check aria-hidden="true" className="mt-0.5 size-4 shrink-0 text-primary" />
-              <span>{feature}</span>
-            </li>
-          ))}
-        </ul>
-      </CardContent>
-      <CardFooter>
-        <Button
-          type="button"
-          variant={isCurrent ? "outline" : "default"}
-          className="w-full"
-          disabled={isCurrent || pending || price === null}
-          onClick={choose}
-        >
-          {isCurrent
-            ? "Current plan"
-            : trialEligible
-              ? `Start 14-day trial with ${plan.name}`
-              : `Choose ${plan.name}`}
-        </Button>
-      </CardFooter>
-    </Card>
-  );
-}
-
 /** A web-only dashboard, so a plain navigation to the Stripe (or fixture) URL is correct. */
 function redirectTo(url: string): void {
   window.location.assign(url);
-}
-
-function priceLabel(
-  price: PublicBillingPlan["prices"][BillingPlanPriceInterval],
-  interval: BillingPlanPriceInterval,
-): string {
-  if (price === null) return "Not available";
-  if (price.unitAmount === 0) return "Free";
-  const amount = new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency: price.currency.toUpperCase(),
-    minimumFractionDigits: 0,
-  }).format(price.unitAmount / 100);
-  return `${amount} / ${interval === "monthly" ? "month" : "year"}`;
-}
-
-function subscriptionStatusLabel(subscription: BillingOverviewView["subscription"]): string {
-  if (subscription.planName === null) return "You're not on a plan yet.";
-  if (subscription.trialEnd !== null) return `Trial ends ${formatDate(subscription.trialEnd)}.`;
-  if (subscription.cancelAtPeriodEnd && subscription.currentPeriodEnd !== null) {
-    return `Cancels on ${formatDate(subscription.currentPeriodEnd)}.`;
-  }
-  if (subscription.currentPeriodEnd !== null) {
-    return `Renews on ${formatDate(subscription.currentPeriodEnd)}.`;
-  }
-  return "Active subscription.";
-}
-
-function formatDate(iso: string): string {
-  return new Date(iso).toLocaleDateString("en-US", {
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-  });
-}
-
-function statusTone(status: string): StatusTone {
-  if (status === "active" || status === "trialing") return "success";
-  if (status === "past_due" || status === "unpaid" || status === "incomplete") return "warning";
-  if (status === "canceled" || status === "incomplete_expired") return "neutral";
-  return "neutral";
-}
-
-function statusText(status: string): string {
-  return status
-    .split("_")
-    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-    .join(" ");
 }
 
 function BillingLoading() {

--- a/src/billing/ui/plan-dialog.tsx
+++ b/src/billing/ui/plan-dialog.tsx
@@ -1,0 +1,281 @@
+import { useCallback, useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { useServerFn } from "@tanstack/react-start";
+import { Check, Sparkles } from "lucide-react";
+import { Alert, AlertDescription } from "../../components/ui/alert.js";
+import { Badge } from "../../components/ui/badge.js";
+import { Button } from "../../components/ui/button.js";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "../../components/ui/dialog.js";
+import { cn } from "../../lib/utils.js";
+import type { BillingPlanPriceInterval } from "../../db/types.js";
+import type { PublicBillingPlan } from "../../server/runtime.js";
+import { billingCheckout } from "./functions.js";
+import {
+  intervalLabel,
+  offeredIntervals,
+  planAction,
+  planPrice,
+  recommendedPlanSlug,
+  trialFootnote,
+  TRIAL_DAYS,
+} from "./presentation.js";
+
+type CheckoutResult = Awaited<ReturnType<typeof billingCheckout>>;
+
+/**
+ * The plan picker. One modal, three bands: what the offer is, which interval to price it at, and
+ * the plans themselves. The grid and the modal width are both driven by how many plans the
+ * catalog publishes, so two plans read as a pair rather than two thirds of a three-column layout.
+ */
+export function PlanDialog({
+  plans,
+  slug,
+  currentPlanSlug,
+  trialEligible,
+  onClose,
+}: {
+  plans: readonly PublicBillingPlan[];
+  slug: string;
+  currentPlanSlug: string | null;
+  trialEligible: boolean;
+  onClose: () => void;
+}) {
+  const intervals = offeredIntervals(plans);
+  const [interval, setInterval] = useState<BillingPlanPriceInterval>(intervals[0] ?? "monthly");
+  const checkout = useMutation({
+    mutationFn: useServerFn(billingCheckout) as (
+      input: Parameters<typeof billingCheckout>[0],
+    ) => Promise<CheckoutResult>,
+    onSuccess: (result) => {
+      if (result.status === "ok") redirectTo(result.data.url);
+    },
+  });
+  const error = checkout.data?.status === "error" ? checkout.data.error.message : undefined;
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open) onClose();
+    },
+    [onClose],
+  );
+  const choose = useCallback(
+    (planSlug: string) => checkout.mutate({ data: { organizationSlug: slug, planSlug, interval } }),
+    [checkout, interval, slug],
+  );
+  const recommended = recommendedPlanSlug(plans, interval, currentPlanSlug);
+
+  return (
+    <Dialog open onOpenChange={handleOpenChange}>
+      <DialogContent
+        className={cn(
+          "max-h-[calc(100dvh-2rem)] gap-0 overflow-y-auto p-0",
+          dialogWidth(plans.length),
+        )}
+      >
+        <div className="grid justify-items-center gap-5 px-6 pt-6 pb-5">
+          {/* The badge reads the brand as text, so it uses `text-link`, not `text-primary` — the
+              fill colour only reaches 2.7:1 against this surface. See the palette note in
+              styles.css. */}
+          {trialEligible && (
+            <Badge variant="secondary" className="gap-1.5 px-3 py-1 text-link dark:bg-primary/15">
+              <Sparkles aria-hidden="true" className="size-3" />
+              {TRIAL_DAYS} days free · No card required
+            </Badge>
+          )}
+          <DialogHeader className="items-center gap-1.5 text-center">
+            <DialogTitle className="text-lg">Choose your plan</DialogTitle>
+            <DialogDescription className="max-w-md text-balance">
+              {trialEligible
+                ? "Nothing is charged until the trial ends, and you can add a card later."
+                : "Change plan at any time. Stripe handles payment, invoices, and cancellation."}
+            </DialogDescription>
+          </DialogHeader>
+          {intervals.length > 1 && (
+            <IntervalSwitch intervals={intervals} value={interval} onSelect={setInterval} />
+          )}
+        </div>
+        <div className={cn("grid gap-3 px-6 pb-6", planColumns(plans.length))}>
+          {plans.map((plan) => (
+            <PlanCard
+              key={plan.slug}
+              plan={plan}
+              interval={interval}
+              isCurrent={plan.slug === currentPlanSlug}
+              isRecommended={plan.slug === recommended}
+              trialEligible={trialEligible}
+              pending={checkout.isPending}
+              onChoose={choose}
+            />
+          ))}
+        </div>
+        {error !== undefined && (
+          <div className="px-6 pb-6">
+            <Alert variant="destructive">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/** A centred segmented control. Deliberately content-width: it is a choice between two words,
+ * not a page-wide toolbar. The selected chip is a raised surface, so the one green thing in the
+ * dialog stays the action the customer is here to take. */
+function IntervalSwitch({
+  intervals,
+  value,
+  onSelect,
+}: {
+  intervals: readonly BillingPlanPriceInterval[];
+  value: BillingPlanPriceInterval;
+  onSelect: (value: BillingPlanPriceInterval) => void;
+}) {
+  return (
+    <div
+      role="group"
+      aria-label="Billing interval"
+      className="inline-flex items-center gap-1 rounded-lg border bg-muted/50 p-1"
+    >
+      {intervals.map((interval) => (
+        <IntervalOption
+          key={interval}
+          value={interval}
+          active={interval === value}
+          onSelect={onSelect}
+        />
+      ))}
+    </div>
+  );
+}
+
+function IntervalOption({
+  value,
+  active,
+  onSelect,
+}: {
+  value: BillingPlanPriceInterval;
+  active: boolean;
+  onSelect: (value: BillingPlanPriceInterval) => void;
+}) {
+  const select = useCallback(() => onSelect(value), [onSelect, value]);
+  return (
+    <Button
+      type="button"
+      size="sm"
+      variant="ghost"
+      aria-pressed={active}
+      onClick={select}
+      className={cn(
+        "min-w-24 px-4 text-muted-foreground hover:text-foreground",
+        active && "bg-background text-foreground shadow-sm hover:bg-background",
+      )}
+    >
+      {intervalLabel(value)}
+    </Button>
+  );
+}
+
+function PlanCard({
+  plan,
+  interval,
+  isCurrent,
+  isRecommended,
+  trialEligible,
+  pending,
+  onChoose,
+}: {
+  plan: PublicBillingPlan;
+  interval: BillingPlanPriceInterval;
+  isCurrent: boolean;
+  isRecommended: boolean;
+  trialEligible: boolean;
+  pending: boolean;
+  onChoose: (planSlug: string) => void;
+}) {
+  const price = plan.prices[interval];
+  const action = planAction({ planName: plan.name, price, isCurrent, trialEligible });
+  const footnote = trialFootnote(price, interval, trialEligible);
+  const { amount, unit } = planPrice(price, interval);
+  const choose = useCallback(() => onChoose(plan.slug), [onChoose, plan.slug]);
+
+  return (
+    <div
+      className={cn(
+        "flex flex-col rounded-xl border bg-card p-5 text-card-foreground",
+        isRecommended && "border-primary/50 bg-primary/[0.04] ring-1 ring-primary/25",
+      )}
+    >
+      <div className="flex min-h-6 items-start justify-between gap-2">
+        <h3 className="text-sm font-medium">{plan.name}</h3>
+        <PlanBadge isCurrent={isCurrent} isRecommended={isRecommended} />
+      </div>
+      <p className="mt-3 text-3xl leading-none font-semibold tracking-tight">{amount}</p>
+      <p className="mt-1.5 text-xs text-muted-foreground">{unit}</p>
+      {/* Stacked on a phone, the plan you are already on collapses to a marker: its feature list
+          is the one thing on the screen nobody needs to read, and it costs a full scroll. */}
+      <ul
+        className={cn(
+          "mt-5 grid flex-1 content-start gap-2 text-sm text-muted-foreground",
+          isCurrent && "hidden sm:grid",
+        )}
+      >
+        {plan.marketingFeatures.map((feature) => (
+          <li key={feature} className="flex items-start gap-2">
+            <Check aria-hidden="true" className="mt-0.5 size-4 shrink-0 text-primary" />
+            <span>{feature}</span>
+          </li>
+        ))}
+      </ul>
+      {/* The footnote sits above the button so every column's button shares one bottom edge,
+          however much a plan has to explain about what happens after the trial. */}
+      <div className="mt-6 grid gap-2">
+        {footnote !== null && (
+          <p className="text-center text-xs text-balance text-muted-foreground">{footnote}</p>
+        )}
+        <Button
+          type="button"
+          variant={isRecommended ? "default" : "outline"}
+          aria-label={action.name}
+          className="w-full"
+          disabled={action.disabled || pending}
+          onClick={choose}
+        >
+          {action.label}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+/** At most one badge per plan, and being the current plan outranks being recommended. */
+function PlanBadge({ isCurrent, isRecommended }: { isCurrent: boolean; isRecommended: boolean }) {
+  if (isCurrent) return <Badge variant="secondary">Current</Badge>;
+  if (isRecommended) return <Badge>Recommended</Badge>;
+  return null;
+}
+
+/** Two plans read as a pair, three as a row. More than three wrap rather than shrink to slivers. */
+function planColumns(count: number): string {
+  if (count <= 1) return "";
+  if (count === 2) return "sm:grid-cols-2";
+  if (count === 3) return "sm:grid-cols-3";
+  return "sm:grid-cols-2";
+}
+
+function dialogWidth(count: number): string {
+  if (count <= 1) return "sm:max-w-sm";
+  if (count === 2) return "sm:max-w-2xl";
+  return "sm:max-w-3xl";
+}
+
+/** A web-only dashboard, so a plain navigation to the Stripe (or fixture) URL is correct. */
+function redirectTo(url: string): void {
+  window.location.assign(url);
+}

--- a/src/billing/ui/plan-dialog.tsx
+++ b/src/billing/ui/plan-dialog.tsx
@@ -92,7 +92,7 @@ export function PlanDialog({
             <DialogDescription className="max-w-md text-balance">
               {trialEligible
                 ? "Nothing is charged until the trial ends, and you can add a card later."
-                : "Change plan at any time. Stripe handles payment, invoices, and cancellation."}
+                : "Stripe handles payment and invoices. Cancel at any time."}
             </DialogDescription>
           </DialogHeader>
           {intervals.length > 1 && (
@@ -107,6 +107,9 @@ export function PlanDialog({
               interval={interval}
               isCurrent={plan.slug === currentPlanSlug}
               isRecommended={plan.slug === recommended}
+              // A recommendation only means something against alternatives; the badge and the
+              // ring would be decoration on a catalog that publishes one plan.
+              isHighlighted={plan.slug === recommended && plans.length > 1}
               trialEligible={trialEligible}
               pending={checkout.isPending}
               onChoose={choose}
@@ -187,6 +190,7 @@ function PlanCard({
   interval,
   isCurrent,
   isRecommended,
+  isHighlighted,
   trialEligible,
   pending,
   onChoose,
@@ -194,7 +198,10 @@ function PlanCard({
   plan: PublicBillingPlan;
   interval: BillingPlanPriceInterval;
   isCurrent: boolean;
+  /** The plan the picker leads with — it carries the filled call to action. */
   isRecommended: boolean;
+  /** Whether to say so visually, which only reads as a recommendation next to another plan. */
+  isHighlighted: boolean;
   trialEligible: boolean;
   pending: boolean;
   onChoose: (planSlug: string) => void;
@@ -209,12 +216,12 @@ function PlanCard({
     <div
       className={cn(
         "flex flex-col rounded-xl border bg-card p-5 text-card-foreground",
-        isRecommended && "border-primary/50 bg-primary/[0.04] ring-1 ring-primary/25",
+        isHighlighted && "border-primary/50 bg-primary/[0.04] ring-1 ring-primary/25",
       )}
     >
       <div className="flex min-h-6 items-start justify-between gap-2">
         <h3 className="text-sm font-medium">{plan.name}</h3>
-        <PlanBadge isCurrent={isCurrent} isRecommended={isRecommended} />
+        <PlanBadge isCurrent={isCurrent} isRecommended={isHighlighted} />
       </div>
       <p className="mt-3 text-3xl leading-none font-semibold tracking-tight">{amount}</p>
       <p className="mt-1.5 text-xs text-muted-foreground">{unit}</p>
@@ -270,7 +277,7 @@ function planColumns(count: number): string {
 }
 
 function dialogWidth(count: number): string {
-  if (count <= 1) return "sm:max-w-sm";
+  if (count <= 1) return "sm:max-w-md";
   if (count === 2) return "sm:max-w-2xl";
   return "sm:max-w-3xl";
 }

--- a/src/billing/ui/plan-dialog.tsx
+++ b/src/billing/ui/plan-dialog.tsx
@@ -5,13 +5,7 @@ import { Check, Sparkles } from "lucide-react";
 import { Alert, AlertDescription } from "../../components/ui/alert.js";
 import { Badge } from "../../components/ui/badge.js";
 import { Button } from "../../components/ui/button.js";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from "../../components/ui/dialog.js";
+import { Dialog, DialogContent, DialogTitle } from "../../components/ui/dialog.js";
 import { cn } from "../../lib/utils.js";
 import type { BillingPlanPriceInterval } from "../../db/types.js";
 import type { PublicBillingPlan } from "../../server/runtime.js";
@@ -21,17 +15,19 @@ import {
   offeredIntervals,
   planAction,
   planPrice,
-  recommendedPlanSlug,
-  trialFootnote,
   TRIAL_DAYS,
 } from "./presentation.js";
 
 type CheckoutResult = Awaited<ReturnType<typeof billingCheckout>>;
 
 /**
- * The plan picker. One modal, three bands: what the offer is, which interval to price it at, and
- * the plans themselves. The grid and the modal width are both driven by how many plans the
- * catalog publishes, so two plans read as a pair rather than two thirds of a three-column layout.
+ * The plan picker. It shows the offer and nothing else: the trial badge when one is available,
+ * then a card per plan, then the action. There is no heading, no framing sentence, and no
+ * interval control unless the catalog actually prices more than one interval — a customer who
+ * has one thing to accept should not have to read past anything to accept it.
+ *
+ * The grid and the modal width are driven by how many plans the catalog publishes, so a future
+ * second product lays out as a pair without a redesign.
  */
 export function PlanDialog({
   plans,
@@ -67,70 +63,65 @@ export function PlanDialog({
     (planSlug: string) => checkout.mutate({ data: { organizationSlug: slug, planSlug, interval } }),
     [checkout, interval, slug],
   );
-  const recommended = recommendedPlanSlug(plans, interval, currentPlanSlug);
 
   return (
     <Dialog open onOpenChange={handleOpenChange}>
       <DialogContent
+        aria-describedby={undefined}
         className={cn(
           "max-h-[calc(100dvh-2rem)] gap-0 overflow-y-auto p-0",
           dialogWidth(plans.length),
         )}
       >
-        <div className="grid justify-items-center gap-5 px-6 pt-6 pb-5">
-          {/* The badge reads the brand as text, so it uses `text-link`, not `text-primary` — the
-              fill colour only reaches 2.7:1 against this surface. See the palette note in
-              styles.css. */}
-          {trialEligible && (
-            <Badge variant="secondary" className="gap-1.5 px-3 py-1 text-link dark:bg-primary/15">
-              <Sparkles aria-hidden="true" className="size-3" />
-              {TRIAL_DAYS} days free · No card required
-            </Badge>
+        {/* Radix requires a title for the dialog to be announced. There is nothing on this
+            surface a sighted customer needs a heading for, so it is read, not shown. */}
+        <DialogTitle className="sr-only">Plan</DialogTitle>
+        <div className="grid gap-5 p-6">
+          {(trialEligible || intervals.length > 1) && (
+            <div className="grid justify-items-center gap-5">
+              {/* The badge reads the brand as text, so it uses `text-link`, not `text-primary` —
+                  the fill colour only reaches 2.7:1 against this surface. See the palette note in
+                  styles.css. */}
+              {trialEligible && (
+                <Badge
+                  variant="secondary"
+                  className="gap-1.5 px-3 py-1 text-link dark:bg-primary/15"
+                >
+                  <Sparkles aria-hidden="true" className="size-3" />
+                  {TRIAL_DAYS} days free · No card required
+                </Badge>
+              )}
+              {intervals.length > 1 && (
+                <IntervalSwitch intervals={intervals} value={interval} onSelect={setInterval} />
+              )}
+            </div>
           )}
-          <DialogHeader className="items-center gap-1.5 text-center">
-            <DialogTitle className="text-lg">Choose your plan</DialogTitle>
-            <DialogDescription className="max-w-md text-balance">
-              {trialEligible
-                ? "Nothing is charged until the trial ends, and you can add a card later."
-                : "Stripe handles payment and invoices. Cancel at any time."}
-            </DialogDescription>
-          </DialogHeader>
-          {intervals.length > 1 && (
-            <IntervalSwitch intervals={intervals} value={interval} onSelect={setInterval} />
-          )}
-        </div>
-        <div className={cn("grid gap-3 px-6 pb-6", planColumns(plans.length))}>
-          {plans.map((plan) => (
-            <PlanCard
-              key={plan.slug}
-              plan={plan}
-              interval={interval}
-              isCurrent={plan.slug === currentPlanSlug}
-              isRecommended={plan.slug === recommended}
-              // A recommendation only means something against alternatives; the badge and the
-              // ring would be decoration on a catalog that publishes one plan.
-              isHighlighted={plan.slug === recommended && plans.length > 1}
-              trialEligible={trialEligible}
-              pending={checkout.isPending}
-              onChoose={choose}
-            />
-          ))}
-        </div>
-        {error !== undefined && (
-          <div className="px-6 pb-6">
+          <div className={cn("grid gap-3", planColumns(plans.length))}>
+            {plans.map((plan) => (
+              <PlanCard
+                key={plan.slug}
+                plan={plan}
+                interval={interval}
+                isCurrent={plan.slug === currentPlanSlug}
+                trialEligible={trialEligible}
+                pending={checkout.isPending}
+                onChoose={choose}
+              />
+            ))}
+          </div>
+          {error !== undefined && (
             <Alert variant="destructive">
               <AlertDescription>{error}</AlertDescription>
             </Alert>
-          </div>
-        )}
+          )}
+        </div>
       </DialogContent>
     </Dialog>
   );
 }
 
-/** A centred segmented control. Deliberately content-width: it is a choice between two words,
- * not a page-wide toolbar. The selected chip is a raised surface, so the one green thing in the
- * dialog stays the action the customer is here to take. */
+/** A centred segmented control, rendered only when the catalog prices more than one interval.
+ * Deliberately content-width: it is a choice between two words, not a page-wide toolbar. */
 function IntervalSwitch({
   intervals,
   value,
@@ -189,8 +180,6 @@ function PlanCard({
   plan,
   interval,
   isCurrent,
-  isRecommended,
-  isHighlighted,
   trialEligible,
   pending,
   onChoose,
@@ -198,30 +187,20 @@ function PlanCard({
   plan: PublicBillingPlan;
   interval: BillingPlanPriceInterval;
   isCurrent: boolean;
-  /** The plan the picker leads with — it carries the filled call to action. */
-  isRecommended: boolean;
-  /** Whether to say so visually, which only reads as a recommendation next to another plan. */
-  isHighlighted: boolean;
   trialEligible: boolean;
   pending: boolean;
   onChoose: (planSlug: string) => void;
 }) {
   const price = plan.prices[interval];
   const action = planAction({ planName: plan.name, price, isCurrent, trialEligible });
-  const footnote = trialFootnote(price, interval, trialEligible);
   const { amount, unit } = planPrice(price, interval);
   const choose = useCallback(() => onChoose(plan.slug), [onChoose, plan.slug]);
 
   return (
-    <div
-      className={cn(
-        "flex flex-col rounded-xl border bg-card p-5 text-card-foreground",
-        isHighlighted && "border-primary/50 bg-primary/[0.04] ring-1 ring-primary/25",
-      )}
-    >
+    <div className="flex flex-col rounded-xl border bg-card p-5 text-card-foreground">
       <div className="flex min-h-6 items-start justify-between gap-2">
         <h3 className="text-sm font-medium">{plan.name}</h3>
-        <PlanBadge isCurrent={isCurrent} isRecommended={isHighlighted} />
+        {isCurrent && <Badge variant="secondary">Current</Badge>}
       </div>
       <p className="mt-3 text-3xl leading-none font-semibold tracking-tight">{amount}</p>
       <p className="mt-1.5 text-xs text-muted-foreground">{unit}</p>
@@ -240,32 +219,17 @@ function PlanCard({
           </li>
         ))}
       </ul>
-      {/* The footnote sits above the button so every column's button shares one bottom edge,
-          however much a plan has to explain about what happens after the trial. */}
-      <div className="mt-6 grid gap-2">
-        {footnote !== null && (
-          <p className="text-center text-xs text-balance text-muted-foreground">{footnote}</p>
-        )}
-        <Button
-          type="button"
-          variant={isRecommended ? "default" : "outline"}
-          aria-label={action.name}
-          className="w-full"
-          disabled={action.disabled || pending}
-          onClick={choose}
-        >
-          {action.label}
-        </Button>
-      </div>
+      <Button
+        type="button"
+        aria-label={action.name}
+        className="mt-6 w-full"
+        disabled={action.disabled || pending}
+        onClick={choose}
+      >
+        {action.label}
+      </Button>
     </div>
   );
-}
-
-/** At most one badge per plan, and being the current plan outranks being recommended. */
-function PlanBadge({ isCurrent, isRecommended }: { isCurrent: boolean; isRecommended: boolean }) {
-  if (isCurrent) return <Badge variant="secondary">Current</Badge>;
-  if (isRecommended) return <Badge>Recommended</Badge>;
-  return null;
 }
 
 /** Two plans read as a pair, three as a row. More than three wrap rather than shrink to slivers. */

--- a/src/billing/ui/presentation.test.tsx
+++ b/src/billing/ui/presentation.test.tsx
@@ -1,6 +1,12 @@
 import assert from "node:assert/strict";
 import { it } from "vitest";
 import type { BillingOverviewView, PublicBillingPlan } from "../../server/runtime.js";
+/**
+ * Copy rules, not the product catalog. Where several plans are needed to pin generic behaviour
+ * these use deliberately synthetic names — Hub sells one plan today, and a fixture that pretends
+ * otherwise is how obsolete tiers end up on a screenshot.
+ */
+
 import {
   intervalLabel,
   offeredIntervals,
@@ -131,22 +137,22 @@ it("spells out what the customer pays when the free days run out", () => {
 it("recommends the first paid plan the organization is not already on", () => {
   const plans = [
     plan("free", "Free", { monthly: euros(0) }),
-    plan("solo", "Solo", { monthly: euros(1500) }),
-    plan("team", "Team", { monthly: euros(4900) }),
+    plan("starter", "Starter", { monthly: euros(1500) }),
+    plan("scale", "Scale", { monthly: euros(4900) }),
   ];
-  assert.equal(recommendedPlanSlug(plans, "monthly", null), "solo");
-  assert.equal(recommendedPlanSlug(plans, "monthly", "solo"), "team");
+  assert.equal(recommendedPlanSlug(plans, "monthly", null), "starter");
+  assert.equal(recommendedPlanSlug(plans, "monthly", "starter"), "scale");
   assert.equal(recommendedPlanSlug(plans.slice(0, 1), "monthly", null), null);
 });
 
 it("hides the interval switch for a catalog that only charges monthly", () => {
   const plans = [
     plan("free", "Free", { monthly: euros(0), annual: euros(0) }),
-    plan("solo", "Solo", { monthly: euros(1500) }),
+    plan("starter", "Starter", { monthly: euros(1500) }),
   ];
   assert.deepEqual(offeredIntervals(plans), ["monthly"]);
   assert.deepEqual(
-    offeredIntervals([plan("solo", "Solo", { monthly: euros(1500), annual: euros(15000) })]),
+    offeredIntervals([plan("starter", "Starter", { monthly: euros(1500), annual: euros(15000) })]),
     ["monthly", "annual"],
   );
   // A catalog with nothing priced still has to render at one interval.
@@ -158,27 +164,27 @@ it("labels intervals the way the picker shows them", () => {
   assert.equal(intervalLabel("annual"), "Annual");
 });
 
-it("asks an unprovisioned organization to pick a plan", () => {
-  assert.deepEqual(subscriptionSummary(subscription({})), {
+it("offers the trial to an organization that has never subscribed", () => {
+  assert.deepEqual(subscriptionSummary(subscription({ trialEligible: true })), {
     planName: null,
     status: null,
-    detail: "Pick a plan to get started.",
+    detail: "Start a 14-day free trial — no card required.",
   });
 });
 
-it("reads a free organization as having no subscription rather than an active one", () => {
-  assert.deepEqual(subscriptionSummary(subscription({ planSlug: "free", planName: "Free" })), {
-    planName: "Free",
+it("sells the plan, not a second trial, to a former subscriber", () => {
+  assert.deepEqual(subscriptionSummary(subscription({ trialEligible: false })), {
+    planName: null,
     status: null,
-    detail: "No subscription — upgrade whenever you're ready.",
+    detail: "Subscribe to run workflows on hosted Hub.",
   });
 });
 
 it("leads with the trial end date while a trial is running", () => {
   const summary = subscriptionSummary(
     subscription({
-      planSlug: "solo",
-      planName: "Solo",
+      planSlug: "hosted",
+      planName: "Paseo Hub",
       status: "trialing",
       trialEnd: "2026-09-11T00:00:00.000Z",
       currentPeriodEnd: "2026-09-11T00:00:00.000Z",
@@ -192,8 +198,8 @@ it("leads with the trial end date while a trial is running", () => {
 it("leads with the cancellation date once a subscription is set to end", () => {
   const summary = subscriptionSummary(
     subscription({
-      planSlug: "solo",
-      planName: "Solo",
+      planSlug: "hosted",
+      planName: "Paseo Hub",
       status: "active",
       cancelAtPeriodEnd: true,
       trialEnd: "2026-09-11T00:00:00.000Z",
@@ -206,11 +212,11 @@ it("leads with the cancellation date once a subscription is set to end", () => {
 
 it("warns on a payment problem and stays neutral on an unrecognised status", () => {
   assert.deepEqual(
-    subscriptionSummary(subscription({ planName: "Solo", status: "past_due" })).status,
+    subscriptionSummary(subscription({ planName: "Paseo Hub", status: "past_due" })).status,
     { tone: "warning", label: "Past Due" },
   );
   assert.deepEqual(
-    subscriptionSummary(subscription({ planName: "Solo", status: "paused" })).status,
+    subscriptionSummary(subscription({ planName: "Paseo Hub", status: "paused" })).status,
     { tone: "neutral", label: "Paused" },
   );
 });

--- a/src/billing/ui/presentation.test.tsx
+++ b/src/billing/ui/presentation.test.tsx
@@ -1,0 +1,216 @@
+import assert from "node:assert/strict";
+import { it } from "vitest";
+import type { BillingOverviewView, PublicBillingPlan } from "../../server/runtime.js";
+import {
+  intervalLabel,
+  offeredIntervals,
+  planAction,
+  planPrice,
+  recommendedPlanSlug,
+  subscriptionSummary,
+  trialFootnote,
+} from "./presentation.js";
+
+const euros = (unitAmount: number) => ({ unitAmount, currency: "eur" });
+
+function plan(
+  slug: string,
+  name: string,
+  prices: Partial<PublicBillingPlan["prices"]>,
+): PublicBillingPlan {
+  return {
+    slug,
+    name,
+    marketingFeatures: [],
+    prices: { monthly: null, annual: null, ...prices },
+  };
+}
+
+function subscription(
+  overrides: Partial<BillingOverviewView["subscription"]>,
+): BillingOverviewView["subscription"] {
+  return {
+    planSlug: null,
+    planName: null,
+    status: null,
+    cancelAtPeriodEnd: false,
+    currentPeriodEnd: null,
+    trialEnd: null,
+    trialEligible: true,
+    manageable: false,
+    ...overrides,
+  };
+}
+
+it("prices a paid plan as a figure the customer can read at a glance", () => {
+  assert.deepEqual(planPrice(euros(1500), "monthly"), {
+    amount: "€15",
+    unit: "per user / month",
+  });
+  assert.deepEqual(planPrice(euros(15000), "annual"), {
+    amount: "€150",
+    unit: "per user / year",
+  });
+});
+
+it("prices the free tier as a figure so every plan column shares a baseline", () => {
+  assert.deepEqual(planPrice(euros(0), "monthly"), { amount: "€0", unit: "forever" });
+});
+
+it("says which interval is missing rather than showing a blank price", () => {
+  assert.deepEqual(planPrice(null, "annual"), { amount: "—", unit: "No yearly price" });
+});
+
+it("keeps the plan name in the trial button's accessible name while the visible label stays short", () => {
+  const action = planAction({
+    planName: "Paseo Hub",
+    price: euros(1500),
+    isCurrent: false,
+    trialEligible: true,
+  });
+  assert.deepEqual(action, {
+    label: "Start free trial",
+    name: "Start free trial with Paseo Hub",
+    disabled: false,
+  });
+  assert.ok(
+    action.name.includes(action.label),
+    "the accessible name must contain the visible label",
+  );
+});
+
+it("offers a former subscriber ordinary checkout instead of a second trial", () => {
+  assert.deepEqual(
+    planAction({
+      planName: "Paseo Hub",
+      price: euros(1500),
+      isCurrent: false,
+      trialEligible: false,
+    }),
+    { label: "Choose Paseo Hub", name: "Choose Paseo Hub", disabled: false },
+  );
+});
+
+it("never offers a trial on the free tier, even when the organization is trial eligible", () => {
+  assert.deepEqual(
+    planAction({ planName: "Free", price: euros(0), isCurrent: false, trialEligible: true }),
+    { label: "Choose Free", name: "Choose Free", disabled: false },
+  );
+  assert.equal(trialFootnote(euros(0), "monthly", true), null);
+});
+
+it("disables the plan the organization is already on and names it", () => {
+  const action = planAction({
+    planName: "Free",
+    price: euros(0),
+    isCurrent: true,
+    trialEligible: true,
+  });
+  assert.deepEqual(action, { label: "Current plan", name: "Current plan: Free", disabled: true });
+});
+
+it("disables a plan the catalog does not price at the selected interval", () => {
+  assert.deepEqual(
+    planAction({ planName: "Paseo Hub", price: null, isCurrent: false, trialEligible: true }),
+    { label: "Not available", name: "Not available: Paseo Hub", disabled: true },
+  );
+});
+
+it("spells out what the customer pays when the free days run out", () => {
+  assert.equal(
+    trialFootnote(euros(1500), "monthly", true),
+    "14 days free, then €15 per user each month.",
+  );
+  assert.equal(
+    trialFootnote(euros(15000), "annual", true),
+    "14 days free, then €150 per user each year.",
+  );
+  assert.equal(trialFootnote(euros(1500), "monthly", false), null);
+});
+
+it("recommends the first paid plan the organization is not already on", () => {
+  const plans = [
+    plan("free", "Free", { monthly: euros(0) }),
+    plan("solo", "Solo", { monthly: euros(1500) }),
+    plan("team", "Team", { monthly: euros(4900) }),
+  ];
+  assert.equal(recommendedPlanSlug(plans, "monthly", null), "solo");
+  assert.equal(recommendedPlanSlug(plans, "monthly", "solo"), "team");
+  assert.equal(recommendedPlanSlug(plans.slice(0, 1), "monthly", null), null);
+});
+
+it("hides the interval switch for a catalog that only charges monthly", () => {
+  const plans = [
+    plan("free", "Free", { monthly: euros(0), annual: euros(0) }),
+    plan("solo", "Solo", { monthly: euros(1500) }),
+  ];
+  assert.deepEqual(offeredIntervals(plans), ["monthly"]);
+  assert.deepEqual(
+    offeredIntervals([plan("solo", "Solo", { monthly: euros(1500), annual: euros(15000) })]),
+    ["monthly", "annual"],
+  );
+  // A catalog with nothing priced still has to render at one interval.
+  assert.deepEqual(offeredIntervals([]), ["monthly"]);
+});
+
+it("labels intervals the way the picker shows them", () => {
+  assert.equal(intervalLabel("monthly"), "Monthly");
+  assert.equal(intervalLabel("annual"), "Annual");
+});
+
+it("asks an unprovisioned organization to pick a plan", () => {
+  assert.deepEqual(subscriptionSummary(subscription({})), {
+    planName: null,
+    status: null,
+    detail: "Pick a plan to get started.",
+  });
+});
+
+it("reads a free organization as having no subscription rather than an active one", () => {
+  assert.deepEqual(subscriptionSummary(subscription({ planSlug: "free", planName: "Free" })), {
+    planName: "Free",
+    status: null,
+    detail: "No subscription — upgrade whenever you're ready.",
+  });
+});
+
+it("leads with the trial end date while a trial is running", () => {
+  const summary = subscriptionSummary(
+    subscription({
+      planSlug: "solo",
+      planName: "Solo",
+      status: "trialing",
+      trialEnd: "2026-09-11T00:00:00.000Z",
+      currentPeriodEnd: "2026-09-11T00:00:00.000Z",
+      manageable: true,
+    }),
+  );
+  assert.deepEqual(summary.status, { tone: "success", label: "Trialing" });
+  assert.equal(summary.detail, "Trial ends September 11, 2026.");
+});
+
+it("leads with the cancellation date once a subscription is set to end", () => {
+  const summary = subscriptionSummary(
+    subscription({
+      planSlug: "solo",
+      planName: "Solo",
+      status: "active",
+      cancelAtPeriodEnd: true,
+      trialEnd: "2026-09-11T00:00:00.000Z",
+      currentPeriodEnd: "2026-10-01T00:00:00.000Z",
+      manageable: true,
+    }),
+  );
+  assert.equal(summary.detail, "Cancels on October 1, 2026.");
+});
+
+it("warns on a payment problem and stays neutral on an unrecognised status", () => {
+  assert.deepEqual(
+    subscriptionSummary(subscription({ planName: "Solo", status: "past_due" })).status,
+    { tone: "warning", label: "Past Due" },
+  );
+  assert.deepEqual(
+    subscriptionSummary(subscription({ planName: "Solo", status: "paused" })).status,
+    { tone: "neutral", label: "Paused" },
+  );
+});

--- a/src/billing/ui/presentation.test.tsx
+++ b/src/billing/ui/presentation.test.tsx
@@ -12,9 +12,7 @@ import {
   offeredIntervals,
   planAction,
   planPrice,
-  recommendedPlanSlug,
   subscriptionSummary,
-  trialFootnote,
 } from "./presentation.js";
 
 const euros = (unitAmount: number) => ({ unitAmount, currency: "eur" });
@@ -86,23 +84,28 @@ it("keeps the plan name in the trial button's accessible name while the visible 
 });
 
 it("offers a former subscriber ordinary checkout instead of a second trial", () => {
-  assert.deepEqual(
-    planAction({
-      planName: "Paseo Hub",
-      price: euros(1500),
-      isCurrent: false,
-      trialEligible: false,
-    }),
-    { label: "Choose Paseo Hub", name: "Choose Paseo Hub", disabled: false },
+  const action = planAction({
+    planName: "Paseo Hub",
+    price: euros(1500),
+    isCurrent: false,
+    trialEligible: false,
+  });
+  assert.deepEqual(action, {
+    label: "Subscribe",
+    name: "Subscribe to Paseo Hub",
+    disabled: false,
+  });
+  assert.ok(
+    action.name.includes(action.label),
+    "the accessible name must contain the visible label",
   );
 });
 
-it("never offers a trial on the free tier, even when the organization is trial eligible", () => {
+it("never offers a trial on a zero-priced plan, even when the organization is trial eligible", () => {
   assert.deepEqual(
     planAction({ planName: "Free", price: euros(0), isCurrent: false, trialEligible: true }),
-    { label: "Choose Free", name: "Choose Free", disabled: false },
+    { label: "Subscribe", name: "Subscribe to Free", disabled: false },
   );
-  assert.equal(trialFootnote(euros(0), "monthly", true), null);
 });
 
 it("disables the plan the organization is already on and names it", () => {
@@ -120,29 +123,6 @@ it("disables a plan the catalog does not price at the selected interval", () => 
     planAction({ planName: "Paseo Hub", price: null, isCurrent: false, trialEligible: true }),
     { label: "Not available", name: "Not available: Paseo Hub", disabled: true },
   );
-});
-
-it("spells out what the customer pays when the free days run out", () => {
-  assert.equal(
-    trialFootnote(euros(1500), "monthly", true),
-    "14 days free, then €15 per user each month.",
-  );
-  assert.equal(
-    trialFootnote(euros(15000), "annual", true),
-    "14 days free, then €150 per user each year.",
-  );
-  assert.equal(trialFootnote(euros(1500), "monthly", false), null);
-});
-
-it("recommends the first paid plan the organization is not already on", () => {
-  const plans = [
-    plan("free", "Free", { monthly: euros(0) }),
-    plan("starter", "Starter", { monthly: euros(1500) }),
-    plan("scale", "Scale", { monthly: euros(4900) }),
-  ];
-  assert.equal(recommendedPlanSlug(plans, "monthly", null), "starter");
-  assert.equal(recommendedPlanSlug(plans, "monthly", "starter"), "scale");
-  assert.equal(recommendedPlanSlug(plans.slice(0, 1), "monthly", null), null);
 });
 
 it("hides the interval switch for a catalog that only charges monthly", () => {
@@ -164,20 +144,14 @@ it("labels intervals the way the picker shows them", () => {
   assert.equal(intervalLabel("annual"), "Annual");
 });
 
-it("offers the trial to an organization that has never subscribed", () => {
-  assert.deepEqual(subscriptionSummary(subscription({ trialEligible: true })), {
-    planName: null,
-    status: null,
-    detail: "Start a 14-day free trial — no card required.",
-  });
-});
-
-it("sells the plan, not a second trial, to a former subscriber", () => {
-  assert.deepEqual(subscriptionSummary(subscription({ trialEligible: false })), {
-    planName: null,
-    status: null,
-    detail: "Subscribe to run workflows on hosted Hub.",
-  });
+it("says nothing beyond the fact when there is no subscription to describe", () => {
+  for (const trialEligible of [true, false]) {
+    assert.deepEqual(subscriptionSummary(subscription({ trialEligible })), {
+      planName: null,
+      status: null,
+      detail: null,
+    });
+  }
 });
 
 it("leads with the trial end date while a trial is running", () => {

--- a/src/billing/ui/presentation.tsx
+++ b/src/billing/ui/presentation.tsx
@@ -1,0 +1,190 @@
+import type { StatusTone } from "../../components/app/status-pill.js";
+import type { BillingPlanPriceInterval } from "../../db/types.js";
+import type {
+  BillingOverviewView,
+  PublicBillingPlan,
+  PublicBillingPlanPrice,
+} from "../../server/runtime.js";
+
+/**
+ * Every word the billing surfaces render: prices, the button on each plan, and the one sentence
+ * that says what happens next. Pure and React-free, so the copy is unit-testable and the panel
+ * and plan dialog only have to lay it out. Nothing here reaches for the DOM or the network.
+ */
+
+const INTERVAL_WORDS: Record<
+  BillingPlanPriceInterval,
+  { label: string; unit: string; adjective: string }
+> = {
+  monthly: { label: "Monthly", unit: "month", adjective: "monthly" },
+  annual: { label: "Annual", unit: "year", adjective: "yearly" },
+};
+
+const INTERVAL_ORDER: readonly BillingPlanPriceInterval[] = ["monthly", "annual"];
+
+export function intervalLabel(interval: BillingPlanPriceInterval): string {
+  return INTERVAL_WORDS[interval].label;
+}
+
+/**
+ * The intervals worth showing a switch for: the ones some plan actually charges at. A catalog
+ * published monthly-only collapses to a single interval and the picker drops the switch rather
+ * than offering a column of "—". Never empty, so the picker always has an interval to price at.
+ */
+export function offeredIntervals(
+  plans: readonly PublicBillingPlan[],
+): readonly BillingPlanPriceInterval[] {
+  const offered = INTERVAL_ORDER.filter((interval) =>
+    plans.some((plan) => isPaidPrice(plan.prices[interval])),
+  );
+  return offered.length === 0 ? ["monthly"] : offered;
+}
+
+/** The number of free trial days Stripe grants on a cardless checkout. */
+export const TRIAL_DAYS = 14;
+
+export interface PlanPrice {
+  /** The headline figure — "€15", "Free", or "—" when this interval has no price. */
+  amount: string;
+  /** The unit line under the figure — never repeats the figure. */
+  unit: string;
+}
+
+export function planPrice(
+  price: PublicBillingPlanPrice | null,
+  interval: BillingPlanPriceInterval,
+): PlanPrice {
+  const words = INTERVAL_WORDS[interval];
+  if (price === null) return { amount: "—", unit: `No ${words.adjective} price` };
+  // Every column shows a figure, including the free tier: the plan's name already says "Free",
+  // and repeating the word where the price goes costs the columns their shared baseline.
+  if (price.unitAmount === 0) return { amount: formatAmount(price), unit: "forever" };
+  return { amount: formatAmount(price), unit: `per user / ${words.unit}` };
+}
+
+/** A plan a customer pays for, as opposed to the mirrored Free tier. Only these carry a trial. */
+export function isPaidPrice(price: PublicBillingPlanPrice | null): boolean {
+  return price !== null && price.unitAmount > 0;
+}
+
+export interface PlanAction {
+  /** The visible button text. Short enough to fit a narrow plan column at any plan name length. */
+  label: string;
+  /** The accessible name. Always contains `label`, so it satisfies WCAG 2.5.3 Label in Name, and
+   * always names the plan, so two plans never present the same name to a screen reader or test. */
+  name: string;
+  disabled: boolean;
+}
+
+export function planAction(input: {
+  planName: string;
+  price: PublicBillingPlanPrice | null;
+  isCurrent: boolean;
+  trialEligible: boolean;
+}): PlanAction {
+  if (input.isCurrent) {
+    return { label: "Current plan", name: `Current plan: ${input.planName}`, disabled: true };
+  }
+  if (input.price === null) {
+    return { label: "Not available", name: `Not available: ${input.planName}`, disabled: true };
+  }
+  if (input.trialEligible && isPaidPrice(input.price)) {
+    return {
+      label: "Start free trial",
+      name: `Start free trial with ${input.planName}`,
+      disabled: false,
+    };
+  }
+  return { label: `Choose ${input.planName}`, name: `Choose ${input.planName}`, disabled: false };
+}
+
+/** The line under a trial button that spells out what happens when the free days run out. Null
+ * when there is no trial to explain, so the free plan's column stays quiet. */
+export function trialFootnote(
+  price: PublicBillingPlanPrice | null,
+  interval: BillingPlanPriceInterval,
+  trialEligible: boolean,
+): string | null {
+  if (!trialEligible || !isPaidPrice(price) || price === null) return null;
+  return `${TRIAL_DAYS} days free, then ${formatAmount(price)} per user each ${INTERVAL_WORDS[interval].unit}.`;
+}
+
+/**
+ * The plan the picker leans on: the first paid plan the organization is not already on. Catalog
+ * order is the author's order, so "first" is the cheapest entry point they published.
+ */
+export function recommendedPlanSlug(
+  plans: readonly PublicBillingPlan[],
+  interval: BillingPlanPriceInterval,
+  currentPlanSlug: string | null,
+): string | null {
+  const recommended = plans.find(
+    (plan) => plan.slug !== currentPlanSlug && isPaidPrice(plan.prices[interval]),
+  );
+  return recommended?.slug ?? null;
+}
+
+export interface SubscriptionSummary {
+  /** The plan the organization is billed on, or null before provisioning stamps one. */
+  planName: string | null;
+  /** The Stripe status pill. Null when no live subscription exists, which is the normal state
+   * for a free organization and for one whose subscription was cancelled. */
+  status: { tone: StatusTone; label: string } | null;
+  /** One sentence naming the next thing that will happen to this subscription. */
+  detail: string;
+}
+
+export function subscriptionSummary(
+  subscription: BillingOverviewView["subscription"],
+): SubscriptionSummary {
+  return {
+    planName: subscription.planName,
+    status:
+      subscription.status === null
+        ? null
+        : { tone: statusTone(subscription.status), label: statusText(subscription.status) },
+    detail: subscriptionDetail(subscription),
+  };
+}
+
+function subscriptionDetail(subscription: BillingOverviewView["subscription"]): string {
+  if (subscription.planName === null) return "Pick a plan to get started.";
+  if (subscription.status === null) return "No subscription — upgrade whenever you're ready.";
+  if (subscription.cancelAtPeriodEnd && subscription.currentPeriodEnd !== null) {
+    return `Cancels on ${formatDate(subscription.currentPeriodEnd)}.`;
+  }
+  if (subscription.trialEnd !== null) return `Trial ends ${formatDate(subscription.trialEnd)}.`;
+  if (subscription.currentPeriodEnd !== null) {
+    return `Renews on ${formatDate(subscription.currentPeriodEnd)}.`;
+  }
+  return "Active subscription.";
+}
+
+function formatAmount(price: PublicBillingPlanPrice): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: price.currency.toUpperCase(),
+    minimumFractionDigits: 0,
+  }).format(price.unitAmount / 100);
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}
+
+function statusTone(status: string): StatusTone {
+  if (status === "active" || status === "trialing") return "success";
+  if (status === "past_due" || status === "unpaid" || status === "incomplete") return "warning";
+  return "neutral";
+}
+
+function statusText(status: string): string {
+  return status
+    .split("_")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}

--- a/src/billing/ui/presentation.tsx
+++ b/src/billing/ui/presentation.tsx
@@ -125,7 +125,8 @@ export function recommendedPlanSlug(
 }
 
 export interface SubscriptionSummary {
-  /** The plan the organization is billed on, or null before provisioning stamps one. */
+  /** The plan the organization is billed on, or null when it has none. Billing never reports the
+   * internal free entitlement record here, so null means "no subscription", not "the free tier". */
   planName: string | null;
   /** The Stripe status pill. Null when no live subscription exists, which is the normal state
    * for a free organization and for one whose subscription was cancelled. */
@@ -147,13 +148,20 @@ export function subscriptionSummary(
   };
 }
 
+/** The headline for an organization with no subscription. Never names a tier — there is nothing
+ * for sale at zero, and the entitlement floor it sits on is enforcement, not an offer. */
+export const NO_SUBSCRIPTION = "No subscription";
+
 function subscriptionDetail(subscription: BillingOverviewView["subscription"]): string {
-  if (subscription.planName === null) return "Pick a plan to get started.";
-  if (subscription.status === null) return "No subscription — upgrade whenever you're ready.";
   if (subscription.cancelAtPeriodEnd && subscription.currentPeriodEnd !== null) {
     return `Cancels on ${formatDate(subscription.currentPeriodEnd)}.`;
   }
   if (subscription.trialEnd !== null) return `Trial ends ${formatDate(subscription.trialEnd)}.`;
+  if (subscription.planName === null) {
+    return subscription.trialEligible
+      ? `Start a ${TRIAL_DAYS}-day free trial — no card required.`
+      : "Subscribe to run workflows on hosted Hub.";
+  }
   if (subscription.currentPeriodEnd !== null) {
     return `Renews on ${formatDate(subscription.currentPeriodEnd)}.`;
   }

--- a/src/billing/ui/presentation.tsx
+++ b/src/billing/ui/presentation.tsx
@@ -95,33 +95,7 @@ export function planAction(input: {
       disabled: false,
     };
   }
-  return { label: `Choose ${input.planName}`, name: `Choose ${input.planName}`, disabled: false };
-}
-
-/** The line under a trial button that spells out what happens when the free days run out. Null
- * when there is no trial to explain, so the free plan's column stays quiet. */
-export function trialFootnote(
-  price: PublicBillingPlanPrice | null,
-  interval: BillingPlanPriceInterval,
-  trialEligible: boolean,
-): string | null {
-  if (!trialEligible || !isPaidPrice(price) || price === null) return null;
-  return `${TRIAL_DAYS} days free, then ${formatAmount(price)} per user each ${INTERVAL_WORDS[interval].unit}.`;
-}
-
-/**
- * The plan the picker leans on: the first paid plan the organization is not already on. Catalog
- * order is the author's order, so "first" is the cheapest entry point they published.
- */
-export function recommendedPlanSlug(
-  plans: readonly PublicBillingPlan[],
-  interval: BillingPlanPriceInterval,
-  currentPlanSlug: string | null,
-): string | null {
-  const recommended = plans.find(
-    (plan) => plan.slug !== currentPlanSlug && isPaidPrice(plan.prices[interval]),
-  );
-  return recommended?.slug ?? null;
+  return { label: "Subscribe", name: `Subscribe to ${input.planName}`, disabled: false };
 }
 
 export interface SubscriptionSummary {
@@ -131,8 +105,9 @@ export interface SubscriptionSummary {
   /** The Stripe status pill. Null when no live subscription exists, which is the normal state
    * for a free organization and for one whose subscription was cancelled. */
   status: { tone: StatusTone; label: string } | null;
-  /** One sentence naming the next thing that will happen to this subscription. */
-  detail: string;
+  /** One sentence naming the next thing that will happen to this subscription, or null when
+   * there is no subscription and so nothing to say about one. */
+  detail: string | null;
 }
 
 export function subscriptionSummary(
@@ -152,16 +127,14 @@ export function subscriptionSummary(
  * for sale at zero, and the entitlement floor it sits on is enforcement, not an offer. */
 export const NO_SUBSCRIPTION = "No subscription";
 
-function subscriptionDetail(subscription: BillingOverviewView["subscription"]): string {
+function subscriptionDetail(subscription: BillingOverviewView["subscription"]): string | null {
+  // No subscription, nothing to date: the headline and the button already say everything, so the
+  // card stays silent rather than filling the gap with a pitch.
+  if (subscription.planName === null) return null;
   if (subscription.cancelAtPeriodEnd && subscription.currentPeriodEnd !== null) {
     return `Cancels on ${formatDate(subscription.currentPeriodEnd)}.`;
   }
   if (subscription.trialEnd !== null) return `Trial ends ${formatDate(subscription.trialEnd)}.`;
-  if (subscription.planName === null) {
-    return subscription.trialEligible
-      ? `Start a ${TRIAL_DAYS}-day free trial — no card required.`
-      : "Subscribe to run workflows on hosted Hub.";
-  }
   if (subscription.currentPeriodEnd !== null) {
     return `Renews on ${formatDate(subscription.currentPeriodEnd)}.`;
   }

--- a/src/db/memory.ts
+++ b/src/db/memory.ts
@@ -86,8 +86,8 @@ import type {
   ConsumeOrganizationUsageInput,
   BillingPlanRecord,
   SyncBillingPlanInput,
-  OrganizationSubscriptionRecord,
-  ReconcileOrganizationSubscriptionInput,
+  OrganizationBillingCustomerRecord,
+  ReconcileOrganizationBillingInput,
   UpdateLinearConnectionTokensInput,
   LinearConnectionRefreshOperation,
 } from "./types.js";
@@ -167,7 +167,10 @@ class MemoryDatabase implements Database {
   private readonly entitlementChanges: EntitlementChangeRecord[] = [];
   private readonly organizationUsage = new Map<string, OrganizationUsageRecord>();
   private readonly billingPlans = new Map<string, BillingPlanRecord>();
-  private readonly organizationSubscriptions = new Map<string, OrganizationSubscriptionRecord>();
+  private readonly organizationBillingCustomers = new Map<
+    string,
+    OrganizationBillingCustomerRecord
+  >();
   private readonly advisoryLocks = new Map<string, Promise<void>>();
   private readonly projects = new Map<string, ProjectRecord>();
   private readonly configurationRevisions = new Map<string, ProjectConfigurationRevisionRecord>();
@@ -2161,20 +2164,15 @@ class MemoryDatabase implements Database {
     return Array.from(this.billingPlans.values());
   }
 
-  async reconcileOrganizationSubscription(
-    input: ReconcileOrganizationSubscriptionInput,
-  ): Promise<OrganizationSubscriptionRecord> {
-    const record: OrganizationSubscriptionRecord = {
+  async reconcileOrganizationBilling(
+    input: ReconcileOrganizationBillingInput,
+  ): Promise<OrganizationBillingCustomerRecord> {
+    const record: OrganizationBillingCustomerRecord = {
       organizationId: input.organizationId,
       stripeCustomerId: input.stripeCustomerId,
-      stripeSubscriptionId: input.stripeSubscriptionId,
-      planId: input.planId,
-      status: input.status,
-      currentPeriodEnd: input.currentPeriodEnd,
-      cancelAtPeriodEnd: input.cancelAtPeriodEnd,
       updatedAt: this.now(),
     };
-    this.organizationSubscriptions.set(input.organizationId, record);
+    this.organizationBillingCustomers.set(input.organizationId, record);
     // No await between the two writes, so on Node's single thread the mirror and the stamp land
     // together — the in-memory stand-in for the Postgres transaction that couples them.
     if (input.stamp !== undefined) {
@@ -2207,10 +2205,10 @@ class MemoryDatabase implements Database {
     }
   }
 
-  async getOrganizationSubscription(
+  async getOrganizationBillingCustomer(
     organizationId: string,
-  ): Promise<OrganizationSubscriptionRecord | undefined> {
-    return this.organizationSubscriptions.get(organizationId);
+  ): Promise<OrganizationBillingCustomerRecord | undefined> {
+    return this.organizationBillingCustomers.get(organizationId);
   }
 
   async listProjectsForOrganization(organizationId: string) {

--- a/src/db/migrations.integration.test.ts
+++ b/src/db/migrations.integration.test.ts
@@ -307,7 +307,7 @@ describe("database migration application", () => {
     assert.deepEqual(after, before);
     assert.deepEqual(await historicalShape(fixture.url), {
       authTables: 7,
-      drizzleMigrations: 41,
+      drizzleMigrations: 42,
       legacyArtifacts: null,
       legacyOperatorPrincipals: null,
       bootstrapOrganizationId: fixture.organizationId,
@@ -487,6 +487,42 @@ describe("database migration application", () => {
         source_kind: "manual",
       },
     ]);
+  }, 120_000);
+
+  it("preserves Stripe customer identity while removing the subscription mirror", async () => {
+    const url = await createHistoricalBaseline({
+      postgres,
+      prefix: "billing_customer_identity",
+      through: "0040_cultured_punisher",
+    });
+    await poolQuery(
+      url,
+      `insert into organization (id, name, slug)
+       values ('organization-billing', 'Billing organization', 'billing-organization');
+       insert into organization_subscriptions
+         (organization_id, stripe_customer_id, stripe_subscription_id, status)
+       values ('organization-billing', 'cus_durable', 'sub_retired', 'active')`,
+    );
+
+    const database = await createDatabase(url);
+    await database.close();
+
+    const customer = await poolQuery<{ organization_id: string; stripe_customer_id: string }>(
+      url,
+      `select organization_id, stripe_customer_id from organization_billing_customers`,
+    );
+    assert.deepEqual(customer.rows, [
+      { organization_id: "organization-billing", stripe_customer_id: "cus_durable" },
+    ]);
+    assert.deepEqual(
+      (
+        await poolQuery<{ subscriptions: string | null }>(
+          url,
+          `select to_regclass('public.organization_subscriptions')::text as subscriptions`,
+        )
+      ).rows,
+      [{ subscriptions: null }],
+    );
   }, 120_000);
 
   it("migrates an empty database and reruns as a no-op", async () => {

--- a/src/db/pg.ts
+++ b/src/db/pg.ts
@@ -106,8 +106,8 @@ import type {
   BillingPlanRecord,
   BillingPlanPriceRecord,
   SyncBillingPlanInput,
-  OrganizationSubscriptionRecord,
-  ReconcileOrganizationSubscriptionInput,
+  OrganizationBillingCustomerRecord,
+  ReconcileOrganizationBillingInput,
 } from "./types.js";
 
 const OUTPUT_ATTEMPT_LEASE_MS = 5 * 60_000;
@@ -2690,37 +2690,24 @@ class PgDatabase implements Database {
     return plans.rows.map((row) => toBillingPlanRecord(row, pricesByPlan.get(row.id) ?? []));
   }
 
-  async reconcileOrganizationSubscription(
-    input: ReconcileOrganizationSubscriptionInput,
-  ): Promise<OrganizationSubscriptionRecord> {
+  async reconcileOrganizationBilling(
+    input: ReconcileOrganizationBillingInput,
+  ): Promise<OrganizationBillingCustomerRecord> {
     try {
       return await this.pool.transaction(async (client) => {
-        const rows = await client.query<OrganizationSubscriptionRow>(
-          `insert into organization_subscriptions
-           (organization_id, stripe_customer_id, stripe_subscription_id, plan_id, status,
-            current_period_end, cancel_at_period_end, updated_at)
-         values ($1, $2, $3, $4, $5, $6, $7, now())
+        const rows = await client.query<OrganizationBillingCustomerRow>(
+          `insert into organization_billing_customers
+           (organization_id, stripe_customer_id, updated_at)
+         values ($1, $2, now())
          on conflict (organization_id) do update
            set stripe_customer_id = excluded.stripe_customer_id,
-               stripe_subscription_id = excluded.stripe_subscription_id,
-               plan_id = excluded.plan_id,
-               status = excluded.status,
-               current_period_end = excluded.current_period_end,
-               cancel_at_period_end = excluded.cancel_at_period_end,
                updated_at = now()
          returning *`,
-          [
-            input.organizationId,
-            input.stripeCustomerId,
-            input.stripeSubscriptionId,
-            input.planId,
-            input.status,
-            input.currentPeriodEnd,
-            input.cancelAtPeriodEnd,
-          ],
+          [input.organizationId, input.stripeCustomerId],
         );
         const row = rows.rows[0];
-        if (row === undefined) throw new Error("organization subscription upsert returned no row");
+        if (row === undefined)
+          throw new Error("organization billing customer upsert returned no row");
         // Same transaction as the mirror upsert: the plan the org is billed on and the entitlements
         // it enforces can never diverge across a crash between the two writes.
         if (input.stamp !== undefined) {
@@ -2729,7 +2716,7 @@ class PgDatabase implements Database {
             ...input.stamp,
           });
         }
-        return toOrganizationSubscriptionRecord(row);
+        return toOrganizationBillingCustomerRecord(row);
       });
     } catch (error) {
       throw toDatabaseError(error);
@@ -2740,15 +2727,17 @@ class PgDatabase implements Database {
     return this.locks.withLock(key, fn);
   }
 
-  async getOrganizationSubscription(
+  async getOrganizationBillingCustomer(
     organizationId: string,
-  ): Promise<OrganizationSubscriptionRecord | undefined> {
-    const rows = await query<OrganizationSubscriptionRow>(
+  ): Promise<OrganizationBillingCustomerRecord | undefined> {
+    const rows = await query<OrganizationBillingCustomerRow>(
       this.pool,
-      `select * from organization_subscriptions where organization_id = $1`,
+      `select * from organization_billing_customers where organization_id = $1`,
       [organizationId],
     );
-    return rows.rows[0] === undefined ? undefined : toOrganizationSubscriptionRecord(rows.rows[0]);
+    return rows.rows[0] === undefined
+      ? undefined
+      : toOrganizationBillingCustomerRecord(rows.rows[0]);
   }
 
   async listProjectsForOrganization(organizationId: string): Promise<ProjectRecord[]> {
@@ -4256,7 +4245,7 @@ export interface OrganizationEntitlementsRow extends QueryRow {
  * that lands the same granted template and the same plan provenance is a no-op — no timestamp
  * bump, no duplicate audit row — which is what stops the webhook re-stamp ping-pong. jsonb
  * `is distinct from` compares granted structurally. Shared by `stampOrganizationEntitlements`
- * and `reconcileOrganizationSubscription` so the subscription mirror and the stamp commit
+ * and `reconcileOrganizationBilling` so the subscription mirror and the stamp commit
  * together.
  */
 async function stampEntitlementsWithinTransaction(
@@ -4431,28 +4420,18 @@ function toBillingPlanRecord(
   };
 }
 
-export interface OrganizationSubscriptionRow extends QueryRow {
+export interface OrganizationBillingCustomerRow extends QueryRow {
   organization_id: string;
   stripe_customer_id: string;
-  stripe_subscription_id: string;
-  plan_id: string | null;
-  status: string;
-  current_period_end: Date | null;
-  cancel_at_period_end: boolean;
   updated_at: Date;
 }
 
-function toOrganizationSubscriptionRecord(
-  row: OrganizationSubscriptionRow,
-): OrganizationSubscriptionRecord {
+function toOrganizationBillingCustomerRecord(
+  row: OrganizationBillingCustomerRow,
+): OrganizationBillingCustomerRecord {
   return {
     organizationId: row.organization_id,
     stripeCustomerId: row.stripe_customer_id,
-    stripeSubscriptionId: row.stripe_subscription_id,
-    planId: row.plan_id,
-    status: row.status,
-    currentPeriodEnd: row.current_period_end,
-    cancelAtPeriodEnd: row.cancel_at_period_end,
     updatedAt: row.updated_at,
   };
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1242,15 +1242,10 @@ export const billingPlanPrices = pgTable(
 // from the subscription's price at webhook time — never dereferenced by enforcement, which reads
 // only `organization_entitlements`. `status` carries Stripe's own vocabulary verbatim, so no
 // check constraint drifts against it. Self-hosted instances never write here.
-export const organizationSubscriptions = pgTable("organization_subscriptions", {
+export const organizationBillingCustomers = pgTable("organization_billing_customers", {
   organizationId: text("organization_id")
     .primaryKey()
     .references(() => organizations.id, { onDelete: "cascade" }),
   stripeCustomerId: text("stripe_customer_id").notNull(),
-  stripeSubscriptionId: text("stripe_subscription_id").notNull().unique(),
-  planId: text("plan_id"),
-  status: text().notNull(),
-  currentPeriodEnd: timestamp("current_period_end", { withTimezone: true }),
-  cancelAtPeriodEnd: boolean("cancel_at_period_end").notNull().default(false),
   updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
 });

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -965,14 +965,9 @@ export interface SyncBillingPlanInput {
  * mirror. Enforcement never reads this — the subscription webhook re-stamps
  * `organization_entitlements` from the resolved plan's template.
  */
-export interface OrganizationSubscriptionRecord {
+export interface OrganizationBillingCustomerRecord {
   organizationId: string;
   stripeCustomerId: string;
-  stripeSubscriptionId: string;
-  planId: string | null;
-  status: string;
-  currentPeriodEnd: Date | null;
-  cancelAtPeriodEnd: boolean;
   updatedAt: Date;
 }
 
@@ -984,14 +979,9 @@ export interface OrganizationSubscriptionRecord {
  * grandfathered (a transient status that leaves the last stamp untouched). The stamp reuses the
  * same idempotent logic as `stampOrganizationEntitlements`, so a replay is a no-op.
  */
-export interface ReconcileOrganizationSubscriptionInput {
+export interface ReconcileOrganizationBillingInput {
   organizationId: string;
   stripeCustomerId: string;
-  stripeSubscriptionId: string;
-  planId: string | null;
-  status: string;
-  currentPeriodEnd: Date | null;
-  cancelAtPeriodEnd: boolean;
   stamp?: Omit<StampOrganizationEntitlementsInput, "organizationId">;
 }
 
@@ -1348,13 +1338,13 @@ export interface Database {
    * re-stamps its entitlements in the same transaction. `src/billing/` only — the sole convergent
    * writer the subscription webhook drives.
    */
-  reconcileOrganizationSubscription(
-    input: ReconcileOrganizationSubscriptionInput,
-  ): Promise<OrganizationSubscriptionRecord>;
+  reconcileOrganizationBilling(
+    input: ReconcileOrganizationBillingInput,
+  ): Promise<OrganizationBillingCustomerRecord>;
   /** The organization's current subscription mirror, or undefined when it never subscribed. */
-  getOrganizationSubscription(
+  getOrganizationBillingCustomer(
     organizationId: string,
-  ): Promise<OrganizationSubscriptionRecord | undefined>;
+  ): Promise<OrganizationBillingCustomerRecord | undefined>;
   /**
    * Runs `fn` while holding a named advisory lock that serializes across processes, so a
    * per-organization critical section (re-read external state, then write) cannot interleave with

--- a/src/e2e/harness/browser-billing.ts
+++ b/src/e2e/harness/browser-billing.ts
@@ -161,6 +161,7 @@ export interface FixtureSubscriptionState {
   quantity: number;
   status: string;
   currentPeriodEnd: Date | null;
+  trialEnd: Date | null;
   cancelAtPeriodEnd: boolean;
 }
 
@@ -194,12 +195,23 @@ export class FixtureStripeBillingClient {
     return `cus_fixture_${input.organizationId}`;
   }
 
+  async listCustomerSubscriptions(
+    customerId: string,
+  ): Promise<readonly FixtureSubscriptionState[]> {
+    const result: FixtureSubscriptionState[] = [];
+    for (const subscription of this.subscriptions.values()) {
+      if (subscription.customerId === customerId) result.push({ ...subscription });
+    }
+    return result;
+  }
+
   async createCheckoutSession(input: {
     organizationId: string;
     customerId: string;
     priceId: string;
     quantity: number;
     successUrl: string;
+    trial: boolean;
   }): Promise<{ url: string }> {
     const id = fixtureSubscriptionId(input.organizationId);
     // Idempotent initial subscription: if one already exists, checkout does not open a second or
@@ -211,8 +223,9 @@ export class FixtureStripeBillingClient {
         organizationId: input.organizationId,
         priceId: input.priceId,
         quantity: input.quantity,
-        status: "active",
+        status: input.trial ? "trialing" : "active",
         currentPeriodEnd: new Date(Date.now() + FIXTURE_SUBSCRIPTION_PERIOD_MS),
+        trialEnd: input.trial ? new Date(Date.now() + 14 * 24 * 60 * 60 * 1000) : null,
         cancelAtPeriodEnd: false,
       });
     }

--- a/src/e2e/harness/browser-billing.ts
+++ b/src/e2e/harness/browser-billing.ts
@@ -23,6 +23,21 @@ export interface FixtureBillingPrice {
   interval: "month" | "year" | null;
 }
 
+/**
+ * A deterministic mirror of the catalog Hub actually publishes, not an invented price list. Two
+ * products, because that is what Stripe carries:
+ *
+ * - `free` is the internal entitlement record. It exists so provisioning and cancellation have a
+ *   template to stamp; it is not an offer, and `BillingRuntime.publicCatalog` withholds it. Its
+ *   zero execution limit is the enforcement floor a customer without a subscription lands on —
+ *   E2E asserts it is never rendered as a plan.
+ * - `hosted` is the one purchasable plan: Paseo Hub, €15 per user per month, monthly only. There
+ *   is no annual price, so the picker has no interval to switch between.
+ *
+ * Keep this in step with the live Stripe catalog. A test that needs several plans to exercise
+ * generic catalog behaviour builds its own synthetic products (see `src/billing/reconcile.test.ts`)
+ * rather than adding fictional tiers here, where they would reach the screenshots.
+ */
 export const FIXTURE_BILLING_PRODUCTS: readonly FixtureBillingProduct[] = [
   {
     id: "prod_fixture_free",
@@ -35,33 +50,25 @@ export const FIXTURE_BILLING_PRODUCTS: readonly FixtureBillingProduct[] = [
       ent_can_invite: "false",
       ent_executions_monthly_limit: "0",
     },
-    marketingFeatures: ["1 seat", "0 executions / month", "Community support"],
+    marketingFeatures: [],
   },
   {
-    id: "prod_fixture_solo",
-    name: "Solo",
+    id: "prod_fixture_hosted",
+    name: "Paseo Hub",
     active: true,
     metadata: {
       paseo_plan: "true",
-      paseo_plan_slug: "solo",
-      ent_seats_max: "unlimited",
-      ent_can_invite: "true",
-      ent_executions_monthly_limit: "2000",
-    },
-    marketingFeatures: ["Unlimited seats", "2,000 executions / month", "Email support"],
-  },
-  {
-    id: "prod_fixture_team",
-    name: "Team",
-    active: true,
-    metadata: {
-      paseo_plan: "true",
-      paseo_plan_slug: "team",
+      paseo_plan_slug: "hosted",
       ent_seats_max: "unlimited",
       ent_can_invite: "true",
       ent_executions_monthly_limit: "unlimited",
     },
-    marketingFeatures: ["Unlimited seats", "Unlimited executions", "Priority support"],
+    marketingFeatures: [
+      "Unlimited daemons",
+      "GitHub, Linear, Slack, and Discord triggers",
+      "Versioned workflows and activity",
+      "Bring your own agents and inference",
+    ],
   },
 ];
 
@@ -71,54 +78,18 @@ export const FIXTURE_BILLING_PRICES: readonly FixtureBillingPrice[] = [
     productId: "prod_fixture_free",
     lookupKey: "free_monthly",
     active: true,
-    currency: "usd",
+    currency: "eur",
     unitAmount: 0,
     interval: "month",
   },
   {
-    id: "price_fixture_free_annual",
-    productId: "prod_fixture_free",
-    lookupKey: "free_annual",
+    id: "price_fixture_hosted_monthly",
+    productId: "prod_fixture_hosted",
+    lookupKey: "hosted_monthly",
     active: true,
-    currency: "usd",
-    unitAmount: 0,
-    interval: "year",
-  },
-  {
-    id: "price_fixture_solo_monthly",
-    productId: "prod_fixture_solo",
-    lookupKey: "solo_monthly",
-    active: true,
-    currency: "usd",
-    unitAmount: 2900,
+    currency: "eur",
+    unitAmount: 1500,
     interval: "month",
-  },
-  {
-    id: "price_fixture_solo_annual",
-    productId: "prod_fixture_solo",
-    lookupKey: "solo_annual",
-    active: true,
-    currency: "usd",
-    unitAmount: 29000,
-    interval: "year",
-  },
-  {
-    id: "price_fixture_team_monthly",
-    productId: "prod_fixture_team",
-    lookupKey: "team_monthly",
-    active: true,
-    currency: "usd",
-    unitAmount: 9900,
-    interval: "month",
-  },
-  {
-    id: "price_fixture_team_annual",
-    productId: "prod_fixture_team",
-    lookupKey: "team_annual",
-    active: true,
-    currency: "usd",
-    unitAmount: 99000,
-    interval: "year",
   },
 ];
 

--- a/src/e2e/harness/browser-billing.ts
+++ b/src/e2e/harness/browser-billing.ts
@@ -33,9 +33,9 @@ export const FIXTURE_BILLING_PRODUCTS: readonly FixtureBillingProduct[] = [
       paseo_plan_slug: "free",
       ent_seats_max: "1",
       ent_can_invite: "false",
-      ent_executions_monthly_limit: "100",
+      ent_executions_monthly_limit: "0",
     },
-    marketingFeatures: ["1 seat", "100 executions / month", "Community support"],
+    marketingFeatures: ["1 seat", "0 executions / month", "Community support"],
   },
   {
     id: "prod_fixture_solo",

--- a/src/entitlements/catalog.ts
+++ b/src/entitlements/catalog.ts
@@ -13,7 +13,7 @@ export const entitlementsSchema = z
     seats: z
       .object({
         /** null means unlimited. */
-        max: z.number().int().positive().nullable(),
+        max: z.number().int().nonnegative().nullable(),
       })
       .strict(),
     canInviteMembers: z.boolean(),
@@ -22,7 +22,7 @@ export const entitlementsSchema = z
         "executions.monthly": z
           .object({
             /** null means unlimited. */
-            limit: z.number().int().positive().nullable(),
+            limit: z.number().int().nonnegative().nullable(),
           })
           .strict(),
       })
@@ -46,12 +46,12 @@ export type Entitlements = z.infer<typeof entitlementsSchema>;
  * decides how an older shape maps onto it.
  */
 const storedEntitlementsSchema = z.object({
-  seats: z.object({ max: z.number().int().positive().nullable() }),
+  seats: z.object({ max: z.number().int().nonnegative().nullable() }),
   canInviteMembers: z.boolean(),
   meters: z
     .object({
       "executions.monthly": z
-        .object({ limit: z.number().int().positive().nullable() })
+        .object({ limit: z.number().int().nonnegative().nullable() })
         .default({ limit: null }),
     })
     .default({ "executions.monthly": { limit: null } }),
@@ -69,7 +69,7 @@ export const entitlementOverridesSchema = z
   .object({
     seats: z
       .object({
-        max: z.number().int().positive().nullable(),
+        max: z.number().int().nonnegative().nullable(),
       })
       .strict()
       .partial(),
@@ -78,7 +78,7 @@ export const entitlementOverridesSchema = z
       .object({
         "executions.monthly": z
           .object({
-            limit: z.number().int().positive().nullable(),
+            limit: z.number().int().nonnegative().nullable(),
           })
           .strict()
           .partial(),

--- a/src/entitlements/service.test.ts
+++ b/src/entitlements/service.test.ts
@@ -342,6 +342,32 @@ describe("EntitlementsService", () => {
     });
   });
 
+  it("denies every execution for a zero-execution Hosted Free stamp", async () => {
+    const service = serviceWith();
+    await service.stamp(
+      "org-free",
+      {
+        seats: { max: 1 },
+        canInviteMembers: false,
+        meters: { "executions.monthly": { limit: 0 } },
+      },
+      { source: "plan_stamp", planId: "prod-free" },
+    );
+
+    const denied = await service.consume("org-free", "executions.monthly", 1).then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+    assert.ok(denied instanceof EntitlementDenied);
+    assert.equal(denied.limit, 0);
+    assert.equal(denied.current, 0);
+    assert.deepEqual(await service.usage("org-free", "executions.monthly"), {
+      meter: "executions.monthly",
+      used: 0,
+      limit: 0,
+    });
+  });
+
   it("rejects a non-positive or non-integer consume amount before touching usage", async () => {
     const service = serviceWith();
     await service.stamp(

--- a/src/server/runtime.ts
+++ b/src/server/runtime.ts
@@ -1,6 +1,10 @@
 import type { HubOperations, HubRuntime } from "../app.js";
 import type { InitialOperator, InstanceClaim } from "../instance-setup/index.js";
-import type { BillingRuntime, CurrentSubscriptionView } from "../billing/index.js";
+import type {
+  BillingRuntime,
+  CurrentSubscriptionView,
+  PublicBillingPlan,
+} from "../billing/index.js";
 import type { BillingPlanPriceInterval } from "../db/types.js";
 import type { OperatorConsole } from "../operator/console.js";
 import type {
@@ -13,20 +17,11 @@ import type { UsageDashboard } from "../usage/dashboard.js";
 import type { ProviderApplications } from "../provider-applications/index.js";
 
 /**
- * The public plan catalog shape — name, slug, prices by interval, marketing bullets. Never
- * carries the entitlement template; see the plan's public plans endpoint section.
+ * The public plan catalog shape is billing's own: `src/billing/public-catalog.ts` decides which
+ * plans are an offer and what a consumer may see of them. Re-exported here so the rest of the app
+ * names it without importing across the billing boundary.
  */
-export interface PublicBillingPlan {
-  slug: string;
-  name: string;
-  marketingFeatures: readonly string[];
-  prices: Record<BillingPlanPriceInterval, PublicBillingPlanPrice | null>;
-}
-
-export interface PublicBillingPlanPrice {
-  unitAmount: number;
-  currency: string;
-}
+export type { PublicBillingPlan, PublicBillingPlanPrice } from "../billing/index.js";
 
 /** The dashboard billing section: the organization's current plan plus the catalog to upgrade
  * into. Only ever built on a billing-configured instance; the route guards on that. */


### PR DESCRIPTION
Paseo Hub customers can start a 14-day Hosted trial without entering a card, see the trial state in Billing, and subscribe after the trial ends. The billing surface now publishes only the actual Stripe-backed offer and keeps internal entitlement floors out of customer-facing pricing.

## Goals

- Offer a 14-day cardless trial that Stripe cancels when no payment method is added.
- Treat Stripe as the subscription and trial source of truth while keeping execution authorization local.
- Publish one customer-facing Paseo Hub offer at the catalog price and hide internal entitlement plans.
- Present concise, responsive trial, active subscription, and expired-trial billing states.
- Preserve the billing-free, unlimited self-hosted boundary when Stripe is not configured.

## Non-goals

- Provision inference or hosted compute.
- Introduce annual pricing or additional public tiers.
- Add a Hub-owned trial clock, expiry worker, or persistent subscription-state mirror.

## Why

Trial timing, payment methods, cancellation, and subscription history belong to Stripe. Hub only persists the customer reference and the entitlement projection needed to authorize workflow execution without putting Stripe on the hot path. Live billing reads use a short-lived private cache, and signed webhooks re-read Stripe before changing access.

## Verification

- `npx vitest run src/billing` — 63 passed
- Billing Playwright matrix across desktop and mobile Chromium — 6 passed
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run db:check`
- `npm run build`
- Manual desktop and mobile review of the trial offer, active trial, expired state, and paid subscribe flow

## Risk surface

- Subscription reconciliation and entitlement stamping
- Checkout trial eligibility and idempotency
- Migration from the copied subscription mirror to customer identity linkage
- Hosted catalog publication and billing UI
- Self-hosted instances remain outside the billing module and are covered by browser verification