### PR TITLE
Email organization invitations when delivery is configured

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,3 +47,7 @@ DISCORD_BOT_TOKEN=
 # without STRIPE_WEBHOOK_SECRET fails startup, since the webhook signature could not be verified.
 STRIPE_SECRET_KEY=
 STRIPE_WEBHOOK_SECRET=
+# Optional invitation email delivery. Both are required together; the sender must be verified
+# for the configured Resend account. Leave these unset to keep the copy-link invitation flow.
+RESEND_API_KEY=
+RESEND_FROM=

--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ Hub generates and stores its authentication secret in the database. Advanced dep
 
 Billing is optional: leave `STRIPE_SECRET_KEY` unset and Hub runs with no billing surface at all. See [docs/billing.md](docs/billing.md).
 
+Invitation email is optional too: set `RESEND_API_KEY` and `RESEND_FROM` to email organization
+invites through Resend. Without them, managers can still copy and share invitation links.
+
 Then start Hub and PostgreSQL:
 
 ```sh

--- a/src/auth/organization-access.ts
+++ b/src/auth/organization-access.ts
@@ -39,6 +39,7 @@ import {
 import { EntitlementDenied } from "../entitlements/catalog.js";
 import { entitlementDenialResponse } from "../entitlements/denial.js";
 import type { EntitlementsService } from "../entitlements/service.js";
+import type { InvitationMailer } from "../invitations/index.js";
 
 const INVITATION_LIFETIME_HOURS = 48;
 
@@ -104,6 +105,8 @@ interface OrganizationAccessOptions {
    * accept, remove). The composition root wires billing's seat-quantity reporter here; undefined
    * self-hosted. Never blocks or fails the member action. */
   onMembershipChanged?: (organizationId: string) => Promise<void>;
+  /** Optional post-commit invitation delivery. Never rolls back or fails a created invitation. */
+  invitationMailer?: InvitationMailer;
 }
 
 interface MembershipRow extends QueryRow {
@@ -543,7 +546,25 @@ export class OrganizationAccess {
       return pending;
     });
     await this.notifyMembershipChanged(access.organization.id);
-    return Response.json(managerInvitationSummary(invitation, this.options.baseURL), {
+    const summary = managerInvitationSummary(invitation, this.options.baseURL);
+    await this.options.invitationMailer
+      ?.send({
+        id: invitation.id,
+        email: invitation.email,
+        inviterName: session.name,
+        organizationName: access.organization.name,
+        role: summary.role,
+        link: summary.link,
+        expiresAt: invitation.expires_at,
+      })
+      .catch((error: unknown) => {
+        reportFailure(error, {
+          operation: "auth.invitation.deliver",
+          component: "invitations",
+          organizationId: access.organization.id,
+        });
+      });
+    return Response.json(summary, {
       status: 201,
     });
   }

--- a/src/auth/server.integration.test.ts
+++ b/src/auth/server.integration.test.ts
@@ -19,6 +19,7 @@ import {
 } from "./organization-contract.js";
 import { createAuthServer, type AuthServer } from "./server.js";
 import { composeEntitlements, type ComposedEntitlements } from "./entitlements.js";
+import type { InvitationEmail, InvitationMailer } from "../invitations/index.js";
 
 type ActiveState = ActiveAccountState;
 
@@ -134,6 +135,28 @@ describe("account and organization boundary", () => {
       replacement.id,
     ]);
     assert.equal(await hub.pendingInvitationCount(organizationId, bob.email), 1);
+  });
+
+  it("delivers a committed invitation through the configured mailer", async () => {
+    const mailer = new RecordingInvitationMailer();
+    const hub = await startAccounts(postgres, mailer);
+    const alice = await hub.signUp("Alice", "alice@example.com");
+    await alice.createOrganization("Acme");
+
+    const invitation = await alice.invite("bob@example.com", "admin");
+
+    const sent = mailer.sent[0];
+    assert.ok(sent !== undefined);
+    assert.deepEqual(sent, {
+      id: invitation.id,
+      email: "bob@example.com",
+      inviterName: "Alice",
+      organizationName: "Acme",
+      role: "admin",
+      link: invitation.link,
+      expiresAt: sent.expiresAt,
+    });
+    assert.ok(sent.expiresAt.getTime() > Date.now());
   });
 
   it("does not create pending invitations for current members", async () => {
@@ -344,8 +367,11 @@ const MISSING_RESOURCES = ["missing", "missing", "missing"] as const;
 
 const activeAccounts: PaseoAccounts[] = [];
 
-async function startAccounts(postgres: StartedPostgreSqlContainer): Promise<PaseoAccounts> {
-  const accounts = await PaseoAccounts.start(postgres);
+async function startAccounts(
+  postgres: StartedPostgreSqlContainer,
+  invitationMailer?: InvitationMailer,
+): Promise<PaseoAccounts> {
+  const accounts = await PaseoAccounts.start(postgres, invitationMailer);
   activeAccounts.push(accounts);
   return accounts;
 }
@@ -366,7 +392,10 @@ class PaseoAccounts {
     this.resources = new OrganizationResources(database);
   }
 
-  static async start(postgres: StartedPostgreSqlContainer): Promise<PaseoAccounts> {
+  static async start(
+    postgres: StartedPostgreSqlContainer,
+    invitationMailer?: InvitationMailer,
+  ): Promise<PaseoAccounts> {
     const url = isolatedDatabaseUrl(postgres);
     const database = await createDatabase(url);
     const entitlements = composeEntitlements(database, testDatabaseRuntime(database));
@@ -381,6 +410,7 @@ class PaseoAccounts {
         secret: "phase-one-auth-secret-at-least-32-characters",
         baseURL: "http://localhost:3000",
         policy: { registrationMode: "open", organizationCreation: "open", bootstrap: undefined },
+        ...(invitationMailer === undefined ? {} : { invitationMailer }),
       }),
     );
   }
@@ -643,6 +673,15 @@ class PaseoAccounts {
     } finally {
       await client.close();
     }
+  }
+}
+
+class RecordingInvitationMailer implements InvitationMailer {
+  readonly sent: InvitationEmail[] = [];
+
+  send(invitation: InvitationEmail): Promise<void> {
+    this.sent.push(invitation);
+    return Promise.resolve();
   }
 }
 

--- a/src/auth/server.ts
+++ b/src/auth/server.ts
@@ -37,6 +37,7 @@ import {
 } from "../organizations/provisioning.js";
 import { InstanceAppOnboarding } from "../instance-setup/app-onboarding.js";
 import { TRUSTED_REQUEST_ORIGIN_HEADER } from "../http/request-origin.js";
+import type { InvitationMailer } from "../invitations/index.js";
 
 export interface AuthServer {
   handle(request: Request): Promise<Response>;
@@ -84,6 +85,8 @@ interface AuthServerOptions {
   /** Post-commit hook fired when a membership change alters an organization's seat count. The
    * composition root wires billing's seat-quantity reporter here; undefined self-hosted. */
   onMembershipChanged?: (organizationId: string) => Promise<void>;
+  /** Optional post-commit delivery for organization invitations. */
+  invitationMailer?: InvitationMailer;
 }
 
 const sessionSchema = z.object({
@@ -203,6 +206,9 @@ export function createAuthServer(options: AuthServerOptions): AuthServer {
     ...(options.onMembershipChanged === undefined
       ? {}
       : { onMembershipChanged: options.onMembershipChanged }),
+    ...(options.invitationMailer === undefined
+      ? {}
+      : { invitationMailer: options.invitationMailer }),
   });
   const browserOrigin = new URL(options.baseURL).origin;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,7 @@ import {
 } from "./provider-applications/index.js";
 import { createSlackSocketInstallationVerifier } from "./providers/slack/installation.js";
 import { resolveHubDataDirectory } from "./data-directory.js";
+import { composeInvitationMailer } from "./invitations/index.js";
 
 export function startProductionRuntime(): Promise<ApplicationRuntime> {
   return startApplication(createProductionRuntime);
@@ -76,6 +77,7 @@ async function createProductionRuntime(): Promise<ApplicationRuntime> {
     const entitlements = composeEntitlements(database, runtime);
     resources.own(() => entitlements.close());
     const billingConfig = readBillingConfig();
+    const invitationMailer = composeInvitationMailer();
     const billing =
       billingConfig === undefined
         ? null
@@ -103,6 +105,7 @@ async function createProductionRuntime(): Promise<ApplicationRuntime> {
       identity,
       config.trustedClientIpHeader,
       billing,
+      invitationMailer,
     );
     resources.own(() => auth.close());
     await auth.initialize?.();
@@ -178,6 +181,7 @@ function createProductionAuthServer(
   identity: HubIdentity,
   trustedClientIpHeader: string | undefined,
   billing: BillingRuntime | null,
+  invitationMailer: ReturnType<typeof composeInvitationMailer>,
 ) {
   return createAuthServer({
     database,
@@ -187,6 +191,7 @@ function createProductionAuthServer(
     baseURL: identity.appUrl,
     policy: authPolicy,
     ...(trustedClientIpHeader === undefined ? {} : { trustedClientIpHeader }),
+    ...(invitationMailer === undefined ? {} : { invitationMailer }),
     // Hosted: new organizations start on the Free plan from the catalog mirror. Self-hosted
     // (billing null) keeps the createAuthServer default, which stamps unlimited.
     ...(billing === null

--- a/src/invitations/index.ts
+++ b/src/invitations/index.ts
@@ -1,0 +1,26 @@
+import { createResendInvitationMailer, readResendConfig } from "./internal/resend.js";
+
+export interface InvitationEmail {
+  id: string;
+  email: string;
+  inviterName: string;
+  organizationName: string;
+  role: "admin" | "member";
+  link: string;
+  expiresAt: Date;
+}
+
+export interface InvitationMailer {
+  send(invitation: InvitationEmail): Promise<void>;
+}
+
+/**
+ * Invitation email is optional. An absent key leaves the existing copy-link workflow intact;
+ * a present key must be accompanied by an explicit, verified sender.
+ */
+export function composeInvitationMailer(
+  environment: Record<string, string | undefined> = process.env,
+): InvitationMailer | undefined {
+  const config = readResendConfig(environment);
+  return config === undefined ? undefined : createResendInvitationMailer(config);
+}

--- a/src/invitations/internal/resend.test.ts
+++ b/src/invitations/internal/resend.test.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import { describe, it } from "vitest";
+import { z } from "zod";
+import { createResendInvitationMailer, readResendConfig } from "./resend.js";
+
+describe("optional Resend invitation delivery", () => {
+  it("is absent when RESEND_API_KEY is absent or blank", () => {
+    assert.equal(readResendConfig({}), undefined);
+    assert.equal(readResendConfig({ RESEND_API_KEY: "   " }), undefined);
+  });
+
+  it("requires a valid key and explicit sender when enabled", () => {
+    assert.throws(
+      () => readResendConfig({ RESEND_API_KEY: "not-a-key", RESEND_FROM: "invites@example.com" }),
+      /RESEND_API_KEY is invalid/,
+    );
+    assert.throws(
+      () => readResendConfig({ RESEND_API_KEY: "re_test_abc123" }),
+      /RESEND_FROM is required/,
+    );
+    assert.deepEqual(
+      readResendConfig({
+        RESEND_API_KEY: " re_test_abc123 ",
+        RESEND_FROM: " Paseo <invites@example.com> ",
+      }),
+      { apiKey: "re_test_abc123", from: "Paseo <invites@example.com>" },
+    );
+  });
+
+  it("sends an escaped text and HTML invitation through Resend", async () => {
+    let request: { input: string; init: RequestInit } | undefined;
+    const mailer = createResendInvitationMailer(
+      { apiKey: "re_test_abc123", from: "Paseo <invites@example.com>" },
+      (input, init = {}) => {
+        let inputUrl: string;
+        if (typeof input === "string") inputUrl = input;
+        else if (input instanceof URL) inputUrl = input.toString();
+        else inputUrl = input.url;
+        request = { input: inputUrl, init };
+        return Promise.resolve(new Response(JSON.stringify({ id: "email-1" }), { status: 200 }));
+      },
+    );
+
+    await mailer.send({
+      id: "invite-1",
+      email: "person@example.com",
+      inviterName: "Alice & Bob",
+      organizationName: "Acme <Labs>",
+      role: "admin",
+      link: "https://hub.example/?invitation=one&next=two",
+      expiresAt: new Date("2026-08-31T12:00:00.000Z"),
+    });
+
+    assert.ok(request !== undefined);
+    assert.equal(request.input, "https://api.resend.com/emails");
+    assert.equal(request.init.method, "POST");
+    assert.deepEqual(request.init.headers, {
+      Authorization: "Bearer re_test_abc123",
+      "Content-Type": "application/json",
+      "Idempotency-Key": "paseo-invitation-invite-1",
+    });
+    const bodyText = request.init.body;
+    assert.ok(typeof bodyText === "string");
+    const body = z
+      .object({ subject: z.string(), text: z.string(), html: z.string() })
+      .parse(JSON.parse(bodyText));
+    assert.equal(body.subject, "Join Acme <Labs> on Paseo");
+    assert.match(body.text, /Alice & Bob invited you/);
+    assert.match(body.html, /Alice &amp; Bob/);
+    assert.match(body.html, /Acme &lt;Labs&gt;/);
+    assert.match(body.html, /invitation=one&amp;next=two/);
+  });
+
+  it("rejects unsuccessful Resend responses without exposing the response body", async () => {
+    const mailer = createResendInvitationMailer(
+      { apiKey: "re_test_abc123", from: "invites@example.com" },
+      () => Promise.resolve(new Response("secret provider detail", { status: 422 })),
+    );
+
+    await assert.rejects(
+      () =>
+        mailer.send({
+          id: "invite-1",
+          email: "person@example.com",
+          inviterName: "Alice",
+          organizationName: "Acme",
+          role: "member",
+          link: "https://hub.example/?invitation=one",
+          expiresAt: new Date("2026-08-31T12:00:00.000Z"),
+        }),
+      /^Error: Resend rejected invitation email with status 422$/,
+    );
+  });
+});

--- a/src/invitations/internal/resend.ts
+++ b/src/invitations/internal/resend.ts
@@ -1,0 +1,84 @@
+import { z } from "zod";
+import type { InvitationEmail, InvitationMailer } from "../index.js";
+
+const RESEND_EMAILS_URL = "https://api.resend.com/emails";
+const DELIVERY_TIMEOUT_MS = 10_000;
+
+export interface ResendConfig {
+  apiKey: string;
+  from: string;
+}
+
+type SendRequest = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
+const apiKeySchema = z
+  .string()
+  .trim()
+  .min(1, "RESEND_API_KEY must not be blank")
+  .refine((value) => value.startsWith("re_"), 'RESEND_API_KEY must start with "re_"');
+
+const senderSchema = z.string().trim().min(1, "RESEND_FROM must not be blank");
+
+export function readResendConfig(
+  environment: Record<string, string | undefined>,
+): ResendConfig | undefined {
+  const rawKey = environment["RESEND_API_KEY"];
+  if (rawKey === undefined || rawKey.trim().length === 0) return undefined;
+  const key = apiKeySchema.safeParse(rawKey);
+  if (!key.success) {
+    throw new Error(`RESEND_API_KEY is invalid: ${key.error.issues[0]?.message}`);
+  }
+  const rawFrom = environment["RESEND_FROM"];
+  if (rawFrom === undefined || rawFrom.trim().length === 0) {
+    throw new Error("RESEND_FROM is required when RESEND_API_KEY is set");
+  }
+  const from = senderSchema.parse(rawFrom);
+  return { apiKey: key.data, from };
+}
+
+export function createResendInvitationMailer(
+  config: ResendConfig,
+  sendRequest: SendRequest = fetch,
+): InvitationMailer {
+  return {
+    async send(invitation) {
+      const response = await sendRequest(RESEND_EMAILS_URL, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${config.apiKey}`,
+          "Content-Type": "application/json",
+          "Idempotency-Key": `paseo-invitation-${invitation.id}`,
+        },
+        body: JSON.stringify(message(config.from, invitation)),
+        signal: AbortSignal.timeout(DELIVERY_TIMEOUT_MS),
+      });
+      if (!response.ok) {
+        throw new Error(`Resend rejected invitation email with status ${response.status}`);
+      }
+    },
+  };
+}
+
+function message(from: string, invitation: InvitationEmail) {
+  const role = invitation.role === "admin" ? "an admin" : "a member";
+  const introduction = `${invitation.inviterName} invited you to join ${invitation.organizationName} as ${role}.`;
+  const expiry = `This invitation expires at ${invitation.expiresAt.toISOString()}.`;
+  const organizationName = escapeHtml(invitation.organizationName);
+  const invitationLink = escapeHtml(invitation.link);
+  return {
+    from,
+    to: [invitation.email],
+    subject: `Join ${invitation.organizationName} on Paseo`,
+    text: `${introduction}\n\nAccept the invitation: ${invitation.link}\n\n${expiry}`,
+    html: `<p>${escapeHtml(introduction)}</p><p><a href="${invitationLink}">Join ${organizationName}</a></p><p>${escapeHtml(expiry)}</p>`,
+  };
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}


### PR DESCRIPTION
Configured Hub instances now email organization invitations automatically. Instances without email delivery configuration keep the existing copy-and-share link workflow.

## Goals

- Deliver committed organization invitations by email when both delivery credentials are configured.
- Keep invitation creation, entitlement enforcement, and copyable links unchanged.
- Treat delivery as post-commit and best-effort so an upstream outage cannot erase a valid invitation.
- Validate partial or invalid delivery configuration at startup.

## Non-goals

- Replace the existing invitation storage or acceptance flow.
- Add email delivery to other product workflows.
- Add a resend action for pending invitations.

## Why

Invitation links already exist and remain the durable capability. Optional delivery removes the manual copy-and-share step for configured deployments without making self-hosted instances depend on an external mail service.

## Verification

- Full typecheck
- Lint and formatting checks
- Production build
- Migration drift check
- Invitation delivery unit tests
- Auth invitation integration suite
- Representative logging and workflow suites

## Risk surface

The change adds one outbound HTTP request after invitation commit. Requests have a 10-second timeout and invitation-scoped idempotency key; provider failures are reported but do not fail or roll back invitation creation.