### PR TITLE
Use color contrast for copy hierarchy

### DIFF
--- a/src/auth/api-key-panel.tsx
+++ b/src/auth/api-key-panel.tsx
@@ -259,7 +259,7 @@ export function ApiKeys() {
       </DataTable>
       <section className="mt-10 grid gap-4" aria-labelledby="cli-logins-heading">
         <div>
-          <h2 id="cli-logins-heading" className="text-lg font-semibold">
+          <h2 id="cli-logins-heading" className="text-lg">
             CLI logins
           </h2>
           <p className="text-muted-foreground text-sm">
@@ -353,7 +353,7 @@ function ApiKeyRow({
   return (
     <DataRow>
       <DataCell>
-        <span className="font-medium">{record.name}</span>
+        <span>{record.name}</span>
       </DataCell>
       <DataCell>
         <span className="font-mono text-xs">{record.prefix}</span>
@@ -467,7 +467,7 @@ function ApiKeyDialog({
               </Field>
               <Field>
                 <fieldset className="grid gap-3">
-                  <legend className="text-sm leading-snug font-medium">Scopes</legend>
+                  <legend className="text-sm leading-snug">Scopes</legend>
                   <div className="grid gap-3">
                     {SCOPE_OPTIONS.map((option) => (
                       <ScopeOption key={option.value} option={option} onChange={updateScope} />
@@ -540,7 +540,7 @@ function ScopeOption({
     <label htmlFor={id} className="flex cursor-pointer items-start gap-3">
       <CheckboxInput id={id} name="scopes" value={option.value} onChange={handleChange} />
       <span className="grid gap-0.5 text-sm">
-        <span className="font-medium">{option.label}</span>
+        <span>{option.label}</span>
         <span className="text-muted-foreground">{option.description}</span>
       </span>
     </label>

--- a/src/auth/dashboard-shell.tsx
+++ b/src/auth/dashboard-shell.tsx
@@ -509,7 +509,7 @@ function InstanceHeader() {
             <ShieldCheck aria-hidden="true" className="size-4" />
           </span>
           <span className="grid flex-1 leading-tight group-data-[collapsible=icon]:hidden">
-            <span className="truncate font-medium">Instance</span>
+            <span className="truncate">Instance</span>
             <span className="truncate text-xs text-muted-foreground">Administration</span>
           </span>
         </div>
@@ -623,7 +623,7 @@ function OrganizationSwitcher({
                 <PaseoGlyph />
               </span>
               <span className="grid flex-1 text-left leading-tight">
-                <span className="truncate text-sm font-medium">{currentOrganization.name}</span>
+                <span className="truncate text-sm">{currentOrganization.name}</span>
                 <span className="truncate text-xs text-muted-foreground">
                   {ROLE_LABELS[currentRole] ?? currentRole}
                 </span>
@@ -846,7 +846,7 @@ function AccountMenu({
           tooltip={email}
           className="data-[state=open]:bg-sidebar-accent"
         >
-          <span className="flex aspect-square size-8 items-center justify-center rounded-md bg-sidebar-accent text-xs font-medium">
+          <span className="flex aspect-square size-8 items-center justify-center rounded-md bg-sidebar-accent text-xs">
             {initials(name, email)}
           </span>
           <span className="grid flex-1 text-left leading-tight">

--- a/src/auth/organization-settings.tsx
+++ b/src/auth/organization-settings.tsx
@@ -45,7 +45,7 @@ export function OrganizationSettingsLayout() {
               aria-current={active ? "page" : undefined}
               className={cn(
                 "rounded-md px-2.5 py-1.5 hover:bg-accent hover:text-accent-foreground",
-                active ? "bg-accent font-medium text-accent-foreground" : "text-muted-foreground",
+                active ? "bg-accent text-accent-foreground" : "text-muted-foreground",
               )}
             >
               {section.label}

--- a/src/billing/ui/panel.tsx
+++ b/src/billing/ui/panel.tsx
@@ -127,7 +127,7 @@ function PlanIdentity({
             <StatusPill tone={summary.status.tone}>{summary.status.label}</StatusPill>
           </div>
         )}
-        <p className="text-2xl leading-tight font-semibold tracking-tight">
+        <p className="text-2xl leading-tight tracking-tight">
           {summary.planName ?? NO_SUBSCRIPTION}
         </p>
         {summary.detail !== null && (

--- a/src/billing/ui/plan-dialog.tsx
+++ b/src/billing/ui/plan-dialog.tsx
@@ -199,10 +199,10 @@ function PlanCard({
   return (
     <div className="flex flex-col rounded-xl border bg-card p-5 text-card-foreground">
       <div className="flex min-h-6 items-start justify-between gap-2">
-        <h3 className="text-sm font-medium">{plan.name}</h3>
+        <h3 className="text-sm">{plan.name}</h3>
         {isCurrent && <Badge variant="secondary">Current</Badge>}
       </div>
-      <p className="mt-3 text-3xl leading-none font-semibold tracking-tight">{amount}</p>
+      <p className="mt-3 text-3xl leading-none tracking-tight">{amount}</p>
       <p className="mt-1.5 text-xs text-muted-foreground">{unit}</p>
       {/* Stacked on a phone, the plan you are already on collapses to a marker: its feature list
           is the one thing on the screen nobody needs to read, and it costs a full scroll. */}

--- a/src/cli-authorizations/approval.tsx
+++ b/src/cli-authorizations/approval.tsx
@@ -89,7 +89,7 @@ export function CliLoginApproval({ accountId, organizationId }: ApprovalIdentity
       >
         <div className="grid gap-1 rounded-md border px-3 py-2.5 text-sm">
           <span className="text-muted-foreground">Organization receiving access</span>
-          <strong>{request.organization.name}</strong>
+          <span className="text-foreground">{request.organization.name}</span>
         </div>
         {request.canManage ? (
           <form className="grid gap-6" onSubmit={submitDecision} aria-label="Approve CLI login">

--- a/src/components/app/auth-layout.tsx
+++ b/src/components/app/auth-layout.tsx
@@ -83,7 +83,7 @@ export function ProductMark({ className }: { className?: string }) {
       <span className="flex size-7 items-center justify-center rounded-md bg-primary text-primary-foreground">
         <PaseoGlyph />
       </span>
-      <span className="text-sm font-medium">Paseo Hub</span>
+      <span className="text-sm">Paseo Hub</span>
     </div>
   );
 }

--- a/src/components/app/data-table.tsx
+++ b/src/components/app/data-table.tsx
@@ -40,7 +40,7 @@ export function DataTable({
               <TableHead
                 key={column.header === "" ? `actions-${String(index)}` : column.header}
                 className={cn(
-                  "h-9 px-4 text-xs font-medium text-muted-foreground",
+                  "h-9 px-4 text-xs text-muted-foreground",
                   // The identifying column absorbs the spare width; everything after it
                   // shrinks to its content, so columns stay next to each other instead of
                   // drifting apart on a wide screen.

--- a/src/components/app/disclosure.tsx
+++ b/src/components/app/disclosure.tsx
@@ -58,9 +58,7 @@ export function Disclosure({
           </span>
         )}
         <span className="contents sm:grid sm:min-w-0 sm:flex-1 sm:gap-0.5">
-          <span className="col-start-2 row-start-1 truncate font-medium sm:col-auto sm:row-auto">
-            {title}
-          </span>
+          <span className="col-start-2 row-start-1 truncate sm:col-auto sm:row-auto">{title}</span>
           {description === undefined ? null : (
             <span className="col-span-3 row-start-2 text-sm text-muted-foreground sm:col-auto sm:row-auto">
               {description}

--- a/src/components/app/page.tsx
+++ b/src/components/app/page.tsx
@@ -29,7 +29,7 @@ export function PageHeader({
   return (
     <header className="mb-6 flex flex-wrap items-start justify-between gap-4">
       <div className="grid min-w-0 gap-1">
-        <h1 id={id} className="text-xl font-semibold tracking-tight">
+        <h1 id={id} className="text-xl font-medium tracking-tight">
           {title}
         </h1>
         {description === undefined ? null : (

--- a/src/components/app/section.tsx
+++ b/src/components/app/section.tsx
@@ -25,7 +25,7 @@ export function Section({
       {title === undefined ? null : (
         <div className="flex min-w-0 items-start justify-between gap-4">
           <div className="grid min-w-0 gap-1">
-            <h2 className="text-sm font-medium">{title}</h2>
+            <h2 className="text-sm">{title}</h2>
             {description === undefined ? null : (
               <p className="text-sm text-muted-foreground">{description}</p>
             )}

--- a/src/components/app/stat-tile.tsx
+++ b/src/components/app/stat-tile.tsx
@@ -23,7 +23,7 @@ export function StatTile({
         {label}
       </div>
       <div className="grid min-h-11 content-start gap-1">
-        <p className="text-2xl leading-none font-semibold tracking-tight tabular-nums">{value}</p>
+        <p className="text-2xl leading-none tracking-tight tabular-nums">{value}</p>
         <p className="min-h-5 text-xs text-muted-foreground">{detail}</p>
       </div>
     </div>

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -91,7 +91,7 @@ function AlertDialogTitle({
     <AlertDialogPrimitive.Title
       data-slot="alert-dialog-title"
       className={cn(
-        "text-lg font-semibold sm:group-data-[size=default]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2",
+        "text-lg sm:group-data-[size=default]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2",
         className,
       )}
       {...props}

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -38,7 +38,7 @@ function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="alert-title"
-      className={cn("col-start-2 line-clamp-1 min-h-4 font-medium tracking-tight", className)}
+      className={cn("col-start-2 line-clamp-1 min-h-4 tracking-tight", className)}
       {...props}
     />
   );

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -5,7 +5,7 @@ import { Slot } from "radix-ui";
 import { cn } from "../../lib/utils.js";
 
 const badgeVariants = cva(
-  "inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-full border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3",
+  "inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-full border border-transparent px-2 py-0.5 text-xs whitespace-nowrap transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3",
   {
     variants: {
       variant: {

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { Slot } from "radix-ui";
 import { cn } from "../../lib/utils.js";
 
 const buttonVariants = cva(
-  "inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -29,13 +29,7 @@ function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
 }
 
 function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
-  return (
-    <div
-      data-slot="card-title"
-      className={cn("leading-none font-semibold", className)}
-      {...props}
-    />
-  );
+  return <div data-slot="card-title" className={cn("leading-none", className)} {...props} />;
 }
 
 function CardDescription({ className, ...props }: React.ComponentProps<"div">) {

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -88,7 +88,7 @@ function DialogTitle({ className, ...props }: React.ComponentProps<typeof Dialog
   return (
     <DialogPrimitive.Title
       data-slot="dialog-title"
-      className={cn("text-base leading-none font-medium", className)}
+      className={cn("text-base leading-none", className)}
       {...props}
     />
   );

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -65,10 +65,7 @@ function DropdownMenuLabel({
     <DropdownMenuPrimitive.Label
       data-slot="dropdown-menu-label"
       data-inset={inset}
-      className={cn(
-        "px-2 py-1.5 text-xs font-medium text-muted-foreground data-[inset]:pl-8",
-        className,
-      )}
+      className={cn("px-2 py-1.5 text-xs text-muted-foreground data-[inset]:pl-8", className)}
       {...props}
     />
   );

--- a/src/components/ui/empty.tsx
+++ b/src/components/ui/empty.tsx
@@ -57,11 +57,7 @@ function EmptyMedia({
 
 function EmptyTitle({ className, ...props }: React.ComponentProps<"div">) {
   return (
-    <div
-      data-slot="empty-title"
-      className={cn("text-lg font-medium tracking-tight", className)}
-      {...props}
-    />
+    <div data-slot="empty-title" className={cn("text-lg tracking-tight", className)} {...props} />
   );
 }
 

--- a/src/components/ui/field.tsx
+++ b/src/components/ui/field.tsx
@@ -29,7 +29,7 @@ function FieldLegend({
       data-slot="field-legend"
       data-variant={variant}
       className={cn(
-        "mb-3 font-medium",
+        "mb-3",
         "data-[variant=legend]:text-base",
         "data-[variant=label]:text-sm",
         className,
@@ -119,7 +119,7 @@ function FieldTitle({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="field-label"
       className={cn(
-        "flex w-fit items-center gap-2 text-sm leading-snug font-medium group-data-[disabled=true]/field:opacity-50",
+        "flex w-fit items-center gap-2 text-sm leading-snug group-data-[disabled=true]/field:opacity-50",
         className,
       )}
       {...props}
@@ -132,7 +132,7 @@ function FieldDescription({ className, ...props }: React.ComponentProps<"p">) {
     <p
       data-slot="field-description"
       className={cn(
-        "text-sm leading-normal font-normal text-muted-foreground group-has-[[data-orientation=horizontal]]/field:text-balance",
+        "text-sm leading-normal text-muted-foreground group-has-[[data-orientation=horizontal]]/field:text-balance",
         "last:mt-0 nth-last-2:-mt-1 [[data-variant=legend]+&]:-mt-1.5",
         "[&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-link",
         className,
@@ -212,7 +212,7 @@ function FieldError({
     <div
       role="alert"
       data-slot="field-error"
-      className={cn("text-sm font-normal text-destructive", className)}
+      className={cn("text-sm text-destructive", className)}
       {...props}
     >
       {content}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "h-9 w-full min-w-0 rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm dark:bg-input/30",
+        "h-9 w-full min-w-0 rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:text-foreground placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm dark:bg-input/30",
         "focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50",
         "aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40",
         className,

--- a/src/components/ui/item.tsx
+++ b/src/components/ui/item.tsx
@@ -112,7 +112,7 @@ function ItemTitle({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="item-title"
-      className={cn("flex w-fit items-center gap-2 text-sm leading-snug font-medium", className)}
+      className={cn("flex w-fit items-center gap-2 text-sm leading-snug", className)}
       {...props}
     />
   );
@@ -123,7 +123,7 @@ function ItemDescription({ className, ...props }: React.ComponentProps<"p">) {
     <p
       data-slot="item-description"
       className={cn(
-        "line-clamp-2 text-sm leading-normal font-normal text-balance text-muted-foreground",
+        "line-clamp-2 text-sm leading-normal text-balance text-muted-foreground",
         "[&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-link",
         className,
       )}

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -8,7 +8,7 @@ function Label({ className, ...props }: React.ComponentProps<typeof LabelPrimiti
     <LabelPrimitive.Root
       data-slot="label"
       className={cn(
-        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        "flex items-center gap-2 text-sm leading-none select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
         className,
       )}
       {...props}

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -48,7 +48,7 @@ function PopoverHeader({ className, ...props }: React.ComponentProps<"div">) {
 }
 
 function PopoverTitle({ className, ...props }: React.ComponentProps<"h2">) {
-  return <div data-slot="popover-title" className={cn("font-medium", className)} {...props} />;
+  return <div data-slot="popover-title" className={cn(className)} {...props} />;
 }
 
 function PopoverDescription({ className, ...props }: React.ComponentProps<"p">) {

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -101,7 +101,7 @@ function SheetTitle({ className, ...props }: React.ComponentProps<typeof SheetPr
   return (
     <SheetPrimitive.Title
       data-slot="sheet-title"
-      className={cn("font-semibold text-foreground", className)}
+      className={cn("text-foreground", className)}
       {...props}
     />
   );

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -384,7 +384,7 @@ function SidebarGroupLabel({
       data-slot="sidebar-group-label"
       data-sidebar="group-label"
       className={cn(
-        "flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium text-sidebar-foreground/70 ring-sidebar-ring outline-hidden transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        "flex h-8 shrink-0 items-center rounded-md px-2 text-xs text-sidebar-foreground/70 ring-sidebar-ring outline-hidden transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
         "group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0",
         className,
       )}
@@ -450,7 +450,7 @@ function SidebarMenuItem({ className, ...props }: React.ComponentProps<"li">) {
 }
 
 const sidebarMenuButtonVariants = cva(
-  "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm ring-sidebar-ring outline-hidden transition-[width,height,padding] group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+  "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm ring-sidebar-ring outline-hidden transition-[width,height,padding] group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
   {
     variants: {
       variant: {
@@ -557,7 +557,7 @@ function SidebarMenuBadge({ className, ...props }: React.ComponentProps<"div">) 
       data-slot="sidebar-menu-badge"
       data-sidebar="menu-badge"
       className={cn(
-        "pointer-events-none absolute right-1 flex h-5 min-w-5 items-center justify-center rounded-md px-1 text-xs font-medium text-sidebar-foreground tabular-nums select-none",
+        "pointer-events-none absolute right-1 flex h-5 min-w-5 items-center justify-center rounded-md px-1 text-xs text-sidebar-foreground tabular-nums select-none",
         "peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[active=true]/menu-button:text-sidebar-accent-foreground",
         "peer-data-[size=sm]/menu-button:top-1",
         "peer-data-[size=default]/menu-button:top-1.5",

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -40,7 +40,7 @@ function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
   return (
     <tfoot
       data-slot="table-footer"
-      className={cn("border-t bg-muted/50 font-medium [&>tr]:last:border-b-0", className)}
+      className={cn("border-t bg-muted/50 [&>tr]:last:border-b-0", className)}
       {...props}
     />
   );
@@ -64,7 +64,7 @@ function TableHead({ className, ...props }: React.ComponentProps<"th">) {
     <th
       data-slot="table-head"
       className={cn(
-        "h-10 px-2 text-left align-middle font-medium whitespace-nowrap text-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        "h-10 px-2 text-left align-middle whitespace-nowrap text-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
         className,
       )}
       {...props}

--- a/src/projects/configuration/code-editor.tsx
+++ b/src/projects/configuration/code-editor.tsx
@@ -112,8 +112,8 @@ const paseoHighlight = HighlightStyle.define([
   { tag: [tags.number, tags.bool, tags.null, tags.atom], color: "var(--chart-4)" },
   { tag: [tags.comment], color: "var(--muted-foreground)", fontStyle: "italic" },
   { tag: [tags.keyword, tags.operator, tags.punctuation], color: "var(--muted-foreground)" },
-  { tag: [tags.heading], color: "var(--link)", fontWeight: "600" },
-  { tag: [tags.strong], fontWeight: "600" },
+  { tag: [tags.heading], color: "var(--foreground)" },
+  { tag: [tags.strong], color: "var(--foreground)" },
   { tag: [tags.emphasis], fontStyle: "italic" },
   { tag: [tags.link, tags.url], color: "var(--chart-2)" },
 ]);

--- a/src/projects/configuration/panel.tsx
+++ b/src/projects/configuration/panel.tsx
@@ -285,7 +285,7 @@ function RevisionSummary({ revision }: { revision: Configuration["activeRevision
         </p>
       ) : (
         <div className="rounded-md border px-2.5 py-2">
-          <p className="text-sm font-medium">Revision {revision.version}</p>
+          <p className="text-sm">Revision {revision.version}</p>
           <p className="text-xs text-muted-foreground">
             {revision.sourceKind === "github" ? "GitHub-managed" : "Manual"} ·{" "}
             {formatDate(revision.createdAt)}
@@ -560,7 +560,7 @@ function SourceModeButton({
       title={title}
       onClick={onClick}
       className={cn(
-        "inline-flex flex-1 items-center justify-center gap-1.5 rounded-sm px-2 py-1 text-xs font-medium transition-colors disabled:pointer-events-none disabled:opacity-50",
+        "inline-flex flex-1 items-center justify-center gap-1.5 rounded-sm px-2 py-1 text-xs transition-colors disabled:pointer-events-none disabled:opacity-50",
         active
           ? "bg-background text-foreground shadow-xs"
           : "text-muted-foreground hover:text-foreground",
@@ -603,9 +603,7 @@ function ManualConfigurationResult({
 
 function RailLabel({ children }: { children: React.ReactNode }) {
   return (
-    <span className="text-[11px] font-medium tracking-wide text-muted-foreground uppercase">
-      {children}
-    </span>
+    <span className="text-[11px] tracking-wide text-muted-foreground uppercase">{children}</span>
   );
 }
 

--- a/src/projects/panels.tsx
+++ b/src/projects/panels.tsx
@@ -150,13 +150,13 @@ function ProjectCard({
     <>
       <span
         aria-hidden="true"
-        className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-primary/15 text-sm font-semibold text-link"
+        className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-primary/15 text-sm text-link"
       >
         {monogram(project.name)}
       </span>
       <span className="grid min-w-0 flex-1 gap-0.5">
         <span className="flex items-center gap-2">
-          <span className="truncate font-medium group-hover:text-link">{project.name}</span>
+          <span className="truncate group-hover:text-link">{project.name}</span>
           {project.status === "active" ? null : <StatusPill tone="neutral">Archived</StatusPill>}
         </span>
         <span className="truncate font-mono text-xs text-muted-foreground">{project.slug}</span>
@@ -276,7 +276,7 @@ export function OrganizationConnectionsPanel() {
           {rows.map((connection) => (
             <DataRow key={`${connection.provider}-${connection.id}`}>
               <DataCell>
-                <span className="font-medium">{connection.name}</span>
+                <span>{connection.name}</span>
                 <span className="block font-mono text-xs text-muted-foreground">
                   {connection.externalId}
                 </span>
@@ -333,7 +333,7 @@ export function OrganizationConnectionsPanel() {
                 key={provider}
                 className="flex items-center justify-between gap-2 rounded-md border p-3"
               >
-                <span className="inline-flex items-center gap-2 text-sm font-medium">
+                <span className="inline-flex items-center gap-2 text-sm">
                   <ProviderGlyph provider={provider} />
                   {providerLabel(provider)}
                 </span>
@@ -511,7 +511,7 @@ export function ProjectActivityRunPanel({ runId }: { runId: string }) {
             {activity.steps.map((step) => (
               <DataRow key={step.id}>
                 <DataCell>
-                  <span className="font-medium">
+                  <span>
                     {step.ordinal + 1}. {step.stepId}
                   </span>
                 </DataCell>
@@ -632,7 +632,7 @@ function SetupCard({ label, ready, detail }: { label: string; ready: boolean; de
   return (
     <section aria-label={label} className="rounded-lg border bg-card p-5">
       <div className="mb-2 flex items-center justify-between">
-        <h2 className="font-medium">{label}</h2>
+        <h2>{label}</h2>
         <StatusPill tone={ready ? "success" : "neutral"}>
           {ready ? "Ready" : "Setup needed"}
         </StatusPill>
@@ -645,7 +645,7 @@ function SetupCard({ label, ready, detail }: { label: string; ready: boolean; de
 function DetailField({ label, children }: { label: string; children: ReactNode }) {
   return (
     <div className="grid gap-1">
-      <dt className="text-xs font-medium text-muted-foreground">{label}</dt>
+      <dt className="text-xs text-muted-foreground">{label}</dt>
       <dd className="min-w-0">{children}</dd>
     </div>
   );
@@ -699,10 +699,7 @@ function ActivityTable({
             {detailBasePath &&
             "configuredTriggerName" in event &&
             event.configuredTriggerName !== null ? (
-              <Link
-                className="font-medium hover:underline"
-                to={`${detailBasePath}/${event.id}` as never}
-              >
+              <Link className="hover:underline" to={`${detailBasePath}/${event.id}` as never}>
                 {event.configuredTriggerName}
               </Link>
             ) : (

--- a/src/projects/repository-combobox.tsx
+++ b/src/projects/repository-combobox.tsx
@@ -53,7 +53,7 @@ export function RepositoryCombobox({
           aria-expanded={open}
           aria-controls={listId}
           disabled={disabled}
-          className="w-full min-w-0 justify-between font-normal"
+          className="w-full min-w-0 justify-between"
         >
           <span className="truncate">{selected?.fullName ?? placeholder}</span>
           {loading ? (

--- a/src/provider-applications/panel.tsx
+++ b/src/provider-applications/panel.tsx
@@ -151,7 +151,7 @@ export function AppSetupEntry({
           <h1
             ref={heading}
             tabIndex={-1}
-            className="text-xl font-semibold tracking-tight outline-none"
+            className="text-xl font-medium tracking-tight outline-none"
           >
             Set up your apps
           </h1>

--- a/src/provider-applications/provider-section.tsx
+++ b/src/provider-applications/provider-section.tsx
@@ -300,7 +300,7 @@ function SlackTransportChoice({
 }) {
   return (
     <fieldset className="grid gap-3">
-      <legend className="text-sm font-medium">How should Slack reach Hub?</legend>
+      <legend className="text-sm">How should Slack reach Hub?</legend>
       <div className="grid gap-3 sm:grid-cols-2">
         {(
           [
@@ -325,7 +325,7 @@ function SlackTransportChoice({
               onChange={() => onChange(transport)}
             />
             <span className="grid gap-1">
-              <span className="font-medium">{label}</span>
+              <span>{label}</span>
               <span className="text-sm text-muted-foreground">{description}</span>
             </span>
           </label>
@@ -588,7 +588,7 @@ function PasteForm({
       className="grid gap-4 rounded-lg border bg-muted/30 p-4 lg:sticky lg:top-6"
     >
       <div className="grid gap-1">
-        <h3 className="font-medium">{replacing ? "Replace credentials" : guide.formTitle}</h3>
+        <h3>{replacing ? "Replace credentials" : guide.formTitle}</h3>
         {replacing ? (
           <p className="text-sm text-muted-foreground">
             Rotating secrets for the same app keeps your connections. Setting up a different app
@@ -808,7 +808,7 @@ function InstructionGroup({
     <section className="grid min-w-0 gap-3">
       {group.title === undefined ? null : (
         <div className="grid gap-1 border-t pt-5">
-          <h3 className="font-medium">{group.title}</h3>
+          <h3>{group.title}</h3>
           {group.description === undefined ? null : (
             <p className="text-sm text-muted-foreground">{group.description}</p>
           )}
@@ -857,7 +857,7 @@ function StepBody({
         <dl className="mt-3 grid gap-x-4 gap-y-1.5 sm:grid-cols-[max-content_1fr]">
           {step.permissions.map((permission) => (
             <div key={permission.name} className="contents">
-              <dt className="font-medium text-foreground">{permission.name}</dt>
+              <dt className="text-foreground">{permission.name}</dt>
               <dd>{permission.access}</dd>
             </div>
           ))}
@@ -897,9 +897,9 @@ function StepBody({
 
 function Segment({ segment }: { segment: StepSegment }) {
   // Instruction prose is muted; the controls to find in the portal are not. That contrast is
-  // what makes a step scannable, and it is why not everything on the page is font-medium.
+  // what makes a step scannable without relying on font weight.
   if (segment.kind === "term") {
-    return <strong className="font-medium text-foreground">{segment.value}</strong>;
+    return <span className="text-foreground">{segment.value}</span>;
   }
   if (segment.kind === "link") {
     return (

--- a/src/public-api/reference.tsx
+++ b/src/public-api/reference.tsx
@@ -3,6 +3,12 @@ import { ApiReferenceReact, type AnyApiReferenceConfiguration } from "@scalar/ap
 import scalarStyles from "@scalar/api-reference-react/style.css?inline";
 
 const referenceStyle = { minHeight: "100vh" };
+const referenceTypography = `
+:where(.scalar-app) *,
+:where(.scalar-app) ::before,
+:where(.scalar-app) ::after { font-weight: 400 !important; }
+:where(.scalar-app) h1 { font-weight: 500 !important; }
+`;
 const referenceConfiguration = {
   url: "/api/openapi.json",
   metaData: { title: "Paseo Hub Public API" },
@@ -23,7 +29,7 @@ const referenceConfiguration = {
     proxyUrl: "/api/reference",
     apiBaseUrl: "/api/reference",
   },
-  customCss: `${scalarStyles}\n:root { --scalar-font: ui-sans-serif, system-ui, sans-serif; --scalar-font-code: ui-monospace, monospace; }`,
+  customCss: `${scalarStyles}\n:root { --scalar-font: ui-sans-serif, system-ui, sans-serif; --scalar-font-code: ui-monospace, monospace; }${referenceTypography}`,
 } satisfies AnyApiReferenceConfiguration;
 
 export function PublicApiReference() {

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -35,8 +35,8 @@ function NotFound() {
     <Document>
       <main className="grid min-h-svh place-items-center px-6 py-16">
         <div className="grid max-w-md gap-4 text-center">
-          <p className="text-sm font-medium text-muted-foreground">404</p>
-          <h1 className="text-2xl font-semibold tracking-tight">Page not found</h1>
+          <p className="text-sm text-muted-foreground">404</p>
+          <h1 className="text-2xl font-medium tracking-tight">Page not found</h1>
           <p className="text-sm text-muted-foreground">
             This address does not match a page in Paseo Hub. Check the address or return home.
           </p>

--- a/src/typography-policy.test.ts
+++ b/src/typography-policy.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, extname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it } from "vitest";
+
+const sourceRoot = dirname(fileURLToPath(import.meta.url));
+const sourceExtensions = new Set([".css", ".ts", ".tsx"]);
+const weightClass =
+  /font-(?:thin|extralight|light|normal|medium|semibold|bold|extrabold|black|[1-9]00|\[[^\]]+\])/g;
+
+function sourceFiles(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) return sourceFiles(path);
+    if (!sourceExtensions.has(extname(entry.name)) || entry.name.includes(".test.")) return [];
+    return [path];
+  });
+}
+
+function isPageTitleWeight(source: string, index: number, weight: string): boolean {
+  if (weight !== "font-medium") return false;
+  const openingHeading = source.lastIndexOf("<h1", index);
+  const openingTagEnd = source.lastIndexOf(">", index);
+  return openingHeading > openingTagEnd;
+}
+
+function hasDisallowedCssWeight(source: string): boolean {
+  const declarations = source.matchAll(/\bfont-weight\s*:\s*([^;]+)/gi);
+  for (const declaration of declarations) {
+    const value = (declaration[1] ?? "").replace(/\s*!important\s*$/, "").trim();
+    if (value === "400") continue;
+    const selector = source.slice(
+      source.lastIndexOf("}", declaration.index) + 1,
+      declaration.index,
+    );
+    if (value === "500" && selector.includes("h1")) continue;
+    return true;
+  }
+  return false;
+}
+
+describe("typography policy", () => {
+  it("uses medium weight only for page titles", () => {
+    const violations: string[] = [];
+
+    for (const path of sourceFiles(sourceRoot)) {
+      const source = readFileSync(path, "utf8");
+      const name = relative(sourceRoot, path);
+
+      for (const match of source.matchAll(weightClass)) {
+        if (!isPageTitleWeight(source, match.index, match[0])) {
+          violations.push(`${name}: ${match[0]}`);
+        }
+      }
+
+      if (/\bfontWeight\b|<(?:strong|b)\b/i.test(source) || hasDisallowedCssWeight(source)) {
+        violations.push(`${name}: non-class font weight`);
+      }
+    }
+
+    assert.deepEqual(violations, []);
+  });
+});


### PR DESCRIPTION
Copy hierarchy now uses foreground and muted colors throughout the dashboard and API reference. Medium font weight is reserved for page titles; all other interface copy renders at normal weight.

## Goals

- Use foreground and muted colors for copy emphasis across shared UI and feature screens.
- Reserve medium weight for page-level titles.
- Apply the same rule to the embedded API reference.
- Prevent future font-weight regressions with a source policy test.

## Non-goals

- Change type sizes, spacing, font families, or content.
- Redesign status, link, or destructive color semantics.

## Why

A single typography rule keeps hierarchy consistent across reusable primitives and feature-owned screens. Centralizing the invariant in a repository test also protects it when shared components are refreshed.

## Verification

- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npx vitest run src/typography-policy.test.ts`

## Risk surface

Visual-only typography changes across dashboard primitives, project/auth/billing/provider screens, configuration syntax highlighting, and the embedded API reference. No data flow, persistence, or server behavior changes.