### PR TITLE
Give daemon enrollment explicit permissions

### DIFF
--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -13,7 +13,7 @@ Hub exposes organization-scoped operator operations under `/api/v1`:
 
 Create a scoped API key in the Hub dashboard or approve `paseo hub login` in the browser, then send the resulting organization credential as `Authorization: Bearer <credential>`. CLI credentials carry all current operator scopes, are stored server-side only as verifiers, and can be revoked under Settings → API keys → CLI logins. They are not daemon credentials.
 
-CLI login starts anonymously at `POST /api/v1/cli-authorizations` and polls at `POST /api/v1/cli-authorizations/poll`. An authenticated owner or admin explicitly approves the active organization at `/cli-login`. The expiring grant is poll-throttled and discloses its durable credential exactly once. Daemons enroll only through the short-lived, single-use token issued by the authenticated enrollment-token operation.
+CLI login starts anonymously at `POST /api/v1/cli-authorizations` and polls at `POST /api/v1/cli-authorizations/poll`. An authenticated owner or admin explicitly approves the active organization at `/cli-login`. The expiring grant is poll-throttled and discloses its durable credential exactly once. Daemons enroll only through the short-lived, single-use token issued by the authenticated enrollment-token operation. A daemon may connect with no permissions and remain available for identity and presence only; only daemons that explicitly grant `hub.execute` are eligible workflow targets.
 
 The canonical, executable operation and schema reference is served by each Hub instance at `/api/reference`; its OpenAPI 3.1 document is `/api/openapi.json`. There are no unversioned operator aliases.
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -23,6 +23,7 @@ import {
   createDaemonModule,
   enrollDaemon,
   revokeDaemon,
+  updateDaemonPermissions,
   type DaemonClock,
   type DaemonModule,
 } from "./daemons/index.js";
@@ -84,6 +85,7 @@ export interface HubRuntime {
 export interface HubOperations {
   handleDaemonEnrollment(request: Request): Promise<Response>;
   handleDaemonRevocation(request: Request, daemonId: string): Promise<Response>;
+  handleDaemonPermissionUpdate(request: Request, daemonId: string): Promise<Response>;
   handleCliAuthorizationStart(request: Request): Promise<Response>;
   handleCliAuthorizationPoll(request: Request): Promise<Response>;
   handleCliAuthorizationInspect(request: Request): Promise<Response>;
@@ -261,6 +263,10 @@ export function createHubApplication(options: HubRuntimeOptions): HubApplication
       options.database === null || daemons === null
         ? databaseUnavailable()
         : revokeDaemon(request, daemonId, options.database, daemons),
+    handleDaemonPermissionUpdate: (request, daemonId) =>
+      options.database === null || daemons === null
+        ? databaseUnavailable()
+        : updateDaemonPermissions(request, daemonId, options.database, daemons),
     handleCliAuthorizationStart: (request) =>
       cliAuthorizations === null ? databaseUnavailable() : cliAuthorizations.start(request),
     handleCliAuthorizationPoll: (request) =>

--- a/src/configuration/compiler-activation.test.ts
+++ b/src/configuration/compiler-activation.test.ts
@@ -183,7 +183,7 @@ async function enrollTestDaemon(database: ReturnType<typeof createMemoryDatabase
     serverId: "server-1",
     daemonPublicKey: "public-key",
     credentialVerifier: "credential-verifier",
-    scopes: ["hub.execution.*"],
+    permissions: ["hub.execute"],
     now: new Date("2026-08-06T11:00:00.000Z"),
   });
 }

--- a/src/configuration/store.ts
+++ b/src/configuration/store.ts
@@ -459,7 +459,7 @@ async function resolveCompiledConfiguration(
   configuration: CompiledHubConfig,
 ): Promise<CompileConfigurationResult> {
   const daemons = (await database.listDaemonsForOrganization(organizationId)).filter(
-    ({ status }) => status === "active",
+    ({ status, permissions }) => status === "active" && permissions.includes("hub.execute"),
   );
   const resolutions = await Promise.all(
     configuration.environments.map(async (environment) =>
@@ -475,7 +475,8 @@ async function resolveCompiledConfiguration(
     ),
   );
   const daemonIssues = resolutions.flatMap(({ environment, daemon }) =>
-    environment.kind === "daemon" && daemon === undefined
+    environment.kind === "daemon" &&
+    (daemon === undefined || !daemon.permissions.includes("hub.execute"))
       ? [
           {
             path: [HUB_RESOURCE_PATH, "environments", environment.name, "daemon"],

--- a/src/daemons/account-daemons.tsx
+++ b/src/daemons/account-daemons.tsx
@@ -34,6 +34,7 @@ const DAEMON_COLUMNS: readonly DataColumn[] = [
   { header: "Slug" },
   { header: "ID" },
   { header: "Status" },
+  { header: "Access" },
   { header: "Last seen" },
   { header: "Registered" },
   { header: "", align: "end" },
@@ -192,6 +193,9 @@ function DaemonRow({
       </DataCell>
       <DataCell>
         <DaemonStatus daemon={daemon} />
+      </DataCell>
+      <DataCell muted>
+        {daemon.permissions.includes("hub.execute") ? "Hub automations" : "Connected only"}
       </DataCell>
       <DataCell muted>{formatDate(daemon.lastSeenAt)}</DataCell>
       <DataCell muted>{formatDate(daemon.registeredAt)}</DataCell>

--- a/src/daemons/daemons.test.ts
+++ b/src/daemons/daemons.test.ts
@@ -1712,14 +1712,25 @@ describe("daemon enrollment and execution", () => {
       });
       assert.equal(result.status, 200);
       assert.ok(result.triggerRunId);
+      const execution = await hub.waitForExecutionForTriggerRun(result.triggerRunId);
+      await hub.waitForExecutionStatus(execution.id, "running");
       await hub.restartApp();
+      await hub.waitForRecoveredExecution(execution.id);
+      assert.deepEqual(
+        await hub.runtimeResources({
+          recoveredExecutionSubscriptions: 1,
+        }),
+        {
+          recoveredExecutionSubscriptions: 1,
+        },
+      );
+      assert.equal(await hub.completeExecution(execution.id), 200);
+      await hub.waitForExecutionStatus(execution.id, "succeeded");
       assert.deepEqual(
         await hub.runtimeResources({
           recoveredExecutionSubscriptions: 0,
         }),
-        {
-          recoveredExecutionSubscriptions: 0,
-        },
+        { recoveredExecutionSubscriptions: 0 },
       );
     }
 
@@ -1727,7 +1738,12 @@ describe("daemon enrollment and execution", () => {
       deliveryKey: "resource-runtime-stop",
     });
     assert.equal(stopped.status, 200);
+    assert.ok(stopped.triggerRunId);
+    const execution = await hub.waitForExecutionForTriggerRun(stopped.triggerRunId);
+    await hub.waitForExecutionStatus(execution.id, "running");
     await hub.restartApp();
+    await hub.waitForRecoveredExecution(execution.id);
+    await hub.runtimeResources({ recoveredExecutionSubscriptions: 1 });
     assert.deepEqual(await hub.stopRuntimeResources(), {
       recoveredExecutionSubscriptions: 0,
     });

--- a/src/daemons/daemons.test.ts
+++ b/src/daemons/daemons.test.ts
@@ -54,6 +54,47 @@ describe("daemon enrollment and execution", () => {
     );
   });
 
+  it("keeps a connected-only daemon online without execution permission", async () => {
+    const daemonId = await hub.connectDaemon(undefined, []);
+    const daemon = await hub.daemon(daemonId);
+
+    assert.deepEqual(
+      {
+        permissions: daemon.permissions,
+        presence: daemon.presence,
+        connected: daemon.connectedAt !== null,
+      },
+      { permissions: [], presence: "connected", connected: true },
+    );
+  });
+
+  it("lets the authenticated daemon update semantic permissions without reconnecting", async () => {
+    const daemonId = await hub.connectDaemon(undefined, []);
+
+    assert.equal(await hub.updateConnectedDaemonPermissions(["hub.execute"]), 200);
+    assert.deepEqual((await hub.daemon(daemonId)).permissions, ["hub.execute"]);
+
+    assert.equal(await hub.updateConnectedDaemonPermissions([]), 200);
+    assert.deepEqual((await hub.daemon(daemonId)).permissions, []);
+  });
+
+  it("rejects permission changes that do not carry the daemon credential", async () => {
+    const daemonId = await hub.connectDaemon(undefined, []);
+
+    assert.equal(
+      await hub.updateConnectedDaemonPermissions(["hub.execute"], "wrong-credential"),
+      401,
+    );
+    assert.deepEqual((await hub.daemon(daemonId)).permissions, []);
+  });
+
+  it("maps a legacy enrollment scope to hub.execute at the compatibility boundary", async () => {
+    const enrollment = await hub.enrollLegacyDaemon();
+
+    assert.deepEqual(enrollment.scopes, ["hub.execution.*"]);
+    assert.deepEqual((await hub.daemon(enrollment.daemonId)).permissions, ["hub.execute"]);
+  });
+
   it("replays one enrollment ceremony with a stable daemon", async () => {
     const enrollment = await hub.connectWithEnrollmentReplay();
 

--- a/src/daemons/functions.ts
+++ b/src/daemons/functions.ts
@@ -13,6 +13,7 @@ const daemonSchema = z.object({
   connectedAt: z.string().datetime().nullable(),
   lastSeenAt: z.string().datetime(),
   registeredAt: z.string().datetime(),
+  permissions: z.array(z.string()),
 });
 const daemonListSchema = z.object({
   daemons: z.array(daemonSchema),

--- a/src/daemons/handoff.test.tsx
+++ b/src/daemons/handoff.test.tsx
@@ -21,6 +21,7 @@ function daemon(overrides: Partial<BrowserDaemon> = {}): BrowserDaemon {
     connectedAt: "2026-01-01T00:00:00.000Z",
     lastSeenAt: "2026-01-01T00:00:00.000Z",
     registeredAt: "2026-01-01T00:00:00.000Z",
+    permissions: ["hub.execute"],
     ...overrides,
   };
 }

--- a/src/daemons/index.ts
+++ b/src/daemons/index.ts
@@ -26,7 +26,7 @@ export type {
 export { DaemonDispatchFailure, DaemonSpawnAckTimeoutError };
 export { AgentExecutionCompletionFailure };
 export { ActiveDaemonRegistry, createDaemonUpgradeHandler, type DaemonClock } from "./registry.js";
-export { enrollDaemon, revokeDaemon } from "./registration.js";
+export { enrollDaemon, revokeDaemon, updateDaemonPermissions } from "./registration.js";
 
 interface DaemonModuleTestOptions {
   logger?: Logger;

--- a/src/daemons/lifecycle.test.ts
+++ b/src/daemons/lifecycle.test.ts
@@ -335,7 +335,7 @@ function daemonRecord(): DaemonRecord {
     serverId: "server-lifecycle",
     daemonPublicKey: "public-key",
     credentialVerifier: "verifier",
-    scopes: ["hub.execution.*"],
+    permissions: ["hub.execute"],
     registeredByApiKeyId: null,
     registeredByCliCredentialId: null,
     status: "active",

--- a/src/daemons/registration.ts
+++ b/src/daemons/registration.ts
@@ -17,9 +17,16 @@ const enrollmentBody = z
     serverId: z.string(),
     daemonPublicKey: z.string(),
     credentialVerifier: z.string(),
-    scopes: z.array(z.string().min(1)).min(1).optional(),
+    permissions: z.array(z.string().min(1)).optional(),
+    scopes: z.array(z.literal("hub.execution.*")).max(1).optional(),
   })
-  .strict();
+  .strict()
+  .superRefine((value, context) => {
+    if (value.permissions !== undefined && value.scopes !== undefined) {
+      context.addIssue({ code: "custom", message: "Use permissions or legacy scopes, not both" });
+    }
+  });
+const permissionsBody = z.object({ permissions: z.array(z.string().min(1)) }).strict();
 
 interface DaemonRegistrationOptions {
   database: Database;
@@ -123,11 +130,16 @@ export async function enrollDaemon(
   const input = enrollmentBody.safeParse(await parsedJson(request, "daemon.enroll.parse"));
   if (!input.success) return Response.json({ error: "invalid enrollment" }, { status: 400 });
   const fallbackSlug = `daemon-${input.data.daemonId.slice(0, 8)}`;
+  const permissions = enrollmentPermissions(input.data);
   const daemon = await database.enrollDaemon({
-    ...input.data,
+    daemonId: input.data.daemonId,
+    idempotencyKey: input.data.idempotencyKey,
+    serverId: input.data.serverId,
+    daemonPublicKey: input.data.daemonPublicKey,
+    credentialVerifier: input.data.credentialVerifier,
     suggestedSlug:
       input.data.hostname === undefined ? fallbackSlug : slugify(input.data.hostname, fallbackSlug),
-    scopes: ["hub.execution.*"],
+    permissions,
     tokenVerifier: verifier(token),
     now: clock.nowDate(),
   });
@@ -137,12 +149,36 @@ export async function enrollDaemon(
   if (daemon.status === "slug_conflict") return daemonSlugConflict(daemon.slug);
   const webSocketUrl = new URL("/api/daemons/socket", publicBaseUrl ?? request.url);
   webSocketUrl.protocol = webSocketUrl.protocol === "https:" ? "wss:" : "ws:";
-  return Response.json({
+  const response = {
     daemonId: daemon.id,
     slug: daemon.slug,
-    scopes: daemon.scopes,
     webSocketUrl: webSocketUrl.toString(),
-  });
+  };
+  return Response.json(
+    input.data.permissions === undefined
+      ? {
+          ...response,
+          scopes: daemon.permissions.includes("hub.execute") ? ["hub.execution.*"] : [],
+        }
+      : { ...response, permissions: daemon.permissions },
+  );
+}
+
+export async function updateDaemonPermissions(
+  request: Request,
+  id: string,
+  database: Database,
+  registry: ActiveDaemonRegistry,
+): Promise<Response> {
+  const daemon = await authenticatedDaemon(request, id, database);
+  if (daemon instanceof Response) return daemon;
+  const input = permissionsBody.safeParse(await parsedJson(request, "daemon.permissions.parse"));
+  if (!input.success) return Response.json({ error: "invalid permissions" }, { status: 400 });
+  const permissions = [...new Set(input.data.permissions)];
+  const updated = await database.setDaemonPermissions(id, permissions);
+  if (updated === undefined) return Response.json({ error: "daemon unavailable" }, { status: 404 });
+  registry.updatePermissions(updated);
+  return Response.json({ permissions: updated.permissions });
 }
 
 export async function revokeDaemon(
@@ -151,6 +187,22 @@ export async function revokeDaemon(
   database: Database,
   registry: ActiveDaemonRegistry,
 ): Promise<Response> {
+  const daemon = await authenticatedDaemon(request, id, database);
+  if (daemon instanceof Response) return daemon;
+  await database.revokeDaemon(id);
+  await registry.revoke(daemon);
+  return new Response(null, { status: 204 });
+}
+
+function verifier(value: string): string {
+  return createHash("sha256").update(value).digest("base64url");
+}
+
+async function authenticatedDaemon(
+  request: Request,
+  id: string,
+  database: Database,
+): Promise<DaemonRecord | Response> {
   const daemon = await database.findDaemonById(id);
   const credential = bearer(request.headers.get("authorization") ?? undefined);
   if (
@@ -160,13 +212,12 @@ export async function revokeDaemon(
   ) {
     return Response.json({ error: "unauthorized" }, { status: 401 });
   }
-  await database.revokeDaemon(id);
-  await registry.revoke(daemon);
-  return new Response(null, { status: 204 });
+  return daemon;
 }
 
-function verifier(value: string): string {
-  return createHash("sha256").update(value).digest("base64url");
+function enrollmentPermissions(input: z.infer<typeof enrollmentBody>): string[] {
+  if (input.permissions !== undefined) return [...new Set(input.permissions)];
+  return input.scopes?.includes("hub.execution.*") === false ? [] : ["hub.execute"];
 }
 
 function matchesVerifier(value: string, expectedVerifier: string): boolean {
@@ -207,6 +258,7 @@ function daemonSummary(daemon: DaemonRecord) {
     connectedAt: daemon.connectedAt?.toISOString() ?? null,
     lastSeenAt: daemon.lastSeenAt.toISOString(),
     registeredAt: daemon.createdAt.toISOString(),
+    permissions: daemon.permissions,
   };
 }
 

--- a/src/daemons/registry.test.ts
+++ b/src/daemons/registry.test.ts
@@ -1,11 +1,133 @@
 import assert from "node:assert/strict";
+import { createHash, randomUUID } from "node:crypto";
+import { createServer } from "node:http";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { WebSocket, type RawData } from "ws";
+import type { DaemonRecord } from "../db/types.js";
+import { HubDaemonHelloSchema } from "../hub/protocol.js";
 import { createLogger } from "../logger.js";
 import { assertOneFailure, FailureLogStream } from "../test-utils/failure-logs.js";
 import { DaemonCreateRejectedError, DaemonCreateResponseLostError } from "./protocol.js";
+import { ActiveDaemonRegistry, createDaemonUpgradeHandler } from "./registry.js";
 import { DaemonRegistryHarness } from "./test-utils/daemon-registry-harness.js";
 
+function rawDataToText(data: RawData): string {
+  if (Array.isArray(data)) return Buffer.concat(data).toString();
+  if (data instanceof ArrayBuffer) return Buffer.from(data).toString();
+  return data.toString();
+}
+
+describe("daemon socket protocol negotiation", () => {
+  it.each([
+    {
+      offered: true,
+      expectedProtocol: "1",
+      expectsHello: true,
+      expectsReady: false,
+    },
+    {
+      offered: false,
+      expectedProtocol: undefined,
+      expectsHello: false,
+      expectsReady: true,
+    },
+  ])(
+    "negotiates the standard session only when offered=$offered",
+    async ({ offered, expectedProtocol, expectsHello, expectsReady }) => {
+      const secret = "daemon-secret";
+      const now = new Date();
+      const daemon: DaemonRecord = {
+        id: randomUUID(),
+        slug: "negotiation-daemon",
+        machineId: randomUUID(),
+        serverId: randomUUID(),
+        daemonPublicKey: "public-key",
+        credentialVerifier: createHash("sha256").update(secret).digest("base64url"),
+        permissions: ["hub.execute"],
+        registeredByApiKeyId: null,
+        registeredByCliCredentialId: null,
+        status: "active",
+        presence: "offline",
+        connectedAt: null,
+        disconnectedAt: null,
+        lastSeenAt: now,
+        createdAt: now,
+      };
+      const registry = new ActiveDaemonRegistry({
+        touchDaemon: async () => undefined,
+        setDaemonPresence: async () => undefined,
+      });
+      const server = createServer();
+      const handleUpgrade = createDaemonUpgradeHandler(
+        { findDaemonById: async () => daemon },
+        registry,
+      );
+      server.on("upgrade", (request, socket, head) => {
+        void handleUpgrade(request, socket, head);
+      });
+      await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+      const address = server.address();
+      assert(address && typeof address !== "string");
+      const messages: string[] = [];
+      let negotiatedProtocol: string | string[] | undefined;
+      const client = new WebSocket(`ws://127.0.0.1:${address.port}/api/daemons/socket`, {
+        headers: {
+          authorization: `Bearer ${secret}`,
+          "x-paseo-daemon-id": daemon.id,
+          ...(offered ? { "x-paseo-session-protocol": "1" } : {}),
+        },
+      });
+      client.on("upgrade", (response) => {
+        negotiatedProtocol = response.headers["x-paseo-session-protocol"];
+      });
+      client.on("message", (data: RawData) => {
+        messages.push(rawDataToText(data));
+      });
+      await new Promise<void>((resolve, reject) => {
+        client.once("open", resolve);
+        client.once("error", reject);
+      });
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      assert.equal(negotiatedProtocol, expectedProtocol);
+      assert.equal(
+        messages.some((message) => HubDaemonHelloSchema.safeParse(JSON.parse(message)).success),
+        expectsHello,
+      );
+      assert.equal(registry.connection(daemon.id) !== undefined, expectsReady);
+
+      client.close();
+      await new Promise<void>((resolve) => client.once("close", () => resolve()));
+      await registry.stop();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    },
+  );
+});
+
 describe("daemon socket generations", () => {
+  it("does not expose a physical socket until standard session bootstrap completes", async () => {
+    await daemon.replaceConnection(false);
+
+    assert.equal(daemon.connected(), false);
+    await daemon.completeServerInfo();
+
+    assert.equal(daemon.connected(), true);
+  });
+
+  it("rejects a session whose effective permissions differ from enrollment", async () => {
+    await daemon.replaceConnection(false);
+    await daemon.completeServerInfo([]);
+
+    await daemon.waitUntilCurrentClosed();
+    assert.equal(daemon.connected(), false);
+  });
+
+  it("keeps a legacy daemon connected without sending the standard hello", async () => {
+    await daemon.replaceConnection(false, "legacy");
+
+    assert.equal(daemon.connected(), true);
+  });
+
   let daemon: DaemonRegistryHarness;
   let stream: FailureLogStream;
 
@@ -57,7 +179,10 @@ describe("daemon socket generations", () => {
       valid: false,
       issues: [
         { path: ["provider"], message: "provider is unavailable" },
-        { path: ["options", "nonsense"], message: "unrecognized provider option" },
+        {
+          path: ["options", "nonsense"],
+          message: "unrecognized provider option",
+        },
       ],
     });
   });

--- a/src/daemons/registry.ts
+++ b/src/daemons/registry.ts
@@ -17,6 +17,8 @@ import {
   HubExecutionControlRequestSchema,
   HubExecutionControlResponseSchema,
   HubExecutionOutboundSchema,
+  HubDaemonHelloSchema,
+  HubDaemonServerInfoEnvelopeSchema,
 } from "../hub/protocol.js";
 import {
   DaemonCreateResponseLostError,
@@ -58,7 +60,14 @@ interface ActiveSocket {
   generation: number;
   socket: WebSocket;
   daemon: DaemonRecord;
+  ready: boolean;
+  presenceReady: Promise<void>;
 }
+
+export type DaemonSessionProtocol = "legacy" | "session-v1";
+
+const DAEMON_SESSION_PROTOCOL_HEADER = "x-paseo-session-protocol";
+const DAEMON_SESSION_PROTOCOL_VERSION = "1";
 
 type DaemonConnectedHandler = (daemon: DaemonRecord) => void | Promise<void>;
 type DaemonRevokedHandler = (daemon: DaemonRecord) => void | Promise<void>;
@@ -69,26 +78,28 @@ export class ActiveDaemonRegistry {
   private readonly subscribersByDaemon = new Map<string, Set<DaemonEventHandler>>();
   private readonly connectedHandlers = new Set<DaemonConnectedHandler>();
   private readonly revokedHandlers = new Set<DaemonRevokedHandler>();
-  private readonly offlinePresenceWrites = new Set<Promise<void>>();
+  private readonly presenceWrites = new Set<Promise<void>>();
   private generation = 0;
 
   constructor(
-    private readonly database: Pick<Database, "setDaemonPresence">,
+    private readonly database: Pick<Database, "setDaemonPresence" | "touchDaemon">,
     private readonly clock: DaemonClock = systemDaemonClock,
     private readonly failureLogger: Pick<Logger, "warn" | "error"> = defaultLogger,
   ) {}
 
-  accept(daemon: DaemonRecord, socket: WebSocket): void {
-    if (!daemon.scopes.includes("hub.execution.*")) {
-      socket.close(4403, "daemon scope unavailable");
-      return;
-    }
+  accept(
+    daemon: DaemonRecord,
+    socket: WebSocket,
+    sessionProtocol: DaemonSessionProtocol = "session-v1",
+  ): void {
     const previous = this.active.get(daemon.id);
     if (previous) this.rejectGeneration(daemon.id, previous.generation);
     const active: ActiveSocket = {
       generation: ++this.generation,
       socket,
       daemon,
+      ready: false,
+      presenceReady: Promise.resolve(),
     };
     this.active.set(daemon.id, active);
     previous?.socket.close(4001, "replaced");
@@ -97,18 +108,31 @@ export class ActiveDaemonRegistry {
       if (this.active.get(daemon.id)?.generation === active.generation) {
         this.active.delete(daemon.id);
         this.rejectGeneration(daemon.id, active.generation);
-        const write = this.database.setDaemonPresence(daemon.id, "offline");
-        this.offlinePresenceWrites.add(write);
+        const write = active.presenceReady.then(() =>
+          this.database.setDaemonPresence(daemon.id, "offline"),
+        );
+        this.presenceWrites.add(write);
         void write.then(
-          () => this.offlinePresenceWrites.delete(write),
+          () => this.presenceWrites.delete(write),
           (error: unknown) => {
             this.report(error, "daemon.presence.offline", daemon.id);
           },
         );
       }
     });
-    for (const handler of this.connectedHandlers) {
-      this.observeHandler(() => handler(daemon), "daemon.connected.handler", daemon.id);
+    if (sessionProtocol === "legacy") {
+      this.markReady(active);
+    } else {
+      socket.send(
+        JSON.stringify(
+          HubDaemonHelloSchema.parse({
+            type: "hello",
+            clientId: `hub:${daemon.id}`,
+            clientType: "hub",
+            protocolVersion: 1,
+          }),
+        ),
+      );
     }
   }
 
@@ -124,7 +148,7 @@ export class ActiveDaemonRegistry {
 
   connection(daemonId: string): DaemonConnection | undefined {
     const active = this.active.get(daemonId);
-    if (!active) return undefined;
+    if (!active?.ready || !active.daemon.permissions.includes("hub.execute")) return undefined;
     return {
       createAgent: (options) => this.createAgent(daemonId, options),
       controlExecution: (options) => this.controlExecution(daemonId, options),
@@ -141,7 +165,10 @@ export class ActiveDaemonRegistry {
     agent: import("../config/compiler.js").CompiledAgent,
   ): Promise<{ valid: true } | { valid: false; issues: readonly AgentValidationIssue[] }> {
     const active = this.active.get(daemonId);
-    if (!active) return Promise.reject(new Error("daemon_not_connected"));
+    if (!active?.ready) return Promise.reject(new Error("daemon_not_connected"));
+    if (!active.daemon.permissions.includes("hub.execute")) {
+      return Promise.reject(new Error("daemon_execution_not_allowed"));
+    }
     const requestId = randomUUID();
     const request = HubExecutionAgentValidateRequestSchema.parse({
       type: "hub.execution.agent.validate.request",
@@ -163,6 +190,11 @@ export class ActiveDaemonRegistry {
     });
   }
 
+  updatePermissions(daemon: DaemonRecord): void {
+    const active = this.active.get(daemon.id);
+    if (active) active.daemon = daemon;
+  }
+
   async revoke(daemon: DaemonRecord): Promise<void> {
     try {
       await Promise.all(Array.from(this.revokedHandlers, async (handler) => handler(daemon)));
@@ -182,7 +214,7 @@ export class ActiveDaemonRegistry {
         }),
     );
     await Promise.all(sockets);
-    await Promise.all(this.offlinePresenceWrites);
+    await Promise.all(this.presenceWrites);
     for (const [daemonId, pending] of this.pendingByDaemon) {
       for (const request of pending.values()) request.reject(disconnectError(request));
       this.pendingByDaemon.delete(daemonId);
@@ -194,7 +226,7 @@ export class ActiveDaemonRegistry {
     options: DaemonCreateAgentOptions,
   ): Promise<{ id: string }> {
     const active = this.active.get(daemonId);
-    if (!active) return Promise.reject(new Error("daemon_not_connected"));
+    if (!active?.ready) return Promise.reject(new Error("daemon_not_connected"));
     const requestId = randomUUID();
     const executionId = options.executionId;
     const request = HubExecutionAgentCreateRequestSchema.parse({
@@ -236,7 +268,7 @@ export class ActiveDaemonRegistry {
     options: DaemonExecutionControlOptions,
   ): Promise<void> {
     const active = this.active.get(daemonId);
-    if (!active) return Promise.reject(new Error("daemon_not_connected"));
+    if (!active?.ready) return Promise.reject(new Error("daemon_not_connected"));
     const requestId = randomUUID();
     const request = HubExecutionControlRequestSchema.parse({
       type: "hub.execution.control.request",
@@ -266,6 +298,11 @@ export class ActiveDaemonRegistry {
     } catch (error) {
       this.report(error, "daemon.websocket.message.parse", active.daemon.id, "validation");
       active.socket.close(4400, "invalid daemon message");
+      return;
+    }
+    const serverInfo = HubDaemonServerInfoEnvelopeSchema.safeParse(value);
+    if (serverInfo.success) {
+      this.acceptServerInfo(active, serverInfo.data.message.payload.permissions);
       return;
     }
     const envelope = HubExecutionOutboundSchema.safeParse(value);
@@ -300,6 +337,39 @@ export class ActiveDaemonRegistry {
       timestamp: receivedAt,
     } as const;
     this.notifySubscribers(active.daemon.id, event);
+  }
+
+  private acceptServerInfo(active: ActiveSocket, permissions: readonly string[]): void {
+    if (!samePermissions(permissions, active.daemon.permissions)) {
+      active.socket.close(4403, "daemon session permissions do not match enrollment");
+      return;
+    }
+    this.markReady(active);
+  }
+
+  private markReady(active: ActiveSocket): void {
+    if (active.ready) return;
+    active.ready = true;
+    const write = Promise.all([
+      this.database.touchDaemon(active.daemon.id),
+      this.database.setDaemonPresence(active.daemon.id, "connected"),
+    ]).then(
+      () => undefined,
+      (error: unknown) => this.report(error, "daemon.presence.connected", active.daemon.id),
+    );
+    active.presenceReady = write;
+    this.presenceWrites.add(write);
+    void write.then(() => {
+      this.presenceWrites.delete(write);
+      for (const handler of this.connectedHandlers) {
+        this.observeHandler(
+          () => handler(active.daemon),
+          "daemon.connected.handler",
+          active.daemon.id,
+        );
+      }
+      return undefined;
+    });
   }
 
   private notifySubscribers(daemonId: string, event: Parameters<DaemonEventHandler>[0]): void {
@@ -492,8 +562,22 @@ function relatedCreateRequests(
   return related;
 }
 
-export function createDaemonUpgradeHandler(database: Database, registry: ActiveDaemonRegistry) {
+function samePermissions(actual: readonly string[], expected: readonly string[]): boolean {
+  return (
+    actual.length === expected.length && expected.every((permission) => actual.includes(permission))
+  );
+}
+
+export function createDaemonUpgradeHandler(
+  database: Pick<Database, "findDaemonById">,
+  registry: ActiveDaemonRegistry,
+) {
   const server = new WebSocketServer({ noServer: true });
+  server.on("headers", (headers, request) => {
+    if (request.headers[DAEMON_SESSION_PROTOCOL_HEADER] === DAEMON_SESSION_PROTOCOL_VERSION) {
+      headers.push(`${DAEMON_SESSION_PROTOCOL_HEADER}: ${DAEMON_SESSION_PROTOCOL_VERSION}`);
+    }
+  });
   return async function upgrade(
     request: IncomingMessage,
     socket: Duplex,
@@ -514,9 +598,13 @@ export function createDaemonUpgradeHandler(database: Database, registry: ActiveD
       !matchesVerifier(credential, daemon.credentialVerifier)
     )
       return rejectUpgrade(socket, 403);
-    await database.touchDaemon(daemon.id);
-    await database.setDaemonPresence(daemon.id, "connected");
-    server.handleUpgrade(request, socket, head, (webSocket) => registry.accept(daemon, webSocket));
+    const sessionProtocol =
+      request.headers[DAEMON_SESSION_PROTOCOL_HEADER] === DAEMON_SESSION_PROTOCOL_VERSION
+        ? "session-v1"
+        : "legacy";
+    server.handleUpgrade(request, socket, head, (webSocket) =>
+      registry.accept(daemon, webSocket, sessionProtocol),
+    );
   };
 }
 

--- a/src/daemons/test-utils/daemon-registry-harness.ts
+++ b/src/daemons/test-utils/daemon-registry-harness.ts
@@ -140,7 +140,10 @@ export class DaemonRegistryHarness {
     return settled;
   }
 
-  async replaceConnection(): Promise<{ supersededClosed: boolean }> {
+  async replaceConnection(
+    completeHello = true,
+    sessionProtocol: "legacy" | "session-v1" = "session-v1",
+  ): Promise<{ supersededClosed: boolean }> {
     const superseded = this.socket;
     const address = this.server.address();
     if (typeof address === "string" || address === null) throw new Error("Registry has no address");
@@ -151,10 +154,42 @@ export class DaemonRegistryHarness {
       client.once("error", reject);
     });
     const serverSocket = await accepted;
-    this.registry.accept(this.daemon, serverSocket);
+    const registrySocket = new RegistrySocket(
+      client,
+      completeHello ? this.daemon.permissions : null,
+    );
+    let ready: Promise<void> | null = null;
+    let unsubscribeReady: () => void = () => undefined;
+    if (completeHello) {
+      let resolveReady!: () => void;
+      ready = new Promise<void>((resolve) => {
+        resolveReady = resolve;
+      });
+      unsubscribeReady = this.registry.onConnected(() => resolveReady());
+    }
+    this.registry.accept(this.daemon, serverSocket, sessionProtocol);
+    if (ready) await ready;
+    unsubscribeReady();
     this.clients.push(client);
-    this.socket = new RegistrySocket(client);
+    this.socket = registrySocket;
     return { supersededClosed: superseded?.closed ?? false };
+  }
+
+  connected(): boolean {
+    return this.registry.connection(this.daemon.id) !== undefined;
+  }
+
+  async completeServerInfo(
+    permissions: readonly string[] = this.daemon.permissions,
+  ): Promise<void> {
+    let resolveReady!: () => void;
+    const ready = new Promise<void>((resolve) => {
+      resolveReady = resolve;
+    });
+    const unsubscribe = this.registry.onConnected(() => resolveReady());
+    this.currentSocket().sendServerInfo(permissions);
+    if (sameStringSet(permissions, this.daemon.permissions)) await ready;
+    unsubscribe();
   }
 
   onConnected(handler: (daemon: DaemonRecord) => void | Promise<void>): () => void {
@@ -293,7 +328,7 @@ export class DaemonRegistryHarness {
 }
 
 class DaemonPresence {
-  private writes = 0;
+  private holdOffline = false;
   private writing: Promise<void> | undefined;
   private resolveWriting: (() => void) | undefined;
   private persistence: Promise<void> | undefined;
@@ -305,6 +340,7 @@ class DaemonPresence {
   }
 
   hold(): void {
+    this.holdOffline = true;
     this.writing = new Promise<void>((resolve) => {
       this.resolveWriting = resolve;
     });
@@ -314,16 +350,18 @@ class DaemonPresence {
   }
 
   async setDaemonPresence(_id: string, _presence: "offline" | "connected"): Promise<void> {
-    this.writes += 1;
     if (this.nextFailure !== undefined) {
       const error = this.nextFailure;
       this.nextFailure = undefined;
       throw error;
     }
-    if (this.writes !== 1) return;
+    if (_presence !== "offline" || !this.holdOffline) return;
+    this.holdOffline = false;
     this.resolveWriting?.();
     await this.persistence;
   }
+
+  async touchDaemon(_id: string): Promise<void> {}
 
   async waitUntilWriting(): Promise<void> {
     if (!this.writing) throw new Error("Offline presence is not held");
@@ -340,12 +378,20 @@ class RegistrySocket {
   private waiter: (() => void) | undefined;
   private didClose = false;
 
-  constructor(private readonly socket: WebSocket) {
+  constructor(
+    private readonly socket: WebSocket,
+    private readonly helloPermissions: readonly string[] | null,
+  ) {
     socket.once("close", () => {
       this.didClose = true;
     });
     socket.on("message", (data) => {
-      this.messages.push(SessionRequestSchema.parse(JSON.parse(readText(data))).message);
+      const value = JSON.parse(readText(data)) as unknown;
+      if (isHubHello(value)) {
+        if (this.helloPermissions) this.sendServerInfo(this.helloPermissions);
+        return;
+      }
+      this.messages.push(SessionRequestSchema.parse(value).message);
       this.waiter?.();
       this.waiter = undefined;
     });
@@ -369,6 +415,18 @@ class RegistrySocket {
     this.socket.send(JSON.stringify({ type: "session", message }));
   }
 
+  sendServerInfo(permissions: readonly string[]): void {
+    this.send({
+      type: "status",
+      payload: {
+        status: "server_info",
+        serverId: "test-daemon",
+        permissions,
+        features: {},
+      },
+    });
+  }
+
   sendRaw(value: string): void {
     this.socket.send(value);
   }
@@ -383,6 +441,14 @@ class RegistrySocket {
   }
 }
 
+function isHubHello(value: unknown): boolean {
+  return typeof value === "object" && value !== null && "type" in value && value.type === "hello";
+}
+
+function sameStringSet(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((value) => right.includes(value));
+}
+
 function daemonRecord(): DaemonRecord {
   const now = new Date();
   return {
@@ -392,7 +458,7 @@ function daemonRecord(): DaemonRecord {
     serverId: randomUUID(),
     daemonPublicKey: "public-key",
     credentialVerifier: "verifier",
-    scopes: ["hub.execution.*"],
+    permissions: ["hub.execute"],
     registeredByApiKeyId: null,
     registeredByCliCredentialId: null,
     status: "active",

--- a/src/daemons/test-utils/hub-harness.ts
+++ b/src/daemons/test-utils/hub-harness.ts
@@ -97,6 +97,12 @@ const IssuedEnrollmentSchema = z.object({
 const EnrollmentSchema = z.object({
   daemonId: z.string(),
   slug: z.string(),
+  permissions: z.array(z.string()),
+  webSocketUrl: z.string(),
+});
+const LegacyEnrollmentSchema = z.object({
+  daemonId: z.string(),
+  slug: z.string(),
   scopes: z.array(z.string()),
   webSocketUrl: z.string(),
 });
@@ -217,14 +223,18 @@ export class HubHarness {
     } as const;
   }
 
-  async connectDaemon(token?: string): Promise<string> {
+  async connectDaemon(
+    token?: string,
+    permissions: readonly string[] = ["hub.execute"],
+  ): Promise<string> {
     const issued =
       token === undefined ? await this.issueEnrollment() : { status: 201 as const, token };
     if (issued.status !== 201 || !("token" in issued))
       throw new Error("Enrollment token was not issued");
     this.connectedDaemon = TestDaemon.create(this.origin);
-    const daemon = await this.connectedDaemon.enroll(issued.token);
+    const daemon = await this.connectedDaemon.enroll(issued.token, undefined, permissions);
     await this.connectedDaemon.connect(daemon);
+    await this.observeConnectedPresence(daemon.daemonId);
     return daemon.daemonId;
   }
 
@@ -234,6 +244,24 @@ export class HubHarness {
       throw new Error("Enrollment token was not issued");
     }
     return TestDaemon.create(this.origin).enroll(issued.token, hostname);
+  }
+
+  async enrollLegacyDaemon(): Promise<{ daemonId: string; scopes: string[] }> {
+    const issued = await this.issueEnrollment();
+    if (issued.status !== 201 || !("token" in issued)) {
+      throw new Error("Enrollment token was not issued");
+    }
+    const daemon = TestDaemon.create(this.origin);
+    const enrollment = await daemon.enrollLegacy(issued.token);
+    return { daemonId: enrollment.daemonId, scopes: enrollment.scopes };
+  }
+
+  async updateConnectedDaemonPermissions(
+    permissions: readonly string[],
+    credential?: string,
+  ): Promise<number> {
+    if (!this.connectedDaemon) throw new Error("No connected daemon");
+    return this.connectedDaemon.updatePermissions(permissions, credential);
   }
 
   async renameConnectedDaemon(slug: string): Promise<void> {
@@ -312,6 +340,7 @@ export class HubHarness {
     const first = await this.connectedDaemon.enroll(issued.token, "Replay Host.local");
     const replay = await this.connectedDaemon.enroll(issued.token, "Replay Host.local");
     await this.connectedDaemon.connect(replay);
+    await this.observeConnectedPresence(replay.daemonId);
     const contender = TestDaemon.create(this.origin);
     const consumedTokenStatus = await contender.enrollmentStatus(issued.token);
     const persisted = await Promise.all([
@@ -330,11 +359,13 @@ export class HubHarness {
 
   async replaceDaemon(options: { acceptSpawns?: boolean } = {}): Promise<void> {
     const daemon = this.requireDaemon();
+    const previousConnectedAt = (await this.daemon(daemon.daemonId)).connectedAt;
     const replacement = daemon.replacement();
     if (options.acceptSpawns === true) replacement.acceptSpawn();
     await replacement.connectExisting();
     await daemon.closed();
     this.connectedDaemon = replacement;
+    await this.observeConnectedPresence(replacement.daemonId, previousConnectedAt);
   }
 
   async revokeDaemon(): Promise<number> {
@@ -342,7 +373,9 @@ export class HubHarness {
     const closed = daemon.closedCode();
     const response = await daemon.revoke();
     assert.equal(response, 204);
-    return closed;
+    const code = await closed;
+    await this.observeOfflinePresence();
+    return code;
   }
   invalidCredentialReconnectStatus(): Promise<number> {
     return this.requireDaemon().reconnectStatus("invalid");
@@ -356,18 +389,24 @@ export class HubHarness {
   }
 
   async reconnectDaemon(): Promise<void> {
-    const replacement = this.requireDaemon().replacement(this.origin);
+    const daemon = this.requireDaemon();
+    const previousConnectedAt = (await this.daemon(daemon.daemonId)).connectedAt;
+    const replacement = daemon.replacement(this.origin);
     await replacement.connectExisting();
     this.connectedDaemon = replacement;
+    await this.observeConnectedPresence(replacement.daemonId, previousConnectedAt);
   }
 
   async reconnectDaemonAndCompleteHubAction(
     executionId: string,
   ): Promise<HubExecutionControlAction> {
-    const replacement = this.requireDaemon().replacement(this.origin);
+    const daemon = this.requireDaemon();
+    const previousConnectedAt = (await this.daemon(daemon.daemonId)).connectedAt;
+    const replacement = daemon.replacement(this.origin);
     const action = replacement.nextControlAction(executionId);
     await replacement.connectExisting();
     this.connectedDaemon = replacement;
+    await this.observeConnectedPresence(replacement.daemonId, previousConnectedAt);
     const acknowledged = await action;
     await this.completePendingCleanup(replacement.daemonId);
     return acknowledged;
@@ -376,6 +415,20 @@ export class HubHarness {
   async observeOfflinePresence(): Promise<void> {
     const daemonId = this.requireDaemon().daemonId;
     await waitFor(async () => (await this.daemon(daemonId)).presence === "offline");
+  }
+
+  private async observeConnectedPresence(
+    daemonId: string,
+    previousConnectedAt: Date | null = null,
+  ): Promise<void> {
+    await waitFor(async () => {
+      const daemon = await this.daemon(daemonId);
+      return (
+        daemon.presence === "connected" &&
+        (previousConnectedAt === null ||
+          daemon.connectedAt?.getTime() !== previousConnectedAt.getTime())
+      );
+    });
   }
 
   async daemon(id?: string): Promise<DaemonRecord> {
@@ -1088,9 +1141,11 @@ export class HubHarness {
     await this.stopApp();
     await this.startApp();
     if (this.connectedDaemon) {
+      const previousConnectedAt = (await this.daemon(this.connectedDaemon.daemonId)).connectedAt;
       const replacement = this.connectedDaemon.replacement(this.origin);
       await replacement.connectExisting();
       this.connectedDaemon = replacement;
+      await this.observeConnectedPresence(replacement.daemonId, previousConnectedAt);
     }
   }
   async restartAppWithoutDaemonReconnect(): Promise<void> {
@@ -1523,7 +1578,7 @@ export class HubHarness {
       serverId: "seed-server",
       daemonPublicKey: "seed-public-key",
       credentialVerifier: "seed-credential-verifier",
-      scopes: ["hub.execution.*"],
+      permissions: ["hub.execute"],
       now: new Date(),
     });
     const config = await store.insertManualBundleRevision({
@@ -1979,10 +2034,11 @@ interface Enrollment {
   daemonId: string;
   slug: string;
   webSocketUrl: string;
-  scopes: string[];
+  permissions: string[];
 }
 class TestDaemon {
   private socket: WebSocket | undefined;
+  private permissions: string[] = [];
   private readonly agents = new Map<string, Record<string, unknown>>();
   private createRequests = 0;
   private readonly controls: HubExecutionControlAction[] = [];
@@ -2021,7 +2077,11 @@ class TestDaemon {
     const id = randomUUID();
     return new TestDaemon(origin, id, `daemon-${id.slice(0, 8)}`, randomUUID());
   }
-  async enroll(token: string, hostname?: string): Promise<Enrollment> {
+  async enroll(
+    token: string,
+    hostname?: string,
+    permissions: readonly string[] = ["hub.execute"],
+  ): Promise<Enrollment> {
     const response = await fetch(`${this.origin}/api/daemons/enroll`, {
       method: "POST",
       headers: {
@@ -2035,10 +2095,12 @@ class TestDaemon {
         daemonPublicKey: "public-key",
         credentialVerifier: createHash("sha256").update(this.credential).digest("base64url"),
         ...(hostname === undefined ? {} : { hostname }),
+        permissions,
       }),
     });
     if (response.status !== 200) throw new Error(`Enrollment failed: ${response.status}`);
     const enrollment = EnrollmentSchema.parse(await response.json());
+    this.permissions = [...enrollment.permissions];
     Object.assign(this, { webSocketUrl: enrollment.webSocketUrl });
     return enrollment;
   }
@@ -2056,6 +2118,41 @@ class TestDaemon {
         daemonPublicKey: "public-key",
         credentialVerifier: createHash("sha256").update(this.credential).digest("base64url"),
       }),
+    });
+    return response.status;
+  }
+
+  async enrollLegacy(token: string): Promise<z.infer<typeof LegacyEnrollmentSchema>> {
+    const response = await fetch(`${this.origin}/api/daemons/enroll`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        daemonId: this.daemonId,
+        idempotencyKey: this.idempotencyKey,
+        serverId: randomUUID(),
+        daemonPublicKey: "public-key",
+        credentialVerifier: createHash("sha256").update(this.credential).digest("base64url"),
+        scopes: ["hub.execution.*"],
+      }),
+    });
+    if (response.status !== 200) throw new Error(`Legacy enrollment failed: ${response.status}`);
+    return LegacyEnrollmentSchema.parse(await response.json());
+  }
+
+  async updatePermissions(
+    permissions: readonly string[],
+    credential = this.credential,
+  ): Promise<number> {
+    const response = await fetch(`${this.origin}/api/daemons/${this.daemonId}`, {
+      method: "PATCH",
+      headers: {
+        authorization: `Bearer ${credential}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ permissions }),
     });
     return response.status;
   }
@@ -2114,6 +2211,7 @@ class TestDaemon {
     replacement.omitSnapshotOnReconnect = this.omitSnapshotOnReconnect;
     replacement.holdControlAck = this.holdControlAck;
     replacement.materializeSpawn = this.materializeSpawn;
+    replacement.permissions = [...this.permissions];
     return replacement;
   }
   omitAgentSnapshotOnReconnect(): void {
@@ -2360,7 +2458,20 @@ class TestDaemon {
     return new Promise((resolve) => this.socket?.once("close", (code) => resolve(code)));
   }
   private receive(data: RawData): void {
-    const envelope = ExecutionSessionRequestSchema.safeParse(JSON.parse(readText(data)));
+    const value = JSON.parse(readText(data)) as unknown;
+    if (isHubHello(value)) {
+      this.send({
+        type: "status",
+        payload: {
+          status: "server_info",
+          serverId: this.daemonId,
+          permissions: this.permissions,
+          features: {},
+        },
+      });
+      return;
+    }
+    const envelope = ExecutionSessionRequestSchema.safeParse(value);
     if (!envelope.success) return;
     const request = envelope.data.message;
     if (request.type === "hub.execution.agent.validate.request") {
@@ -2459,6 +2570,10 @@ class TestDaemon {
   private send(value: unknown): void {
     this.socket?.send(JSON.stringify({ type: "session", message: value }));
   }
+}
+
+function isHubHello(value: unknown): boolean {
+  return typeof value === "object" && value !== null && "type" in value && value.type === "hello";
 }
 
 type HubCreateError =

--- a/src/daemons/test-utils/hub-harness.ts
+++ b/src/daemons/test-utils/hub-harness.ts
@@ -718,6 +718,17 @@ export class HubHarness {
     await waitFor(async () => (await this.execution(id)).daemonAgentId !== null);
     return this.execution(id);
   }
+  async waitForExecutionForTriggerRun(triggerRunId: string): Promise<AgentExecutionRecord> {
+    let execution: AgentExecutionRecord | undefined;
+    await waitFor(async () => {
+      const step = await this.requireDatabase().findWorkflowStepRunByTriggerRun(triggerRunId);
+      if (step === undefined) return false;
+      execution = await this.requireDatabase().findAgentExecutionByWorkflowStepRunId(step.id);
+      return execution !== undefined;
+    });
+    if (execution === undefined) throw new Error("Workflow execution does not exist");
+    return execution;
+  }
   async waitForExecutionStatus(
     id: string,
     status: AgentExecutionRecord["status"],

--- a/src/db/memory.ts
+++ b/src/db/memory.ts
@@ -1520,7 +1520,7 @@ class MemoryDatabase implements Database {
       serverId: input.serverId,
       daemonPublicKey: input.daemonPublicKey,
       credentialVerifier: input.credentialVerifier,
-      scopes: input.scopes,
+      permissions: input.permissions,
       registeredByApiKeyId: token.issuedByApiKeyId ?? null,
       registeredByCliCredentialId: token.issuedByCliCredentialId ?? null,
       status: "active",
@@ -1579,6 +1579,13 @@ class MemoryDatabase implements Database {
       connectedAt: presence === "connected" ? new Date() : value.connectedAt,
       disconnectedAt: presence === "offline" ? new Date() : value.disconnectedAt,
     });
+  }
+  async setDaemonPermissions(id: string, permissions: string[]) {
+    const value = this.daemons.get(id);
+    if (!value) return undefined;
+    const updated = { ...value, permissions: [...permissions] };
+    this.daemons.set(id, updated);
+    return updated;
   }
   async revokeDaemon(id: string) {
     const value = this.daemons.get(id);

--- a/src/db/migrations.integration.test.ts
+++ b/src/db/migrations.integration.test.ts
@@ -551,7 +551,7 @@ describe("database migration application", () => {
         serverId: "phase-one-server",
         daemonPublicKey: "phase-one-public-key",
         credentialVerifier: "phase-one-credential",
-        scopes: ["hub.execution.*"],
+        permissions: ["hub.execute"],
         now: new Date(),
       });
       assert.ok(enrolled !== undefined);

--- a/src/db/pg.ts
+++ b/src/db/pg.ts
@@ -1619,7 +1619,7 @@ class PgDatabase implements Database {
             input.serverId,
             input.daemonPublicKey,
             input.credentialVerifier,
-            JSON.stringify(input.scopes),
+            JSON.stringify(input.permissions),
             consumedToken.issued_by_api_key_id,
             consumedToken.issued_by_cli_credential_id,
           ],
@@ -1643,7 +1643,7 @@ class PgDatabase implements Database {
               input.serverId,
               input.daemonPublicKey,
               input.credentialVerifier,
-              JSON.stringify(input.scopes),
+              JSON.stringify(input.permissions),
               consumedToken.issued_by_api_key_id,
               consumedToken.issued_by_cli_credential_id,
             ],
@@ -1737,6 +1737,15 @@ class PgDatabase implements Database {
       `update daemons set presence = $2, connected_at = case when $2 = 'connected' then now() else connected_at end, disconnected_at = case when $2 = 'offline' then now() else disconnected_at end where id = $1`,
       [id, presence],
     );
+  }
+
+  async setDaemonPermissions(id: string, permissions: string[]): Promise<DaemonRecord | undefined> {
+    const rows = await query<DaemonRow>(
+      this.pool,
+      `update daemons set scopes = $2 where id = $1 and status = 'active' returning *`,
+      [id, JSON.stringify(permissions)],
+    );
+    return rows.rows[0] === undefined ? undefined : toDaemon(rows.rows[0]);
   }
 
   async revokeDaemon(id: string): Promise<boolean> {
@@ -4592,7 +4601,7 @@ function toDaemon(row: DaemonRow): DaemonRecord {
     serverId: row.server_id,
     daemonPublicKey: row.daemon_public_key,
     credentialVerifier: row.credential_verifier,
-    scopes: row.scopes,
+    permissions: semanticDaemonPermissions(row.scopes),
     registeredByApiKeyId: row.registered_by_api_key_id,
     registeredByCliCredentialId: row.registered_by_cli_credential_id,
     status: row.status,
@@ -4602,6 +4611,14 @@ function toDaemon(row: DaemonRow): DaemonRecord {
     lastSeenAt: row.last_seen_at,
     createdAt: row.created_at,
   };
+}
+
+function semanticDaemonPermissions(stored: readonly string[]): string[] {
+  return [
+    ...new Set(
+      stored.map((permission) => (permission === "hub.execution.*" ? "hub.execute" : permission)),
+    ),
+  ];
 }
 
 function toCliAuthorization(row: CliAuthorizationRow): CliAuthorizationRecord {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -604,7 +604,7 @@ export const daemons = pgTable(
     serverId: text("server_id").notNull(),
     daemonPublicKey: text("daemon_public_key").notNull(),
     credentialVerifier: text("credential_verifier").notNull(),
-    scopes: jsonb().$type<string[]>().notNull(),
+    permissions: jsonb("scopes").$type<string[]>().notNull(),
     registeredByApiKeyId: uuid("registered_by_api_key_id"),
     registeredByCliCredentialId: uuid("registered_by_cli_credential_id").references(
       (): AnyPgColumn => organizationCliCredentials.id,

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -170,7 +170,7 @@ export interface DaemonRecord {
   serverId: string;
   daemonPublicKey: string;
   credentialVerifier: string;
-  scopes: string[];
+  permissions: string[];
   registeredByApiKeyId: string | null;
   registeredByCliCredentialId: string | null;
   status: "active" | "revoked";
@@ -847,7 +847,7 @@ export interface EnrollDaemonInput {
   serverId: string;
   daemonPublicKey: string;
   credentialVerifier: string;
-  scopes: string[];
+  permissions: string[];
   now: Date;
 }
 
@@ -1292,6 +1292,7 @@ export interface Database {
   ): Promise<DaemonWriteResult>;
   touchDaemon(id: string): Promise<void>;
   setDaemonPresence(id: string, presence: "offline" | "connected"): Promise<void>;
+  setDaemonPermissions(id: string, permissions: string[]): Promise<DaemonRecord | undefined>;
   revokeDaemon(id: string): Promise<boolean>;
   attachAgentToExecution(
     executionId: string,

--- a/src/e2e/harness/hub-child.ts
+++ b/src/e2e/harness/hub-child.ts
@@ -106,7 +106,7 @@ async function main(): Promise<void> {
       serverId: "hub-e2e-seed-server",
       daemonPublicKey: "hub-e2e-seed-public-key",
       credentialVerifier: "hub-e2e-seed-credential-verifier",
-      scopes: ["hub.execution.*"],
+      permissions: ["hub.execute"],
       now: new Date(),
     });
     daemon = enrollment?.status === "slug_conflict" ? undefined : enrollment;

--- a/src/hub/protocol.ts
+++ b/src/hub/protocol.ts
@@ -50,6 +50,26 @@ export function isHubFinishExecutionToolName(name: string): boolean {
   return name === "hub.finish_execution" || name === "mcp__hub__finish_execution";
 }
 
+export const HubDaemonHelloSchema = z.object({
+  type: z.literal("hello"),
+  clientId: z.string(),
+  clientType: z.literal("hub"),
+  protocolVersion: z.literal(1),
+});
+
+export const HubDaemonServerInfoEnvelopeSchema = z.object({
+  type: z.literal("session"),
+  message: z.object({
+    type: z.literal("status"),
+    payload: z
+      .object({
+        status: z.literal("server_info"),
+        permissions: z.array(z.string()),
+      })
+      .passthrough(),
+  }),
+});
+
 export const HubExecutionAgentStreamEventSchema = z.discriminatedUnion("type", [
   z
     .object({

--- a/src/public-api/built-server.integration.test.ts
+++ b/src/public-api/built-server.integration.test.ts
@@ -109,7 +109,7 @@ builtServerTests("built TanStack public API PostgreSQL contract", () => {
         serverId: "built-test-server",
         daemonPublicKey: `built-public-key-${organizationId}`,
         credentialVerifier: `built-credential-${organizationId}`,
-        scopes: ["hub.execution.*"],
+        permissions: ["hub.execute"],
         now: new Date("2026-08-07T00:00:00.000Z"),
       });
     }

--- a/src/public-operations/database-adapter.ts
+++ b/src/public-operations/database-adapter.ts
@@ -20,7 +20,9 @@ export function createDatabasePublicOperationRepository(
       ]);
       return {
         daemons: daemons
-          .filter(({ status }) => status === "active")
+          .filter(
+            ({ status, permissions }) => status === "active" && permissions.includes("hub.execute"),
+          )
           .map(({ id, slug }) => ({ id, slug })),
         github: connections.github.map(({ id, slug, accountLogin, accountType }) => ({
           slug,

--- a/src/routes/api/daemons/$daemonId.ts
+++ b/src/routes/api/daemons/$daemonId.ts
@@ -4,6 +4,11 @@ import { getApplication } from "../../../server/runtime.js";
 export const Route = createFileRoute("/api/daemons/$daemonId")({
   server: {
     handlers: {
+      PATCH: async ({ request }) =>
+        (await getApplication()).operations.handleDaemonPermissionUpdate(
+          request,
+          new URL(request.url).pathname.split("/")[3] ?? "",
+        ),
       DELETE: async ({ request }) =>
         (await getApplication()).operations.handleDaemonRevocation(
           request,

--- a/src/test-utils/project-configuration.ts
+++ b/src/test-utils/project-configuration.ts
@@ -86,7 +86,7 @@ export async function enrollTestDaemon(
     serverId: "server-1",
     daemonPublicKey: "public-key",
     credentialVerifier: "credential-verifier",
-    scopes: ["hub.execution.*"],
+    permissions: ["hub.execute"],
     now: new Date("2026-08-06T11:00:00.000Z"),
   });
 }

--- a/src/triggers/store.test.ts
+++ b/src/triggers/store.test.ts
@@ -21,7 +21,7 @@ describe("organization trigger store", () => {
       serverId: "server",
       daemonPublicKey: "public-key",
       credentialVerifier: "credential-verifier",
-      scopes: ["hub.execution.*"],
+      permissions: ["hub.execute"],
       now: new Date("2026-08-29T21:00:00.000Z"),
     });
     const store = new OrganizationTriggerStore(database, "org");

--- a/src/workflows/reactions.test.ts
+++ b/src/workflows/reactions.test.ts
@@ -266,7 +266,7 @@ async function runTwoStepWorkflow<
     serverId: "server-1",
     daemonPublicKey: "public-key",
     credentialVerifier: "credential-verifier",
-    scopes: ["hub.execution.*"],
+    permissions: ["hub.execute"],
     now: new Date("2026-08-10T00:00:00.000Z"),
   });
   const { project, revision } = await createActiveProjectConfiguration(


### PR DESCRIPTION
Daemons can register with Hub for identity and presence without automatically granting workflow execution. Operators can explicitly grant or revoke `hub.execute`, and Hub only routes trigger executions to daemons carrying that permission.

## Goals

- Default new daemon enrollment to connected-only access.
- Persist semantic daemon permissions instead of transport-shaped scopes.
- Let authenticated operators update daemon permissions.
- Require `hub.execute` before exposing a daemon to workflow dispatch.
- Negotiate the standard daemon session bootstrap during mixed-version rollout.
- Preserve existing execution access when loading legacy enrolled daemons.

## Non-goals

- Device principals or device-pairing authorization.
- Hub-managed daemon administration.
- Replacing the relay transport or changing end-to-end encryption.
- Granting new authority merely because a daemon is registered.

## Why

Registration and authority are separate product decisions. Keeping them separate lets Hub provide presence and coordination without silently gaining the ability to create workspaces or run agents.

## Verification

- `npm run lint`
- `npm run typecheck`
- `npm run format`
- `npm exec vitest -- run src/daemons` — 134 passed
- `npm exec vitest -- run src/daemons/registry.test.ts` — 17 passed

## Risk surface

The material surfaces are persisted permission migration, workflow daemon selection, permission updates, and mixed-version WebSocket negotiation. The database column remains physically compatible while records are normalized at the boundary.

## Related work

- [getpaseo/paseo#4088](https://github.com/getpaseo/paseo/pull/4088) — Defines the daemon-side semantic permission model, enrollment flow, and common session bootstrap consumed by this Hub change.