### PR TITLE
Support managed Postgres deployments

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -1,5 +1,5 @@
 app = 'paseo-cloud'
-primary_region = 'sin'
+primary_region = 'ord'
 
 [build]
   dockerfile = 'Dockerfile'

--- a/src/db/migrations.integration.test.ts
+++ b/src/db/migrations.integration.test.ts
@@ -539,6 +539,42 @@ describe("database migration application", () => {
     assert.deepEqual(await historicalShape(url), before);
   });
 
+  it("opens an existing database without requiring access to the maintenance database", async () => {
+    const suffix = randomUUID().replaceAll("-", "");
+    const databaseName = `existing_${suffix}`;
+    const username = `runtime_${suffix}`;
+    const password = randomUUID();
+    const adminUrl = postgres.getConnectionUri();
+
+    await poolQuery(
+      adminUrl,
+      `create role ${quoteIdentifier(username)} login password ${quoteLiteral(password)}`,
+    );
+    await poolQuery(
+      adminUrl,
+      `create database ${quoteIdentifier(databaseName)} owner ${quoteIdentifier(username)}`,
+    );
+    await poolQuery(adminUrl, "revoke connect on database postgres from public");
+
+    try {
+      const url = new URL(adminUrl);
+      url.username = username;
+      url.password = password;
+      url.pathname = `/${databaseName}`;
+      const bundle = await postgresDatabaseRuntime(url.toString());
+      try {
+        const result = await bundle.runtime.query<{ database: string }>(
+          "select current_database() as database",
+        );
+        assert.equal(result.rows[0]?.database, databaseName);
+      } finally {
+        await bundle.runtime.close();
+      }
+    } finally {
+      await poolQuery(adminUrl, "grant connect on database postgres to public");
+    }
+  });
+
   it("keeps a pending enrollment token usable before the first daemon connects", async () => {
     const fixture = await createPendingEnrollmentDatabase(postgres);
     const database = await createDatabase(fixture.url);
@@ -2033,6 +2069,14 @@ function databaseUrl(postgres: StartedPostgreSqlContainer, prefix: string): stri
   const url = new URL(postgres.getConnectionUri());
   url.pathname = `/${prefix}_${randomUUID().replaceAll("-", "")}`;
   return url.toString();
+}
+
+function quoteIdentifier(value: string): string {
+  return `"${value.replaceAll('"', '""')}"`;
+}
+
+function quoteLiteral(value: string): string {
+  return `'${value.replaceAll("'", "''")}'`;
 }
 
 async function poolQuery<Row extends QueryRow = QueryRow>(

--- a/src/db/runtime/internal/postgres.ts
+++ b/src/db/runtime/internal/postgres.ts
@@ -119,6 +119,16 @@ class PostgresQueryHandle implements TransactionHandle {
 class PostgresTransactionHandle extends PostgresQueryHandle {}
 
 async function ensureDatabaseExists(connectionString: string): Promise<void> {
+  const targetPool = createPool(connectionString);
+  try {
+    await query(targetPool, "select 1", []);
+    return;
+  } catch (error) {
+    if (!isMissingDatabaseError(error)) throw toDatabaseError(error);
+  } finally {
+    await targetPool.end();
+  }
+
   const targetUrl = new URL(connectionString);
   const databaseName = basename(targetUrl.pathname);
   const postgresUrl = new URL(connectionString);
@@ -135,6 +145,10 @@ async function ensureDatabaseExists(connectionString: string): Promise<void> {
   } finally {
     await pool.end();
   }
+}
+
+function isMissingDatabaseError(error: unknown): boolean {
+  return error instanceof Error && "code" in error && error.code === "3D000";
 }
 
 /** @package */


### PR DESCRIPTION
## Summary
- open an already-provisioned PostgreSQL database without requiring maintenance-database access
- retain automatic database creation when PostgreSQL explicitly reports a missing target
- move the hosted Hub primary region to Chicago alongside managed Postgres

## Why
Managed PostgreSQL providers provision the application database up front and may restrict maintenance-database operations. An existing target should not depend on that access.

## Verification
- `npm run typecheck:node`
- `npm run lint:node`
- formatting check
- `npx vitest run src/db/runtime/internal/postgres.test.ts`
- integration coverage added for an existing database whose application user cannot connect to `postgres`

The integration suite requires a local container runtime, so the new case is delegated to CI. Production data migration is validated separately by complete per-table row counts before cutover.
