### PR TITLE
Complete the single-run trigger contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ the names and nesting exactly; the selected Paseo provider validates and applies
 agent:
   provider: codex
   model: gpt-5.5
+  mode: full-access
   thinkingOptionId: high
   options:
     sandbox_workspace_write:
@@ -127,12 +128,12 @@ agent:
       network_access: false
 ```
 
-Options are specific to the selected provider and are not portable. Omit `mode` to inherit the
-provider or daemon default. Tool preapproval is not configurable in Hub YAML: Hub grants only the
-execution-scoped MCP tools it materializes (`finish_execution`, plus an allowed output tool such as
-`reply`). Provider or machine policy still controls every unrelated tool. A read-only provider
-configuration is defense in depth; Hub output authorization remains enforced by the execution MCP
-server.
+Options and modes are specific to the selected provider and are not portable. New triggers require
+an explicit `mode`; `thinkingOptionId` may be omitted to use the provider default. Hub always grants
+the execution-scoped `finish_execution` tool. Conversational triggers also receive an unlimited
+event-native `reply` tool for progress and final responses. Provider or machine policy still
+controls every unrelated tool. A read-only provider configuration is defense in depth; Hub output
+authorization remains enforced by the execution MCP server.
 
 ## Public API
 

--- a/docs/trigger-migration.md
+++ b/docs/trigger-migration.md
@@ -47,6 +47,12 @@ The simple editor writes `from_users: ["*"]` when “Allowed users” is left at
 wildcard is an explicit allow-everyone policy for Slack, Discord, and GitHub; an absent or empty
 allowlist still fails closed.
 
+New single-run triggers require an absolute daemon working directory and an explicit agent mode.
+Existing migrated YAML keeps its authored provider defaults until it is edited. Legacy output
+grants and limits remain enforceable, but newly-authored conversational triggers automatically
+receive an unlimited provider-native `hub.reply`; `hub.finish_execution` remains available to every
+execution. GitHub replies are posted to the issue or pull request that originated the event.
+
 ## CLI deployment tradeoffs
 
 The new CLI reads sorted direct children of `.paseo/triggers/` and upserts each by YAML name. It

--- a/e2e/helpers/triggers.ts
+++ b/e2e/helpers/triggers.ts
@@ -41,7 +41,7 @@ export class OrganizationTriggers {
   }) {
     await this.page.getByLabel("Trigger name").fill(input.name);
     await this.page.getByLabel("When this happens").selectOption("slack.mention");
-    await this.page.getByLabel("Connection").selectOption(input.connection);
+    await this.page.getByLabel("Connection", { exact: true }).selectOption(input.connection);
     await this.page.getByRole("button", { name: "Specific people" }).click();
     await this.page.getByLabel("User IDs").fill(input.users);
     await this.page.getByLabel("Run on daemon").selectOption(input.daemon);

--- a/e2e/helpers/triggers.ts
+++ b/e2e/helpers/triggers.ts
@@ -47,7 +47,7 @@ export class OrganizationTriggers {
     await this.page.getByLabel("Run on daemon").selectOption(input.daemon);
     await this.page.getByLabel("Working directory").fill(input.cwd);
     await this.page.getByLabel("Agent ID", { exact: true }).fill(input.agent);
-    await this.page.getByLabel("Execution mode (optional)").fill(input.mode);
+    await this.page.getByLabel("Execution mode", { exact: true }).fill(input.mode);
     await this.page
       .locator("summary")
       .filter({ hasText: "Advanced provider options (JSON)" })
@@ -107,7 +107,7 @@ export class OrganizationTriggers {
     prompt: string;
   }) {
     await expect(this.page.getByLabel("Agent ID", { exact: true })).toHaveValue(input.agent);
-    await expect(this.page.getByLabel("Execution mode (optional)")).toHaveValue(input.mode);
+    await expect(this.page.getByLabel("Execution mode", { exact: true })).toHaveValue(input.mode);
     await this.page
       .locator("summary")
       .filter({ hasText: "Advanced provider options (JSON)" })

--- a/src/config/compiler.ts
+++ b/src/config/compiler.ts
@@ -246,7 +246,7 @@ export interface CompiledStep {
   github?: CompiledGitHubAuthority | undefined;
   condition?: Expression | undefined;
   output?: { schema: JsonValue } | undefined;
-  allowOutputs: readonly { type: string; max: number; required: boolean }[];
+  allowOutputs: readonly { type: string; max?: number | undefined; required: boolean }[];
   autoArchive: boolean;
 }
 
@@ -397,7 +397,7 @@ const CompiledStepSchema: z.ZodType<CompiledStep> = z
       z
         .object({
           type: z.string().regex(EVENT_NAME),
-          max: z.number().int().positive(),
+          max: z.number().int().positive().optional(),
           required: z.boolean().default(false),
         })
         .strict(),

--- a/src/db/memory.ts
+++ b/src/db/memory.ts
@@ -1716,13 +1716,13 @@ class MemoryDatabase implements Database {
   async beginAgentExecutionOutput(
     executionId: string,
     outputType: string,
-    maxOutputs: number,
+    maxOutputs: number | undefined,
     startedAt: Date,
   ): Promise<AgentExecutionOutputAttempt | undefined> {
     const execution = this.agentExecutions.get(executionId);
     if (
       execution === undefined ||
-      maxOutputs < 1 ||
+      (maxOutputs !== undefined && maxOutputs < 1) ||
       (execution.status !== "spawning" && execution.status !== "running")
     ) {
       return undefined;
@@ -1733,7 +1733,10 @@ class MemoryDatabase implements Database {
         attempt.status === "pending" &&
         attempt.leaseExpiresAt > startedAt,
     ).length;
-    if ((execution.outputEmissions[outputType] ?? 0) + activeAttempts >= maxOutputs) {
+    if (
+      maxOutputs !== undefined &&
+      (execution.outputEmissions[outputType] ?? 0) + activeAttempts >= maxOutputs
+    ) {
       return undefined;
     }
     const attempt: AgentExecutionOutputAttempt = {

--- a/src/db/pg.ts
+++ b/src/db/pg.ts
@@ -2004,7 +2004,7 @@ class PgDatabase implements Database {
   async beginAgentExecutionOutput(
     executionId: string,
     outputType: string,
-    maxOutputs: number,
+    maxOutputs: number | undefined,
     startedAt: Date,
   ): Promise<AgentExecutionOutputAttempt | undefined> {
     try {
@@ -2025,9 +2025,10 @@ class PgDatabase implements Database {
             attempt.leaseExpiresAt > startedAt,
         ).length;
         if (
-          maxOutputs < 1 ||
+          (maxOutputs !== undefined && maxOutputs < 1) ||
           (execution.status !== "spawning" && execution.status !== "running") ||
-          (execution.outputEmissions[outputType] ?? 0) + activeAttempts >= maxOutputs
+          (maxOutputs !== undefined &&
+            (execution.outputEmissions[outputType] ?? 0) + activeAttempts >= maxOutputs)
         ) {
           return undefined;
         }

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -1322,7 +1322,7 @@ export interface Database {
   beginAgentExecutionOutput(
     executionId: string,
     outputType: string,
-    maxOutputs: number,
+    maxOutputs: number | undefined,
     startedAt: Date,
   ): Promise<AgentExecutionOutputAttempt | undefined>;
   completeAgentExecutionOutput(

--- a/src/execution-capabilities/outputs.ts
+++ b/src/execution-capabilities/outputs.ts
@@ -3,7 +3,8 @@ import { compileFinishExecutionArguments } from "../workflows/json-schema.js";
 
 export interface AllowedOutput {
   type: string;
-  max: number;
+  /** Absent for the event-native reply capability exposed by single-run triggers. */
+  max?: number | undefined;
   required?: boolean;
 }
 
@@ -161,7 +162,10 @@ export function executionToolDefinitions(
     },
     ...materializedOutputs.map(({ declaration, capability }) => ({
       name: capability.tool.name,
-      description: `${capability.tool.description} (up to ${declaration.max} times).`,
+      description:
+        declaration.max === undefined
+          ? capability.tool.description
+          : `${capability.tool.description} (up to ${String(declaration.max)} times).`,
       inputSchema: capability.tool.inputSchema,
     })),
   ];

--- a/src/execution-capabilities/server.test.ts
+++ b/src/execution-capabilities/server.test.ts
@@ -168,6 +168,24 @@ describe("execution capability MCP boundary", () => {
     }
   });
 
+  it("allows an event-native reply to be sent repeatedly without a synthetic cap", async () => {
+    const fixture = await capabilityFixture(undefined, "succeeded", null);
+
+    for (const content of ["Starting.", "Still working.", "Done."]) {
+      const response = await fixture.call("tools/call", {
+        name: "reply",
+        arguments: { content },
+      });
+      assert.equal(ToolResultSchema.parse(response.result).isError, undefined);
+    }
+
+    assert.equal(fixture.outbound.length, 3);
+    assert.deepEqual(
+      (await fixture.database.findAgentExecutionById(fixture.executionId))?.outputEmissions,
+      { "slack.reply": 3 },
+    );
+  });
+
   it("renders the structured execution MCP contract exposed by the server", async () => {
     const fixture = await capabilityFixture(undefined, "succeeded", 1, {
       type: "object",
@@ -712,7 +730,7 @@ const slackOutputContext = {
 async function capabilityFixture(
   execute: (() => Promise<void>) | undefined = () => Promise.resolve(),
   completionStatus: "succeeded" | "failed" = "succeeded",
-  maxReplies = 1,
+  maxReplies: number | null = 1,
   outputSchema?: JsonValue,
   autoArchive = false,
   requiredOutputTypes: readonly string[] = [],
@@ -861,7 +879,7 @@ async function abortHttpRequestAfterFirstResponseData(options: {
 }
 
 function launchIntent(
-  maxReplies = 1,
+  maxReplies: number | null = 1,
   outputSchema?: JsonValue,
   autoArchive = false,
   requiredOutputTypes: readonly string[] = [],
@@ -884,7 +902,7 @@ function launchIntent(
     allowOutputs: [
       {
         type: "slack.reply",
-        max: maxReplies,
+        ...(maxReplies === null ? {} : { max: maxReplies }),
         ...(requiredOutputTypes.includes("slack.reply") ? { required: true } : {}),
       },
       ...requiredOutputTypes

--- a/src/providers/github/index.ts
+++ b/src/providers/github/index.ts
@@ -36,6 +36,8 @@ import type { GitHubConfigurationProvider } from "../../configuration/github-syn
 import { createGitHubConfigurationProvider } from "./configuration.js";
 import type { ConnectionResolutionContext } from "../../config/connections.js";
 import type { ProjectConfigurationStore } from "../../configuration/store.js";
+import { replyOutputTool } from "../../execution-capabilities/outputs.js";
+import { createGitHubReplyExecutor, githubReplyAvailable } from "../../triggers/github/reply.js";
 
 export interface GitHubRegistrationConfiguration {
   appId: string;
@@ -228,7 +230,26 @@ export function createGitHubRegistration(
       },
     ],
     sources: [webhook],
-    outputs: [],
+    outputs: [
+      {
+        type: "github.reply",
+        tool: replyOutputTool,
+        available: githubReplyAvailable,
+        execute: createGitHubReplyExecutor({
+          client: {
+            async createIssueComment(input) {
+              const octokit = await appAuth.createInstallationOctokit(input.installationId);
+              await octokit.request("POST /repos/{owner}/{repo}/issues/{issue_number}/comments", {
+                owner: input.owner,
+                repo: input.repo,
+                issue_number: input.issueNumber,
+                body: input.body,
+              });
+            },
+          },
+        }),
+      },
+    ],
     requests: [{ name: "webhook", handle: (request) => webhook.handle(request) }],
     githubConfiguration,
   };

--- a/src/providers/github/registration.test.ts
+++ b/src/providers/github/registration.test.ts
@@ -177,7 +177,7 @@ describe("GitHub registration", () => {
     assert.equal(registration.triggerProviders.length, 1);
     assert.deepEqual(
       registration.outputs.map((output) => output.type),
-      [],
+      ["github.reply"],
     );
     assert.deepEqual(
       registration.requests.map((request) => request.name),
@@ -430,7 +430,10 @@ describe("GitHub registration", () => {
 
     assert.equal(registration.sources.length, 1);
     assert.equal(registration.triggerProviders.length, 1);
-    assert.equal(registration.outputs.length, 0);
+    assert.deepEqual(
+      registration.outputs.map((output) => output.type),
+      ["github.reply"],
+    );
     assert.deepEqual(registration.connection.actions, {});
   });
 

--- a/src/public-operations/database-adapter.test.ts
+++ b/src/public-operations/database-adapter.test.ts
@@ -63,7 +63,7 @@ on:
   manual.run: {}
 run:
   target: { daemon: daemon-10000000, cwd: /workspace }
-  agent: { provider: test }
+  agent: { provider: test, mode: full-access }
   prompt: Handle it
 `;
 }

--- a/src/triggers/configuration/editor.test.ts
+++ b/src/triggers/configuration/editor.test.ts
@@ -150,7 +150,14 @@ describe("trigger form YAML bridge", () => {
       cwd: "/workspace",
       agent: "codex/gpt-5.4",
       mode: "full-access",
+      thinkingOptionId: "",
       providerOptions: "",
+      maxRuntime: "2h",
+      idleTimeout: "10m",
+      githubConnection: "",
+      githubRepositories: "",
+      githubPermissions: "",
+      githubDuration: "1h",
       prompt: "Handle it.",
     });
     expect(parseDocument(yaml).toJS()).toEqual({
@@ -160,6 +167,8 @@ describe("trigger form YAML bridge", () => {
       run: {
         target: { daemon: "office", cwd: "/workspace" },
         agent: { provider: "codex", model: "gpt-5.4", mode: "full-access" },
+        max_runtime: "2h",
+        idle_timeout: "10m",
         prompt: "Handle it.",
       },
     });
@@ -175,8 +184,15 @@ describe("trigger form YAML bridge", () => {
       daemon: "office",
       cwd: "/workspace",
       agent: "opencode",
-      mode: "",
+      mode: "full-access",
+      thinkingOptionId: "",
       providerOptions: "",
+      maxRuntime: "2h",
+      idleTimeout: "10m",
+      githubConnection: "",
+      githubRepositories: "",
+      githubPermissions: "",
+      githubDuration: "1h",
       prompt: "${{ paseo.prompt }}",
     });
     const projection = projectTriggerForm(initial);

--- a/src/triggers/configuration/editor.ts
+++ b/src/triggers/configuration/editor.ts
@@ -26,7 +26,14 @@ export interface TriggerFormValue {
   cwd: string;
   agent: string;
   mode: string;
+  thinkingOptionId: string;
   providerOptions: string;
+  maxRuntime: string;
+  idleTimeout: string;
+  githubConnection: string;
+  githubRepositories: string;
+  githubPermissions: string;
+  githubDuration: string;
   prompt: string;
 }
 
@@ -35,6 +42,7 @@ export type TriggerFormProjection =
   | { status: "yaml_only"; reason: string };
 
 const ProviderOptionsSchema = z.record(z.string(), z.unknown());
+const GitHubPermissionsSchema = z.record(z.string(), z.enum(["read", "write", "admin"]));
 
 export function projectTriggerForm(yaml: string): TriggerFormProjection {
   const parsed = parseEditorDocument(yaml);
@@ -54,19 +62,38 @@ export function projectTriggerForm(yaml: string): TriggerFormProjection {
   const agent = trigger.run.agent;
   return {
     status: "editable",
-    value: {
-      name: trigger.name,
-      enabled: trigger.enabled,
-      event,
-      connection: definition.connection ?? "",
-      allowedUsers: definition.filters?.from_users?.join(", ") ?? "*",
-      daemon: trigger.run.target.daemon,
-      cwd: trigger.run.target.cwd,
-      agent: joinAgentId(agent.provider, agent.model),
-      mode: agent.mode ?? "",
-      providerOptions: agent.options === undefined ? "" : JSON.stringify(agent.options, null, 2),
-      prompt: trigger.run.prompt,
-    },
+    value: toFormValue(trigger, event, definition, agent),
+  };
+}
+
+function toFormValue(
+  trigger: TriggerDocument,
+  event: EditorEvent,
+  definition: TriggerDocument["on"][string],
+  agent: Extract<TriggerDocument["run"]["agent"], { provider: string }>,
+): TriggerFormValue {
+  return {
+    name: trigger.name,
+    enabled: trigger.enabled,
+    event,
+    connection: definition.connection ?? "",
+    allowedUsers: definition.filters?.from_users?.join(", ") ?? "*",
+    daemon: trigger.run.target.daemon,
+    cwd: trigger.run.target.cwd,
+    agent: joinAgentId(agent.provider, agent.model),
+    mode: agent.mode ?? "",
+    thinkingOptionId: agent.thinkingOptionId ?? "",
+    providerOptions: agent.options === undefined ? "" : JSON.stringify(agent.options, null, 2),
+    maxRuntime: trigger.run.max_runtime,
+    idleTimeout: trigger.run.idle_timeout,
+    githubConnection: trigger.run.github?.connection ?? "",
+    githubRepositories: trigger.run.github?.repositories?.join(", ") ?? "",
+    githubPermissions:
+      trigger.run.github?.permissions === undefined
+        ? ""
+        : JSON.stringify(trigger.run.github.permissions, null, 2),
+    githubDuration: trigger.run.github?.duration ?? "",
+    prompt: trigger.run.prompt,
   };
 }
 
@@ -75,6 +102,7 @@ export function patchTriggerYaml(yaml: string, value: TriggerFormValue): string 
   const projection = projectTriggerForm(yaml);
   if (projection.status !== "editable") throw new Error(projection.reason);
   if (sameFormValue(projection.value, value)) return yaml;
+  validateFormValue(value);
 
   const document = parseDocument(yaml);
   assertDocument(document);
@@ -100,8 +128,16 @@ export function patchTriggerYaml(yaml: string, value: TriggerFormValue): string 
   const agent = splitAgentId(value.agent);
   setIfChanged(document, ["run", "agent", "provider"], agent.provider);
   setOptional(document, ["run", "agent", "model"], agent.model);
-  setOptional(document, ["run", "agent", "mode"], blankToUndefined(value.mode));
+  setIfChanged(document, ["run", "agent", "mode"], value.mode.trim());
+  setOptional(
+    document,
+    ["run", "agent", "thinkingOptionId"],
+    blankToUndefined(value.thinkingOptionId),
+  );
   setOptional(document, ["run", "agent", "options"], parseProviderOptions(value.providerOptions));
+  setIfChanged(document, ["run", "max_runtime"], value.maxRuntime.trim());
+  setIfChanged(document, ["run", "idle_timeout"], value.idleTimeout.trim());
+  setOptional(document, ["run", "github"], githubAuthority(value));
   setIfChanged(document, ["run", "prompt"], value.prompt);
   return document.toString({ lineWidth: 0 });
 }
@@ -114,9 +150,10 @@ export function mergeTriggerForm(yaml: string, value: TriggerFormValue): string 
 }
 
 export function createTriggerYaml(value: TriggerFormValue): string {
+  validateFormValue(value);
   const agent = splitAgentId(value.agent);
-  const mode = blankToUndefined(value.mode);
   const providerOptions = parseProviderOptions(value.providerOptions);
+  const github = githubAuthority(value);
   const definition =
     value.event === "manual.run"
       ? {}
@@ -131,14 +168,49 @@ export function createTriggerYaml(value: TriggerFormValue): string {
         agent: {
           provider: agent.provider,
           ...(agent.model === undefined ? {} : { model: agent.model }),
-          ...(mode === undefined ? {} : { mode }),
+          mode: value.mode.trim(),
+          ...(blankToUndefined(value.thinkingOptionId) === undefined
+            ? {}
+            : { thinkingOptionId: value.thinkingOptionId.trim() }),
           ...(providerOptions === undefined ? {} : { options: providerOptions }),
         },
+        max_runtime: value.maxRuntime.trim(),
+        idle_timeout: value.idleTimeout.trim(),
+        ...(github === undefined ? {} : { github }),
         prompt: value.prompt,
       },
     },
     { lineWidth: 0 },
   );
+}
+
+function githubAuthority(value: TriggerFormValue) {
+  const connection = blankToUndefined(value.githubConnection);
+  if (connection === undefined) return undefined;
+  const repositories = commaSeparated(value.githubRepositories);
+  const permissions = parsePermissions(value.githubPermissions);
+  const duration = blankToUndefined(value.githubDuration);
+  return {
+    connection,
+    ...(repositories.length === 0 ? {} : { repositories }),
+    ...(permissions === undefined ? {} : { permissions }),
+    ...(duration === undefined ? {} : { duration }),
+  };
+}
+
+function parsePermissions(value: string): Record<string, "read" | "write" | "admin"> | undefined {
+  const parsed = parseProviderOptions(value);
+  if (parsed === undefined) return undefined;
+  return GitHubPermissionsSchema.parse(parsed);
+}
+
+function validateFormValue(value: TriggerFormValue): void {
+  if (!value.cwd.trim().startsWith("/")) {
+    throw new Error("Working directory must be an absolute path.");
+  }
+  if (value.mode.trim().length === 0) throw new Error("Execution mode is required.");
+  if (value.maxRuntime.trim().length === 0) throw new Error("Maximum runtime is required.");
+  if (value.idleTimeout.trim().length === 0) throw new Error("Idle timeout is required.");
 }
 
 export function parseProviderOptions(value: string): Record<string, unknown> | undefined {
@@ -209,11 +281,15 @@ function sameFormValue(left: TriggerFormValue, right: TriggerFormValue): boolean
 }
 
 function users(value: string): string[] {
-  const values = value
+  const values = commaSeparated(value);
+  return values.length === 0 ? ["*"] : values;
+}
+
+function commaSeparated(value: string): string[] {
+  return value
     .split(",")
     .map((entry) => entry.trim())
     .filter(Boolean);
-  return values.length === 0 ? ["*"] : values;
 }
 
 function blankToUndefined(value: string): string | undefined {

--- a/src/triggers/configuration/index.test.ts
+++ b/src/triggers/configuration/index.test.ts
@@ -85,6 +85,10 @@ describe("self-contained trigger documents", () => {
     assert.deepEqual(compiled.events[0]?.steps[0]?.allowOutputs, [
       { type: "slack.reply", max: 5, required: false },
     ]);
+    assert.deepEqual(compiled.events[1]?.steps[0]?.allowOutputs, [
+      { type: "slack.reply", max: 5, required: false },
+      { type: "github.reply", required: false },
+    ]);
   });
 
   it("round-trips the semantic document through canonical YAML", () => {
@@ -105,6 +109,25 @@ run:
 `);
 
     assert.deepEqual(compiled.events[0]?.filters?.from_users, ["*"]);
+    assert.deepEqual(compiled.events[0]?.steps[0]?.allowOutputs, []);
+  });
+
+  it("automatically grants an unlimited event-native reply for a new conversational trigger", () => {
+    const compiled = compileTriggerDocument(`
+name: answer
+on:
+  slack.mention:
+    connection: acme-slack
+    filters: { from_users: ["*"] }
+run:
+  target: { daemon: devbox, cwd: /workspace }
+  agent: { provider: codex, mode: full-access }
+  prompt: Handle it
+`);
+
+    assert.deepEqual(compiled.events[0]?.steps[0]?.allowOutputs, [
+      { type: "slack.reply", required: false },
+    ]);
   });
 
   it("rejects a trigger without events at the document boundary", () => {

--- a/src/triggers/configuration/index.ts
+++ b/src/triggers/configuration/index.ts
@@ -99,9 +99,33 @@ export function compileTriggerDocument(yaml: string): CompiledTriggerDocument {
   return {
     authored,
     environment: compiledEnvironment,
-    events: compiled.triggers,
+    events: compiled.triggers.map(withAutomaticReply),
     authoredHash: createHash("sha256").update(yaml).digest("hex"),
   };
+}
+
+function withAutomaticReply(trigger: CompiledTrigger): CompiledTrigger {
+  const replyType = automaticReplyType(trigger.on);
+  if (replyType === undefined) return trigger;
+  return {
+    ...trigger,
+    steps: trigger.steps.map((step) => ({
+      ...step,
+      allowOutputs: step.allowOutputs.some(({ type }) => type === replyType)
+        ? step.allowOutputs
+        : [...step.allowOutputs, { type: replyType, required: false }],
+    })),
+  };
+}
+
+function automaticReplyType(event: string): string | undefined {
+  const provider = event.split(".", 1)[0];
+  return provider === "slack" ||
+    provider === "discord" ||
+    provider === "linear" ||
+    provider === "github"
+    ? `${provider}.reply`
+    : undefined;
 }
 
 function authoredFilters(

--- a/src/triggers/dashboard.test.ts
+++ b/src/triggers/dashboard.test.ts
@@ -74,7 +74,7 @@ on:
   manual.run: {}
 run:
   target: { daemon: ${TEST_DAEMON_SLUG}, cwd: /workspace }
-  agent: { provider: test }
+  agent: { provider: test, mode: full-access }
   prompt: Handle it
 `;
 

--- a/src/triggers/github/reply.test.ts
+++ b/src/triggers/github/reply.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { describe, it, vi } from "vitest";
+import { createGitHubReplyExecutor, githubReplyAvailable } from "./reply.js";
+
+describe("GitHub reply output", () => {
+  it("posts a comment to the originating issue or pull request", async () => {
+    const createIssueComment = vi.fn(() => Promise.resolve());
+    const outputContext = {
+      provider: "github",
+      target: { installationId: 42, repository: "getpaseo/hub" },
+      event: { github: { item: { number: 92 } } },
+    };
+
+    assert.equal(githubReplyAvailable(outputContext), true);
+    await createGitHubReplyExecutor({ client: { createIssueComment } })({
+      agentExecutionId: "execution-1",
+      toolType: "github.reply",
+      args: { content: "Shipped." },
+      outputContext,
+    });
+
+    assert.deepEqual(createIssueComment.mock.calls, [
+      [
+        {
+          installationId: 42,
+          owner: "getpaseo",
+          repo: "hub",
+          issueNumber: 92,
+          body: "Shipped.",
+        },
+      ],
+    ]);
+  });
+
+  it("does not advertise reply when the event has no conversation item", () => {
+    assert.equal(
+      githubReplyAvailable({
+        provider: "github",
+        target: { installationId: 42, repository: "getpaseo/hub" },
+        event: { github: { item: null } },
+      }),
+      false,
+    );
+  });
+});

--- a/src/triggers/github/reply.ts
+++ b/src/triggers/github/reply.ts
@@ -1,0 +1,62 @@
+import { z } from "zod";
+import type { OutputExecutor } from "../../execution-capabilities/outputs.js";
+
+const GitHubReplyArgsSchema = z.object({ content: z.string().min(1) });
+const GitHubReplyOutputContextSchema = z.object({
+  provider: z.literal("github"),
+  target: z.object({
+    installationId: z.number().int().positive(),
+    repository: z.string().min(3),
+  }),
+  event: z.object({
+    github: z.object({
+      item: z.object({ number: z.number().int().positive() }).nullable(),
+    }),
+  }),
+});
+
+export function githubReplyAvailable(outputContext: unknown): boolean {
+  const parsed = GitHubReplyOutputContextSchema.safeParse(outputContext);
+  return parsed.success && parsed.data.event.github.item !== null;
+}
+
+export interface GitHubReplyClient {
+  createIssueComment(input: {
+    installationId: number;
+    owner: string;
+    repo: string;
+    issueNumber: number;
+    body: string;
+  }): Promise<void>;
+}
+
+export function createGitHubReplyExecutor(options: { client: GitHubReplyClient }): OutputExecutor {
+  return async function executeGitHubReply(input) {
+    const args = GitHubReplyArgsSchema.parse(input.args);
+    const context = GitHubReplyOutputContextSchema.parse(input.outputContext);
+    const item = context.event.github.item;
+    if (item === null) throw new Error("GitHub event has no issue or pull request to reply to");
+    const [owner, repo] = splitRepository(context.target.repository);
+    await options.client.createIssueComment({
+      installationId: context.target.installationId,
+      owner,
+      repo,
+      issueNumber: item.number,
+      body: args.content,
+    });
+  };
+}
+
+function splitRepository(fullName: string): [owner: string, repo: string] {
+  const [owner, repo, extra] = fullName.split("/");
+  if (
+    owner === undefined ||
+    repo === undefined ||
+    extra !== undefined ||
+    owner === "" ||
+    repo === ""
+  ) {
+    throw new Error(`invalid GitHub repository: ${fullName}`);
+  }
+  return [owner, repo];
+}

--- a/src/triggers/panel.tsx
+++ b/src/triggers/panel.tsx
@@ -4,7 +4,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useNavigate } from "@tanstack/react-router";
 import { useServerFn } from "@tanstack/react-start";
 import { AlertTriangle, ArrowLeft, Braces, Copy, FileText, LockKeyhole, Plus } from "lucide-react";
-import { useRef, useState, type FormEvent, type ReactNode } from "react";
+import { useLayoutEffect, useRef, useState, type FormEvent, type ReactNode } from "react";
 import { DataCell, DataRow, DataTable } from "../components/app/data-table.js";
 import { PageHeader } from "../components/app/page.js";
 import { SiteHeaderActions } from "../components/app/site-header-actions.js";
@@ -444,6 +444,11 @@ function TriggerForm({
 }) {
   const provider = form.event.split(".")[0];
   const connections = snapshot.connections.filter((connection) => connection.provider === provider);
+  const githubConnections = snapshot.connections.filter(
+    (connection) => connection.provider === "github",
+  );
+  const githubEnabled = form.githubConnection !== "";
+  const [githubExpanded, setGithubExpanded] = useState(githubEnabled);
   const everyone = form.allowedUsers.trim() === "*";
   const update = <Key extends keyof TriggerFormValue>(key: Key, value: TriggerFormValue[Key]) =>
     onChange({ ...form, [key]: value });
@@ -581,7 +586,21 @@ function TriggerForm({
             label="Working directory"
             value={form.cwd}
             onChange={(value) => update("cwd", value)}
-            description="Absolute or home-relative path on the daemon."
+            description="Absolute path on the daemon."
+            required
+          />
+          <ControlledInput
+            label="Maximum runtime"
+            value={form.maxRuntime}
+            onChange={(value) => update("maxRuntime", value)}
+            description="Hard deadline for the agent, for example 2h."
+            required
+          />
+          <ControlledInput
+            label="Idle timeout"
+            value={form.idleTimeout}
+            onChange={(value) => update("idleTimeout", value)}
+            description="Stop an unresponsive agent, for example 10m."
             required
           />
         </div>
@@ -601,10 +620,17 @@ function TriggerForm({
             required
           />
           <ControlledInput
-            label="Execution mode (optional)"
+            label="Execution mode"
             value={form.mode}
             onChange={(value) => update("mode", value)}
             description="Provider mode, for example full-access."
+            required
+          />
+          <ControlledInput
+            label="Thinking option ID"
+            value={form.thinkingOptionId}
+            onChange={(value) => update("thinkingOptionId", value)}
+            description="Leave blank to use the provider's default thinking option."
           />
         </div>
         <details className="rounded-md border bg-muted/20 p-3">
@@ -624,6 +650,67 @@ function TriggerForm({
               Passed to the provider on your daemon. YAML-only agent fields remain untouched.
             </FieldDescription>
           </Field>
+        </details>
+        <details
+          className="rounded-md border bg-muted/20 p-3"
+          open={githubExpanded}
+          onToggle={(event) => setGithubExpanded(event.currentTarget.open)}
+        >
+          <summary className="cursor-pointer text-sm">GitHub access</summary>
+          <div className="mt-3 grid gap-4 sm:grid-cols-2">
+            <Field>
+              <FieldLabel htmlFor="trigger-github-connection">GitHub connection</FieldLabel>
+              <select
+                id="trigger-github-connection"
+                value={form.githubConnection}
+                onChange={(event) => update("githubConnection", event.target.value)}
+                className="h-9 rounded-md border bg-background px-3 text-sm"
+              >
+                <option value="">Do not inject a GitHub token</option>
+                {githubConnections.map((connection) => (
+                  <option key={connection.id} value={connection.slug}>
+                    {connection.label}
+                  </option>
+                ))}
+              </select>
+              <FieldDescription>
+                Mints a short-lived, restricted GH_TOKEN for this run.
+              </FieldDescription>
+            </Field>
+            {githubEnabled ? (
+              <>
+                <ControlledInput
+                  label="GitHub repositories"
+                  value={form.githubRepositories}
+                  onChange={(value) => update("githubRepositories", value)}
+                  description="Comma-separated owner/repository names."
+                  required
+                />
+                <ControlledInput
+                  label="GitHub token lifetime"
+                  value={form.githubDuration}
+                  onChange={(value) => update("githubDuration", value)}
+                  description="At most 1h."
+                  required
+                />
+                <Field>
+                  <FieldLabel htmlFor="trigger-github-permissions">
+                    GitHub permissions (JSON)
+                  </FieldLabel>
+                  <Textarea
+                    id="trigger-github-permissions"
+                    value={form.githubPermissions}
+                    onChange={(event) => update("githubPermissions", event.target.value)}
+                    rows={4}
+                    placeholder={'{"contents":"write","pull_requests":"write"}'}
+                  />
+                  <FieldDescription>
+                    Defaults to read-only repository contents when empty.
+                  </FieldDescription>
+                </Field>
+              </>
+            ) : null}
+          </div>
         </details>
         <PromptEditor value={form.prompt} onChange={(prompt) => update("prompt", prompt)} />
         <div className="flex items-center gap-2 rounded-md border bg-muted/40 p-3 text-sm text-muted-foreground">
@@ -717,6 +804,12 @@ function EnabledSwitch({
 
 function PromptEditor({ value, onChange }: { value: string; onChange: (value: string) => void }) {
   const textarea = useRef<HTMLTextAreaElement>(null);
+  useLayoutEffect(() => {
+    const element = textarea.current;
+    if (element === null) return;
+    element.style.height = "0px";
+    element.style.height = `${String(element.scrollHeight)}px`;
+  }, [value]);
   const insert = (mergeTag: string) => {
     const element = textarea.current;
     if (element === null) return;
@@ -797,11 +890,18 @@ function defaultForm(snapshot: TriggerSnapshot): TriggerFormValue {
     allowedUsers: "*",
     daemon: snapshot.daemons[0]?.slug ?? "",
     cwd: "/workspace",
-    agent: "codex",
-    mode: "",
+    agent: "codex/gpt-5.4",
+    mode: "full-access",
+    thinkingOptionId: "",
     providerOptions: "",
+    maxRuntime: "2h",
+    idleTimeout: "10m",
+    githubConnection: "",
+    githubRepositories: "",
+    githubPermissions: "",
+    githubDuration: "1h",
     prompt:
-      "Handle the request. Use Paseo to delegate or create worktrees when useful.\n\n${{ paseo.prompt }}",
+      "Handle this request in the originating conversation.\n\nWhen hub.reply is available, use it for useful progress updates and your final user-facing response. Call hub.finish_execution once the request is complete.\n\nRequest:\n${{ paseo.prompt }}",
   };
 }
 

--- a/src/triggers/slack/provider.test.ts
+++ b/src/triggers/slack/provider.test.ts
@@ -13,6 +13,30 @@ import { createSlackTriggerProvider } from "./provider.js";
 import { isAcceptedTriggerProviderMatch } from "../index.js";
 
 describe("Slack Phase 1 trigger provider", () => {
+  it("accepts the explicit wildcard without a pointless username lookup", async () => {
+    const database = createMemoryDatabase();
+    const wildcard = configuration();
+    wildcard.triggers[0]!.filters.from_users = ["*"];
+    const { project, revision, store } = await createActiveProjectConfiguration(
+      database,
+      wildcard,
+      { organizationId: "org-1" },
+    );
+    const client = new RecordingSlackClient();
+    const provider = createSlackTriggerProvider({
+      configurationStoreForProject: () => store,
+      botUserIdForWorkspace: () => Promise.resolve("UBOT"),
+      client,
+    });
+
+    const matched = await provider.match(
+      external(project.id, revision.id, { authorId: "U-ANYONE" }),
+    );
+
+    assert.notEqual(typeof matched, "string");
+    assert.deepEqual(client.userLookups, []);
+  });
+
   it("resolves the authored Slack username once before matching", async () => {
     const database = createMemoryDatabase();
     const { project, revision, store } = await createActiveProjectConfiguration(

--- a/src/triggers/slack/provider.ts
+++ b/src/triggers/slack/provider.ts
@@ -297,6 +297,7 @@ function needsSlackUsername(
     (candidate) =>
       candidate.on === "slack.mention" &&
       candidate.filters?.from_users !== undefined &&
+      !candidate.filters.from_users.includes("*") &&
       !candidate.filters.from_users.includes(authorId),
   );
 }

--- a/src/triggers/store.test.ts
+++ b/src/triggers/store.test.ts
@@ -47,6 +47,20 @@ describe("organization trigger store", () => {
     assert.equal((await store.list()).length, 0);
     assert.equal((await database.listProjectsForOrganization("org")).length, 0);
   });
+
+  it.each([
+    ["a relative working directory", "cwd: workspace", /absolute path/iu],
+    ["an omitted execution mode", "provider: test, mode: full-access", /mode.*required/iu],
+  ])("rejects %s at the authoring boundary", async (_name, authored, expected) => {
+    const database = createMemoryDatabase({ organizationIds: ["org"] });
+    const store = new OrganizationTriggerStore(database, "org");
+    const yaml = triggerYaml(true).replace(
+      authored === "cwd: workspace" ? "cwd: /workspace" : authored,
+      authored === "cwd: workspace" ? authored : "provider: test",
+    );
+
+    await assert.rejects(store.save({ yaml, userId: null }), expected);
+  });
 });
 
 function triggerYaml(enabled: boolean): string {
@@ -56,7 +70,7 @@ on:
   manual.run: {}
 run:
   target: { daemon: devbox, cwd: /workspace }
-  agent: { provider: test }
+  agent: { provider: test, mode: full-access }
   prompt: Handle it
   max_runtime: 1h
   idle_timeout: 5m

--- a/src/triggers/store.ts
+++ b/src/triggers/store.ts
@@ -39,7 +39,8 @@ export class OrganizationTriggerStore {
   }
 
   async save(input: SaveTriggerInput): Promise<OrganizationTriggerRecord> {
-    const prepared = await this.validate(input.yaml);
+    const unchangedLegacyAuthoring = await this.isUnchangedExistingYaml(input);
+    const prepared = await this.validate(input.yaml, !unchangedLegacyAuthoring);
     return this.database.saveOrganizationTrigger({
       organizationId: this.organizationId,
       ...(input.triggerId === undefined ? {} : { triggerId: input.triggerId }),
@@ -59,8 +60,9 @@ export class OrganizationTriggerStore {
     });
   }
 
-  async validate(yaml: string) {
+  async validate(yaml: string, enforceAuthoringContract = true) {
     const compiled = compileTriggerDocument(yaml);
+    if (enforceAuthoringContract) validateAuthoringContract(compiled.authored);
     const resolved = await resolveTriggerConfigurationForOrganization(
       this.database,
       this.organizationId,
@@ -74,4 +76,36 @@ export class OrganizationTriggerStore {
     }
     return { compiled, resolved };
   }
+
+  private async isUnchangedExistingYaml(input: SaveTriggerInput): Promise<boolean> {
+    if (input.triggerId === undefined) return false;
+    const trigger = (await this.list()).find(({ id }) => id === input.triggerId);
+    if (trigger === undefined) return false;
+    return (await this.activeRevision(trigger)).yaml === input.yaml;
+  }
+}
+
+function validateAuthoringContract(
+  trigger: ReturnType<typeof compileTriggerDocument>["authored"],
+): void {
+  const issues: Array<{ path: readonly (string | number)[]; message: string }> = [];
+  if (!trigger.run.target.cwd.startsWith("/")) {
+    issues.push({ path: ["run", "target", "cwd"], message: "must be an absolute path" });
+  }
+  if ("choices" in trigger.run.agent) {
+    for (const [name, agent] of Object.entries(trigger.run.agent.choices)) {
+      if (agent.mode === undefined) {
+        issues.push({
+          path: ["run", "agent", "choices", name, "mode"],
+          message: "is required for new triggers",
+        });
+      }
+    }
+  } else if (trigger.run.agent.mode === undefined) {
+    issues.push({
+      path: ["run", "agent", "mode"],
+      message: "is required for new triggers",
+    });
+  }
+  if (issues.length > 0) throw new TriggerDocumentError(issues);
 }


### PR DESCRIPTION
New triggers now expose the complete single-run contract in both the form and YAML editor: explicit runtime settings, scoped GitHub access, and reliable conversational replies. Existing unchanged trigger YAML remains runnable without being silently rewritten.

## Goals

- Require explicit execution mode and an absolute daemon working directory for newly authored or edited triggers.
- Expose runtime and idle limits, thinking options, provider options, and scoped GitHub token authority in the form editor.
- Preserve comments, ordering, and YAML-only fields across form edits.
- Provide unlimited provider-native replies for conversational triggers while keeping `finish_execution` available to every execution.
- Keep legacy explicit output caps and unchanged legacy trigger YAML compatible.

## Non-goals

- Remove legacy multi-step workflow execution.
- Infer provider models or modes from a daemon.
- Add reply semantics to manual triggers, which have no originating conversation.
- Rewrite unchanged legacy trigger documents into the new authoring contract.

## Why

The simplified trigger editor hid runtime controls that materially affect execution and required users to know implementation details to get a useful conversational agent. The authoring surface should make the supported runtime contract explicit while the compiler supplies safe conversational defaults and preserves existing configurations.

## Verification

- 92 focused trigger, provider, output-capability, migration, dashboard, and public-operation tests passed.
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run db:check`
- `npm run test:scripts`
- `npm run build`
- Browser QA covered the new-trigger form and YAML modes, required mode, thinking option, absolute path guidance, runtime limits, autosizing instructions, and merge-tag insertion.
- A full Vitest pass reached 1,128 passing tests. One existing daemon recovery timing test remained flaky because its helper observes the agent ID before the persisted status advances from `spawning` to `running`; this branch does not change daemon lifecycle code.

## Risk surface

- New and edited organization triggers are rejected when mode is omitted or the working directory is relative; unchanged stored YAML bypasses only this new authoring check.
- Output accounting now represents an absent maximum as unlimited. Existing numeric caps retain their previous behavior in both database implementations.
- GitHub reply delivery uses the originating installation and issue or pull-request number to create a comment.
