### PR TITLE
Publish hosted plan presentation and open signups

### DIFF
--- a/docs/billing.md
+++ b/docs/billing.md
@@ -23,11 +23,10 @@ The coupling runs one direction: `billing` calls
 
 ## Plan catalog
 
-Stripe is the source of truth for plan data; Hub mirrors it into
-`billing_plans`/`billing_plan_prices` (`src/db/schema.ts:1098`) rather than fetching live. Sync
-runs on boot and on `product.created`/`product.updated`/`price.created`/`price.updated` webhooks
-(`syncBillingCatalog`, `src/billing/catalog-sync.ts:23`), always a full resync of every plan
-product — one code path to keep correct instead of an incremental one plus a full one.
+Stripe is the source of truth for prices and entitlement inputs. Hub owns the customer-facing
+plan name, features, and tooltips in `src/billing/plan-presentation.ts`. Catalog sync combines the
+two into `billing_plans`/`billing_plan_prices` rather than making either UI fetch Stripe live. It
+runs on boot and on `product.created`/`product.updated`/`price.created`/`price.updated` webhooks.
 
 Entitlement values live in product metadata as flat scalar keys (`ent_seats_max`,
 `ent_can_invite`, `ent_executions_monthly_limit`), not one JSON blob — Stripe's metadata limits
@@ -37,6 +36,9 @@ ingest gate: a dashboard typo rejects only that product's sync and keeps the las
 logged loudly — nothing ever stamps from an unvalidated template. `plan_version` is
 `hashTemplate()` (`src/entitlements/catalog.ts:260`) of the validated template, because Stripe
 carries no version counter of its own; an off-template organization is a hash mismatch.
+
+Catalog sync stores Hub's presentation with the mirrored price data in `billing_plans.marketing`.
+The public endpoint and Hub billing UI both read that combined record.
 
 Catalog sync uses Stripe's List API, not Search. Search has indexing lag, which would make the
 boot sync racy right after a dashboard edit.
@@ -48,7 +50,7 @@ never the entitlement template.
 
 The Stripe catalog carries a `free` product. It is not a tier Hub sells: it is where the
 entitlement floor is authored, so provisioning and cancellation have a real template to stamp
-instead of a constant in the code. Hosted Hub sells exactly one plan today — Paseo Hub, per user,
+instead of a constant in the code. Hosted Hub sells exactly one plan today — Paseo Hub, per seat,
 per month.
 
 `BillingRuntime.publicCatalog` is the boundary that keeps those two apart. It withholds the free
@@ -57,6 +59,10 @@ every consumer — the plans endpoint, the billing overview, the picker. `subscr
 the other half: an organization stamped with the free record reports **no plan**, which is why the
 billing page reads as a paywall rather than advertising a zero-execution tier as the customer's
 own. No consumer knows the slug exists, and none should learn it.
+
+Every paid plan is seat-based today: checkout and reconciliation report members plus pending
+invitations as Stripe quantity. The public catalog commits that billing unit to its DTO instead of
+making consumers infer it from copy.
 
 Nothing about this is hardcoded to one plan. Publish a second product in Stripe and the picker
 lays out two columns; publish an annual price and the interval switch appears. What is fixed is

--- a/docs/billing.md
+++ b/docs/billing.md
@@ -50,7 +50,7 @@ never the entitlement template.
 
 The Stripe catalog carries a `free` product. It is not a tier Hub sells: it is where the
 entitlement floor is authored, so provisioning and cancellation have a real template to stamp
-instead of a constant in the code. Hosted Hub sells exactly one plan today — Paseo Hub, per seat,
+instead of a constant in the code. Hosted Hub sells exactly one plan today — Hosted, per seat,
 per month.
 
 `BillingRuntime.publicCatalog` is the boundary that keeps those two apart. It withholds the free

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -54,24 +54,38 @@ customer can see. Today the hosted offer is one plan:
   "plans": [
     {
       "slug": "hosted",
-      "name": "Paseo Hub",
-      "marketingFeatures": [
-        "Unlimited daemons",
-        "GitHub, Linear, Slack, and Discord triggers",
-        "Versioned workflows and activity",
-        "Bring your own agents and inference"
+      "name": "Hosted",
+      "billing": {
+        "model": "per_unit",
+        "unit": {
+          "key": "seat",
+          "label": "seat"
+        }
+      },
+      "features": [
+        {
+          "key": "hub-operation",
+          "label": "Paseo operates Hub",
+          "tooltip": null
+        }
       ],
-      "prices": {
-        "monthly": { "unitAmount": 1500, "currency": "eur" },
-        "annual": null
-      }
+      "prices": [
+        {
+          "interval": "monthly",
+          "intervalCount": 1,
+          "unitAmount": 1500,
+          "currency": "eur",
+          "tooltip": "Seats are Hub members and pending invitations. People who only trigger agents through GitHub, Slack, or Discord do not count as seats."
+        }
+      ]
     }
   ]
 }
 ```
 
-`unitAmount` is in the smallest currency unit (cents for `eur`), matching Stripe's own `Price`
-convention. An interval is `null` when the plan has no active price at that interval. A
+`unitAmount` is the amount per billing unit in the smallest currency unit (cents for `eur`),
+matching Stripe's own `Price` convention. An interval is absent when the plan has no active price
+at that interval. A
 self-hosted instance without `STRIPE_SECRET_KEY` 404s this route rather than serving an empty
 catalog — the billing boundary means the route is never registered on an unconfigured instance.
 See docs/billing.md.

--- a/e2e/billing-downgrade.spec.ts
+++ b/e2e/billing-downgrade.spec.ts
@@ -13,7 +13,7 @@ import { test } from "./app.js";
 // webhook is HMAC-signed with a known secret so signature verification is real.
 
 const DIR = "e2e/screenshots/slice-7";
-const PLAN = "Paseo Hub";
+const PLAN = "Hosted";
 
 test.use({ billing: true });
 

--- a/e2e/billing-mobile.spec.ts
+++ b/e2e/billing-mobile.spec.ts
@@ -25,7 +25,7 @@ test("the cardless trial can be started and read on a phone", async ({ hub, page
   });
 
   await test.step("starting the trial leaves a readable trial card behind", async () => {
-    await hub.choosePlan("owner", "Paseo Hub");
+    await hub.choosePlan("owner", "Hosted");
     await hub.deliverSubscriptionWebhook("owner");
     await hub.expectActiveTrial("owner");
     await page.screenshot({ path: `${SCREENSHOT_DIR}/02-active-trial.png`, fullPage: true });

--- a/e2e/billing-subscription.spec.ts
+++ b/e2e/billing-subscription.spec.ts
@@ -42,12 +42,12 @@ test("subscribing lifts an unsubscribed org's invite limit, and replaying the we
   await test.step("open the upgrade dialog and choose a paid plan", async () => {
     await hub.expectCardlessTrialOffer("owner");
     await page.screenshot({ path: `${SLICE_6_DIR}/03-upgrade-dialog.png`, fullPage: true });
-    await hub.choosePlan("owner", "Paseo Hub");
+    await hub.choosePlan("owner", "Hosted");
   });
 
   await test.step("the subscription webhook stamps the paid plan and bills for one seat", async () => {
     await hub.deliverSubscriptionWebhook("owner");
-    await hub.expectCurrentPlan("owner", "Paseo Hub");
+    await hub.expectCurrentPlan("owner", "Hosted");
     await hub.expectActiveTrial("owner");
     // Post-paid seats: with only the owner, Stripe is billed for one seat.
     await hub.expectReportedSeatQuantity("owner", 1);
@@ -64,7 +64,7 @@ test("subscribing lifts an unsubscribed org's invite limit, and replaying the we
 
   await test.step("replaying the subscription webhook changes nothing", async () => {
     await hub.deliverSubscriptionWebhook("owner");
-    await hub.expectCurrentPlan("owner", "Paseo Hub");
+    await hub.expectCurrentPlan("owner", "Hosted");
     await hub.expectPendingInvitation("owner", invitee);
   });
 

--- a/e2e/helpers/hub.ts
+++ b/e2e/helpers/hub.ts
@@ -894,7 +894,6 @@ export class PaseoHub {
         ent_can_invite: "true",
         ent_executions_monthly_limit: "unlimited",
       },
-      marketingFeatures: [],
     });
     await this.deliverBillingWebhook(application, "product.updated", "prod_fixture_hosted");
 
@@ -908,7 +907,6 @@ export class PaseoHub {
       name: "Paseo Hub",
       active: true,
       metadata: { paseo_plan: "false" },
-      marketingFeatures: [],
     });
     await this.deliverBillingWebhook(application, "product.updated", "prod_fixture_hosted");
     // Nothing left to sell. The free record is still mirrored for entitlement stamping, so an
@@ -4188,7 +4186,7 @@ class HubUser {
   private async expectPickerShowsOnlyTheOffer(dialog: Locator): Promise<void> {
     await expect(dialog.getByRole("heading", { level: 3 })).toHaveText([HOSTED_PLAN_NAME]);
     await expect(dialog).toContainText("€15");
-    await expect(dialog).toContainText("per user / month");
+    await expect(dialog).toContainText("per seat / month");
     await expect(dialog).not.toContainText("0 executions");
     await expect(dialog).not.toContainText("Choose your plan");
     await expect(dialog).not.toContainText("Recommended");
@@ -5242,11 +5240,18 @@ const STRIPE_WEBHOOK_SECRET = "whsec_phase_zero_fixture_secret";
 interface PublicBillingPlanExpectation {
   slug: string;
   name: string;
-  marketingFeatures: readonly string[];
-  prices: {
-    monthly: { unitAmount: number; currency: string } | null;
-    annual: { unitAmount: number; currency: string } | null;
+  billing: {
+    model: "per_unit";
+    unit: { key: "seat"; label: "seat" };
   };
+  features: readonly { key: string; label: string; tooltip: string | null }[];
+  prices: readonly {
+    interval: "monthly" | "annual";
+    intervalCount: 1;
+    unitAmount: number;
+    currency: string;
+    tooltip: string | null;
+  }[];
 }
 
 /**
@@ -5258,13 +5263,36 @@ const FIXTURE_BILLING_PLAN_EXPECTATIONS: readonly PublicBillingPlanExpectation[]
   {
     slug: "hosted",
     name: "Paseo Hub",
-    marketingFeatures: [
-      "Unlimited daemons",
-      "GitHub, Linear, Slack, and Discord triggers",
-      "Versioned workflows and activity",
-      "Bring your own agents and inference",
+    billing: {
+      model: "per_unit",
+      unit: {
+        key: "seat",
+        label: "seat",
+      },
+    },
+    features: [
+      {
+        key: "feature-1",
+        label: "Unlimited daemons",
+        tooltip: "Connect any number of development machines.",
+      },
+      {
+        key: "feature-2",
+        label: "GitHub, Linear, Slack, and Discord triggers",
+        tooltip: "Start agents from supported provider events.",
+      },
+      { key: "feature-3", label: "Versioned workflows and activity", tooltip: null },
+      { key: "feature-4", label: "Bring your own agents and inference", tooltip: null },
     ],
-    prices: { monthly: { unitAmount: 1500, currency: "eur" }, annual: null },
+    prices: [
+      {
+        interval: "monthly",
+        intervalCount: 1,
+        unitAmount: 1500,
+        currency: "eur",
+        tooltip: "€15 per seat, billed monthly.",
+      },
+    ],
   },
 ];
 /** The one plan the fixture catalog — and the live Stripe catalog — publishes. */

--- a/e2e/helpers/hub.ts
+++ b/e2e/helpers/hub.ts
@@ -4217,10 +4217,10 @@ class HubUser {
     // The card states what the trial entitles the organization to, unlabelled — the plan name
     // above it is the label.
     await expect(plan.getByRole("listitem")).toHaveText([
-      "Unlimited daemons",
-      "GitHub, Linear, Slack, and Discord triggers",
-      "Versioned workflows and activity",
-      "Bring your own agents and inference",
+      "Paseo operates Hub",
+      "Managed GitHub, Slack, and Discord triggers",
+      "Daemons run on your machines",
+      "Same projects, workflows, and activity",
     ]);
     // One public offer means nothing to change to, so the picker has no entry point here.
     await expect(plan.getByRole("button", { name: "Change plan" })).toHaveCount(0);
@@ -5262,7 +5262,7 @@ interface PublicBillingPlanExpectation {
 const FIXTURE_BILLING_PLAN_EXPECTATIONS: readonly PublicBillingPlanExpectation[] = [
   {
     slug: "hosted",
-    name: "Paseo Hub",
+    name: "Hosted",
     billing: {
       model: "per_unit",
       unit: {
@@ -5272,17 +5272,21 @@ const FIXTURE_BILLING_PLAN_EXPECTATIONS: readonly PublicBillingPlanExpectation[]
     },
     features: [
       {
-        key: "feature-1",
-        label: "Unlimited daemons",
-        tooltip: "Connect any number of development machines.",
+        key: "hub-operation",
+        label: "Paseo operates Hub",
+        tooltip: null,
       },
       {
-        key: "feature-2",
-        label: "GitHub, Linear, Slack, and Discord triggers",
-        tooltip: "Start agents from supported provider events.",
+        key: "managed-triggers",
+        label: "Managed GitHub, Slack, and Discord triggers",
+        tooltip: null,
       },
-      { key: "feature-3", label: "Versioned workflows and activity", tooltip: null },
-      { key: "feature-4", label: "Bring your own agents and inference", tooltip: null },
+      { key: "daemon-location", label: "Daemons run on your machines", tooltip: null },
+      {
+        key: "shared-model",
+        label: "Same projects, workflows, and activity",
+        tooltip: null,
+      },
     ],
     prices: [
       {
@@ -5290,13 +5294,14 @@ const FIXTURE_BILLING_PLAN_EXPECTATIONS: readonly PublicBillingPlanExpectation[]
         intervalCount: 1,
         unitAmount: 1500,
         currency: "eur",
-        tooltip: "€15 per seat, billed monthly.",
+        tooltip:
+          "Seats are Hub members and pending invitations. People who only trigger agents through GitHub, Slack, or Discord do not count as seats.",
       },
     ],
   },
 ];
 /** The one plan the fixture catalog — and the live Stripe catalog — publishes. */
-const HOSTED_PLAN_NAME = "Paseo Hub";
+const HOSTED_PLAN_NAME = "Hosted";
 const HOSTILE_ORIGIN = "https://hostile.invalid";
 const JSON_TYPE = "application/json";
 const PROBLEM_TYPE = "application/problem+json";

--- a/fly.toml
+++ b/fly.toml
@@ -9,8 +9,8 @@ primary_region = 'ord'
   PORT = '3000'
   PASEO_HUB_APP_URL = 'https://hub.paseo.sh'
   PASEO_HUB_TRUSTED_CLIENT_IP_HEADER = 'fly-client-ip'
-  PASEO_REGISTRATION_MODE = 'disabled'
-  PASEO_ORGANIZATION_CREATION = 'disabled'
+  PASEO_REGISTRATION_MODE = 'open'
+  PASEO_ORGANIZATION_CREATION = 'open'
 
 [http_service]
   internal_port = 3000

--- a/src/billing/catalog-sync.test.ts
+++ b/src/billing/catalog-sync.test.ts
@@ -3,10 +3,12 @@ import { Writable } from "node:stream";
 import { describe, it } from "vitest";
 import { z } from "zod";
 import { createMemoryDatabase } from "../db/memory.js";
+import type { Database } from "../db/types.js";
 import { hashTemplate } from "../entitlements/catalog.js";
 import { runWithFailureTracking } from "../failures/index.js";
 import { createLogger } from "../logger.js";
-import { syncBillingCatalog } from "./catalog-sync.js";
+import { syncBillingCatalog as syncBillingCatalogWithPresentations } from "./catalog-sync.js";
+import type { BillingPlanPresentations } from "./plan-presentation.js";
 import type {
   StripeCatalogPrice,
   StripeCatalogProduct,
@@ -44,7 +46,6 @@ function soloProduct(overrides: Partial<StripeCatalogProduct> = {}): StripeCatal
       ent_can_invite: "true",
       ent_executions_monthly_limit: "2000",
     },
-    marketingFeatures: ["5 seats", "2000 executions / month"],
     ...overrides,
   };
 }
@@ -70,6 +71,25 @@ function soloPrices(): StripeCatalogPrice[] {
       interval: "year",
     },
   ];
+}
+
+const TEST_PLAN_PRESENTATIONS: BillingPlanPresentations = {
+  solo: {
+    name: "Solo",
+    features: [
+      {
+        key: "feature-1",
+        label: "5 seats",
+        tooltip: "Includes owners, members, and pending invitations.",
+      },
+      { key: "feature-2", label: "2000 executions / month", tooltip: null },
+    ],
+    priceTooltips: { monthly: "Billed monthly for each seat.", annual: null },
+  },
+};
+
+function syncBillingCatalog(source: StripeCatalogSource, database: Database): Promise<void> {
+  return syncBillingCatalogWithPresentations(source, database, TEST_PLAN_PRESENTATIONS);
 }
 
 describe("syncBillingCatalog", () => {
@@ -108,7 +128,21 @@ describe("syncBillingCatalog", () => {
     assert.equal(plan.slug, "solo");
     assert.equal(plan.name, "Solo");
     assert.equal(plan.active, true);
-    assert.deepEqual(plan.marketing, { features: ["5 seats", "2000 executions / month"] });
+    assert.deepEqual(plan.marketing, {
+      features: [
+        {
+          key: "feature-1",
+          label: "5 seats",
+          tooltip: "Includes owners, members, and pending invitations.",
+        },
+        {
+          key: "feature-2",
+          label: "2000 executions / month",
+          tooltip: null,
+        },
+      ],
+      priceTooltips: { monthly: "Billed monthly for each seat.", annual: null },
+    });
     assert.equal(
       plan.templateHash,
       hashTemplate({

--- a/src/billing/catalog-sync.ts
+++ b/src/billing/catalog-sync.ts
@@ -2,13 +2,16 @@ import type { Database, SyncBillingPlanInput, SyncBillingPlanPriceInput } from "
 import { hashTemplate } from "../entitlements/catalog.js";
 import { reportFailure } from "../failures/index.js";
 import { parsePlanMetadata, type ParsedPlanTemplate } from "./plan-template.js";
+import {
+  HUB_PLAN_PRESENTATIONS,
+  type BillingPlanPresentation,
+  type BillingPlanPresentations,
+} from "./plan-presentation.js";
 import type {
   StripeCatalogPrice,
   StripeCatalogProduct,
   StripeCatalogSource,
 } from "./stripe-catalog-source.js";
-
-const MAX_MARKETING_FEATURES = 15;
 
 /**
  * Mirrors the Stripe plan catalog into `billing_plans`/`billing_plan_prices` as one reconciled
@@ -28,6 +31,7 @@ const MAX_MARKETING_FEATURES = 15;
 export async function syncBillingCatalog(
   source: StripeCatalogSource,
   database: Database,
+  presentations: BillingPlanPresentations = HUB_PLAN_PRESENTATIONS,
 ): Promise<void> {
   const [products, prices] = await Promise.all([source.listProducts(), source.listPrices()]);
   const pricesByProduct = groupPricesByProduct(prices);
@@ -61,8 +65,19 @@ export async function syncBillingCatalog(
       );
       continue;
     }
+    const presentation = presentations[result.data.slug];
+    if (presentation === undefined) {
+      reportFailure(
+        Object.assign(new Error("Billing plan has no Hub presentation"), {
+          code: "missing_plan_presentation",
+        }),
+        { operation: "billing.catalog.product.validate", component: "billing" },
+        { kind: "validation", diagnostic: { productId: product.id } },
+      );
+      continue;
+    }
     await database.syncBillingPlan(
-      planInput(product, result.data, pricesByProduct.get(product.id) ?? []),
+      planInput(product, result.data, pricesByProduct.get(product.id) ?? [], presentation),
     );
   }
   await database.deactivateBillingPlansExcept(products.map((product) => product.id));
@@ -83,14 +98,18 @@ function planInput(
   product: StripeCatalogProduct,
   parsed: ParsedPlanTemplate,
   productPrices: readonly StripeCatalogPrice[],
+  presentation: BillingPlanPresentation,
 ): SyncBillingPlanInput {
   return {
     id: product.id,
     slug: parsed.slug,
-    name: product.name,
+    name: presentation.name,
     template: parsed.template,
     templateHash: hashTemplate(parsed.template),
-    marketing: { features: product.marketingFeatures.slice(0, MAX_MARKETING_FEATURES) },
+    marketing: {
+      features: presentation.features.map((feature) => ({ ...feature })),
+      priceTooltips: { ...presentation.priceTooltips },
+    },
     active: product.active,
     prices: syncablePrices(product.id, productPrices),
   };

--- a/src/billing/index.ts
+++ b/src/billing/index.ts
@@ -20,6 +20,7 @@ import type { BillingPlanPriceInterval } from "../db/types.js";
 import type { StripeBillingClient, StripeSubscriptionState } from "./stripe-billing-client.js";
 import { selectActivePlanPrice } from "./plan-prices.js";
 import { publicBillingPlans, type PublicBillingPlan } from "./public-catalog.js";
+import { HUB_PLAN_PRESENTATIONS, type BillingPlanPresentations } from "./plan-presentation.js";
 
 /** The organization's live seat count (members + pending invitations). Injected by the
  * composition root — the count reads Better Auth tables the `Database` interface does not model,
@@ -36,7 +37,11 @@ export type {
 } from "./stripe-catalog-source.js";
 export type { StripeBillingClient, StripeSubscriptionState } from "./stripe-billing-client.js";
 export { selectActivePlanPrice, AmbiguousPlanPriceError } from "./plan-prices.js";
-export type { PublicBillingPlan, PublicBillingPlanPrice } from "./public-catalog.js";
+export type {
+  PublicBillingPlan,
+  PublicBillingPlanFeature,
+  PublicBillingPlanPrice,
+} from "./public-catalog.js";
 
 /**
  * The four Stripe events that mean "the plan catalog may have changed" — see the plan's
@@ -117,6 +122,8 @@ export interface ComposeBillingOptions {
   billingClient: StripeBillingClient;
   /** Reads an organization's live seat count for post-paid quantity reporting. */
   seatUsage: SeatUsageReader;
+  /** Hub-owned customer-facing plan copy. Production uses the built-in catalog. */
+  presentations?: BillingPlanPresentations;
 }
 
 export interface CreateCheckoutInput {
@@ -184,12 +191,13 @@ export class BillingRuntime {
     private readonly catalogSource: StripeCatalogSource,
     private readonly billingClient: StripeBillingClient,
     private readonly seatUsage: SeatUsageReader,
+    private readonly presentations: BillingPlanPresentations,
   ) {
     this.stripe = new StripeSDK(config.stripeSecretKey);
   }
 
   async syncCatalog(): Promise<void> {
-    await syncBillingCatalog(this.catalogSource, this.database);
+    await syncBillingCatalog(this.catalogSource, this.database, this.presentations);
   }
 
   /**
@@ -596,5 +604,6 @@ export function composeBilling(options: ComposeBillingOptions): BillingRuntime {
     options.catalogSource,
     options.billingClient,
     options.seatUsage,
+    options.presentations ?? HUB_PLAN_PRESENTATIONS,
   );
 }

--- a/src/billing/plan-presentation.ts
+++ b/src/billing/plan-presentation.ts
@@ -1,0 +1,37 @@
+export interface BillingPlanPresentation {
+  name: string;
+  features: readonly { key: string; label: string; tooltip: string | null }[];
+  priceTooltips: { monthly: string | null; annual: string | null };
+}
+
+export type BillingPlanPresentations = Readonly<Record<string, BillingPlanPresentation>>;
+
+export const HUB_PLAN_PRESENTATIONS: BillingPlanPresentations = {
+  free: {
+    name: "Free",
+    features: [],
+    priceTooltips: { monthly: null, annual: null },
+  },
+  hosted: {
+    name: "Hosted",
+    features: [
+      { key: "hub-operation", label: "Paseo operates Hub", tooltip: null },
+      {
+        key: "managed-triggers",
+        label: "Managed GitHub, Slack, and Discord triggers",
+        tooltip: null,
+      },
+      { key: "daemon-location", label: "Daemons run on your machines", tooltip: null },
+      {
+        key: "shared-model",
+        label: "Same projects, workflows, and activity",
+        tooltip: null,
+      },
+    ],
+    priceTooltips: {
+      monthly:
+        "Seats are Hub members and pending invitations. People who only trigger agents through GitHub, Slack, or Discord do not count as seats.",
+      annual: null,
+    },
+  },
+};

--- a/src/billing/provisioning-entitlement.test.ts
+++ b/src/billing/provisioning-entitlement.test.ts
@@ -43,7 +43,10 @@ function freePlan(overrides: Partial<SyncBillingPlanInput> = {}): SyncBillingPla
       meters: { "executions.monthly": { limit: 0 } },
     },
     templateHash: "hash-free",
-    marketing: { features: ["1 seat"] },
+    marketing: {
+      features: [{ key: "feature-1", label: "1 seat", tooltip: null }],
+      priceTooltips: { monthly: null, annual: null },
+    },
     active: true,
     prices: [],
     ...overrides,

--- a/src/billing/public-catalog.test.ts
+++ b/src/billing/public-catalog.test.ts
@@ -48,7 +48,10 @@ const internalFreePlan: SyncBillingPlanInput = {
     meters: { "executions.monthly": { limit: 0 } },
   },
   templateHash: "hash-free",
-  marketing: { features: ["0 executions / month"] },
+  marketing: {
+    features: [{ key: "feature-1", label: "0 executions / month", tooltip: null }],
+    priceTooltips: { monthly: null, annual: null },
+  },
   active: true,
   prices: [
     {
@@ -72,7 +75,16 @@ const hostedPlan: SyncBillingPlanInput = {
     meters: { "executions.monthly": { limit: null } },
   },
   templateHash: "hash-hosted",
-  marketing: { features: ["Unlimited daemons"] },
+  marketing: {
+    features: [
+      {
+        key: "feature-1",
+        label: "Unlimited daemons",
+        tooltip: "Connect any number of development machines.",
+      },
+    ],
+    priceTooltips: { monthly: "€15 per seat, billed monthly.", annual: null },
+  },
   active: true,
   prices: [
     {
@@ -98,8 +110,29 @@ describe("BillingRuntime.publicCatalog", () => {
       {
         slug: "hosted",
         name: "Paseo Hub",
-        marketingFeatures: ["Unlimited daemons"],
-        prices: { monthly: { unitAmount: 1500, currency: "eur" }, annual: null },
+        billing: {
+          model: "per_unit",
+          unit: {
+            key: "seat",
+            label: "seat",
+          },
+        },
+        features: [
+          {
+            key: "feature-1",
+            label: "Unlimited daemons",
+            tooltip: "Connect any number of development machines.",
+          },
+        ],
+        prices: [
+          {
+            interval: "monthly",
+            intervalCount: 1,
+            unitAmount: 1500,
+            currency: "eur",
+            tooltip: "€15 per seat, billed monthly.",
+          },
+        ],
       },
     ]);
   });
@@ -125,7 +158,7 @@ describe("BillingRuntime.publicCatalog", () => {
     const [plan] = await billingOver(database).publicCatalog();
 
     assert.notEqual(plan, undefined);
-    assert.deepEqual(Object.keys(plan!).sort(), ["marketingFeatures", "name", "prices", "slug"]);
+    assert.deepEqual(Object.keys(plan!).sort(), ["billing", "features", "name", "prices", "slug"]);
   });
 
   it("prices an interval only from its exact lookup key, so a mismatched price reads unavailable", async () => {
@@ -146,6 +179,6 @@ describe("BillingRuntime.publicCatalog", () => {
 
     const [plan] = await billingOver(database).publicCatalog();
 
-    assert.deepEqual(plan?.prices, { monthly: null, annual: null });
+    assert.deepEqual(plan?.prices, []);
   });
 });

--- a/src/billing/public-catalog.ts
+++ b/src/billing/public-catalog.ts
@@ -10,16 +10,45 @@ import { selectActivePlanPrice } from "./plan-prices.js";
 export interface PublicBillingPlan {
   slug: string;
   name: string;
-  marketingFeatures: readonly string[];
-  prices: Record<BillingPlanPriceInterval, PublicBillingPlanPrice | null>;
+  billing: {
+    model: "per_unit";
+    unit: {
+      key: "seat";
+      label: "seat";
+    };
+  };
+  features: readonly PublicBillingPlanFeature[];
+  prices: readonly PublicBillingPlanPrice[];
+}
+
+export interface PublicBillingPlanFeature {
+  key: string;
+  label: string;
+  tooltip: string | null;
 }
 
 export interface PublicBillingPlanPrice {
+  interval: BillingPlanPriceInterval;
+  intervalCount: 1;
   unitAmount: number;
   currency: string;
+  tooltip: string | null;
 }
 
-const billingPlanMarketingSchema = z.object({ features: z.array(z.string()) });
+const billingPlanMarketingSchema = z.object({
+  features: z.array(
+    z.object({ key: z.string(), label: z.string(), tooltip: z.string().nullable() }),
+  ),
+  priceTooltips: z.object({ monthly: z.string().nullable(), annual: z.string().nullable() }),
+});
+
+const SEAT_BILLING: PublicBillingPlan["billing"] = {
+  model: "per_unit",
+  unit: {
+    key: "seat",
+    label: "seat",
+  },
+};
 
 /**
  * Turns the catalog mirror into the plans a customer may buy. Two things are withheld: a plan the
@@ -37,27 +66,38 @@ export function publicBillingPlans(
 }
 
 function publicBillingPlan(record: BillingPlanRecord): PublicBillingPlan {
+  const marketing = billingPlanMarketingSchema.parse(record.marketing);
   return {
     slug: record.slug,
     name: record.name,
-    marketingFeatures: billingPlanMarketingSchema.parse(record.marketing).features,
-    prices: {
-      monthly: activePriceForInterval(record, "monthly"),
-      annual: activePriceForInterval(record, "annual"),
-    },
+    billing: SEAT_BILLING,
+    features: marketing.features,
+    prices: (["monthly", "annual"] as const).flatMap((interval) => {
+      const price = activePriceForInterval(record, interval, marketing.priceTooltips[interval]);
+      return price === null ? [] : [price];
+    }),
   };
 }
 
 function activePriceForInterval(
   record: BillingPlanRecord,
   interval: BillingPlanPriceInterval,
+  tooltip: string | null,
 ): PublicBillingPlanPrice | null {
   // Exact `{slug}_{interval}` lookup-key identity, matching checkout. Ambiguous pricing (two active
   // prices for one key) is surfaced as "unavailable" and logged, never displayed as an arbitrary
   // amount the customer might not be charged.
   try {
     const price = selectActivePlanPrice(record.prices, record.slug, interval);
-    return price === undefined ? null : { unitAmount: price.unitAmount, currency: price.currency };
+    return price === undefined
+      ? null
+      : {
+          interval,
+          intervalCount: 1,
+          unitAmount: price.unitAmount,
+          currency: price.currency,
+          tooltip,
+        };
   } catch (error) {
     reportFailure(
       error,

--- a/src/billing/reconcile.test.ts
+++ b/src/billing/reconcile.test.ts
@@ -5,6 +5,7 @@ import { createMemoryDatabase } from "../db/memory.js";
 import type { Database } from "../db/types.js";
 import { normalizeStoredEntitlements } from "../entitlements/catalog.js";
 import { composeBilling, type BillingRuntime } from "./index.js";
+import type { BillingPlanPresentations } from "./plan-presentation.js";
 import type {
   StripeCatalogPrice,
   StripeCatalogProduct,
@@ -35,6 +36,17 @@ const FREE_PRICE = "price_free_monthly";
 const SOLO_PRICE = "price_solo_monthly";
 const TEAM_PRICE = "price_team_monthly";
 
+const TEST_PLAN_PRESENTATIONS: BillingPlanPresentations = Object.fromEntries(
+  ["free", "solo", "team"].map((slug) => [
+    slug,
+    {
+      name: `${slug[0]?.toUpperCase()}${slug.slice(1)}`,
+      features: [],
+      priceTooltips: { monthly: null, annual: null },
+    },
+  ]),
+);
+
 const PRODUCTS: StripeCatalogProduct[] = [
   {
     id: FREE_PRODUCT,
@@ -47,7 +59,6 @@ const PRODUCTS: StripeCatalogProduct[] = [
       ent_can_invite: "false",
       ent_executions_monthly_limit: "0",
     },
-    marketingFeatures: [],
   },
   {
     id: SOLO_PRODUCT,
@@ -60,7 +71,6 @@ const PRODUCTS: StripeCatalogProduct[] = [
       ent_can_invite: "true",
       ent_executions_monthly_limit: "2000",
     },
-    marketingFeatures: [],
   },
   {
     id: TEAM_PRODUCT,
@@ -73,7 +83,6 @@ const PRODUCTS: StripeCatalogProduct[] = [
       ent_can_invite: "true",
       ent_executions_monthly_limit: "unlimited",
     },
-    marketingFeatures: [],
   },
 ];
 
@@ -180,6 +189,7 @@ async function setup(): Promise<{
     catalogSource: new FakeCatalogSource(),
     billingClient,
     seatUsage: () => Promise.resolve(seats.count),
+    presentations: TEST_PLAN_PRESENTATIONS,
   });
   await billing.syncCatalog();
   return { database, billingClient, billing, seats };

--- a/src/billing/stripe-catalog-source.ts
+++ b/src/billing/stripe-catalog-source.ts
@@ -16,11 +16,8 @@ export interface StripeCatalogProduct {
   id: string;
   name: string;
   active: boolean;
-  /** Flat scalar keys, e.g. `ent_seats_max`. See the plan's "Stripe is the plan catalog's
-   * source of truth" section for why this is not one JSON blob. */
+  /** Flat scalar entitlement keys, e.g. `ent_seats_max`. */
   metadata: Record<string, string>;
-  /** Pricing-page bullet copy, from Stripe's own `marketing_features` product field (max 15). */
-  marketingFeatures: readonly string[];
 }
 
 export interface StripeCatalogPrice {

--- a/src/billing/stripe-client.ts
+++ b/src/billing/stripe-client.ts
@@ -39,9 +39,6 @@ export function createStripeCatalogSource(stripeSecretKey: string): StripeCatalo
           name: product.name,
           active: product.active,
           metadata: product.metadata,
-          marketingFeatures: product.marketing_features.flatMap((feature) =>
-            feature.name === undefined ? [] : [feature.name],
-          ),
         });
       }
       return products;

--- a/src/billing/ui/panel.tsx
+++ b/src/billing/ui/panel.tsx
@@ -145,14 +145,14 @@ function PlanIdentity({
 
 /** What the organization is actually entitled to right now, in the plan author's own words. */
 function PlanIncludes({ plan }: { plan: PublicBillingPlan }) {
-  if (plan.marketingFeatures.length === 0) return null;
+  if (plan.features.length === 0) return null;
   return (
     <div className="border-t bg-muted/20 p-5 sm:p-6">
       <ul className="grid gap-2 text-sm sm:grid-cols-2 sm:gap-x-6">
-        {plan.marketingFeatures.map((feature) => (
-          <li key={feature} className="flex items-start gap-2">
+        {plan.features.map((feature) => (
+          <li key={feature.key} className="flex items-start gap-2">
             <Check aria-hidden="true" className="mt-0.5 size-4 shrink-0 text-primary" />
-            <span>{feature}</span>
+            <span title={feature.tooltip ?? undefined}>{feature.label}</span>
           </li>
         ))}
       </ul>

--- a/src/billing/ui/plan-dialog.tsx
+++ b/src/billing/ui/plan-dialog.tsx
@@ -15,6 +15,7 @@ import {
   offeredIntervals,
   planAction,
   planPrice,
+  priceForInterval,
   TRIAL_DAYS,
 } from "./presentation.js";
 
@@ -191,7 +192,7 @@ function PlanCard({
   pending: boolean;
   onChoose: (planSlug: string) => void;
 }) {
-  const price = plan.prices[interval];
+  const price = priceForInterval(plan, interval);
   const action = planAction({ planName: plan.name, price, isCurrent, trialEligible });
   const { amount, unit } = planPrice(price, interval);
   const choose = useCallback(() => onChoose(plan.slug), [onChoose, plan.slug]);
@@ -212,10 +213,10 @@ function PlanCard({
           isCurrent && "hidden sm:grid",
         )}
       >
-        {plan.marketingFeatures.map((feature) => (
-          <li key={feature} className="flex items-start gap-2">
+        {plan.features.map((feature) => (
+          <li key={feature.key} className="flex items-start gap-2">
             <Check aria-hidden="true" className="mt-0.5 size-4 shrink-0 text-primary" />
-            <span>{feature}</span>
+            <span title={feature.tooltip ?? undefined}>{feature.label}</span>
           </li>
         ))}
       </ul>

--- a/src/billing/ui/presentation.test.tsx
+++ b/src/billing/ui/presentation.test.tsx
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { it } from "vitest";
+import type { BillingPlanPriceInterval } from "../../db/types.js";
 import type { BillingOverviewView, PublicBillingPlan } from "../../server/runtime.js";
 /**
  * Copy rules, not the product catalog. Where several plans are needed to pin generic behaviour
@@ -15,18 +16,31 @@ import {
   subscriptionSummary,
 } from "./presentation.js";
 
-const euros = (unitAmount: number) => ({ unitAmount, currency: "eur" });
+const euros = (unitAmount: number, interval: BillingPlanPriceInterval = "monthly") => ({
+  interval,
+  intervalCount: 1 as const,
+  unitAmount,
+  currency: "eur",
+  tooltip: null,
+});
 
 function plan(
   slug: string,
   name: string,
-  prices: Partial<PublicBillingPlan["prices"]>,
+  prices: Partial<Record<BillingPlanPriceInterval, ReturnType<typeof euros>>>,
 ): PublicBillingPlan {
   return {
     slug,
     name,
-    marketingFeatures: [],
-    prices: { monthly: null, annual: null, ...prices },
+    billing: {
+      model: "per_unit",
+      unit: {
+        key: "seat",
+        label: "seat",
+      },
+    },
+    features: [],
+    prices: Object.values(prices),
   };
 }
 
@@ -49,11 +63,11 @@ function subscription(
 it("prices a paid plan as a figure the customer can read at a glance", () => {
   assert.deepEqual(planPrice(euros(1500), "monthly"), {
     amount: "€15",
-    unit: "per user / month",
+    unit: "per seat / month",
   });
-  assert.deepEqual(planPrice(euros(15000), "annual"), {
+  assert.deepEqual(planPrice(euros(15000, "annual"), "annual"), {
     amount: "€150",
-    unit: "per user / year",
+    unit: "per seat / year",
   });
 });
 
@@ -127,12 +141,17 @@ it("disables a plan the catalog does not price at the selected interval", () => 
 
 it("hides the interval switch for a catalog that only charges monthly", () => {
   const plans = [
-    plan("free", "Free", { monthly: euros(0), annual: euros(0) }),
+    plan("free", "Free", { monthly: euros(0), annual: euros(0, "annual") }),
     plan("starter", "Starter", { monthly: euros(1500) }),
   ];
   assert.deepEqual(offeredIntervals(plans), ["monthly"]);
   assert.deepEqual(
-    offeredIntervals([plan("starter", "Starter", { monthly: euros(1500), annual: euros(15000) })]),
+    offeredIntervals([
+      plan("starter", "Starter", {
+        monthly: euros(1500),
+        annual: euros(15000, "annual"),
+      }),
+    ]),
     ["monthly", "annual"],
   );
   // A catalog with nothing priced still has to render at one interval.

--- a/src/billing/ui/presentation.tsx
+++ b/src/billing/ui/presentation.tsx
@@ -35,9 +35,16 @@ export function offeredIntervals(
   plans: readonly PublicBillingPlan[],
 ): readonly BillingPlanPriceInterval[] {
   const offered = INTERVAL_ORDER.filter((interval) =>
-    plans.some((plan) => isPaidPrice(plan.prices[interval])),
+    plans.some((plan) => isPaidPrice(priceForInterval(plan, interval))),
   );
   return offered.length === 0 ? ["monthly"] : offered;
+}
+
+export function priceForInterval(
+  plan: PublicBillingPlan,
+  interval: BillingPlanPriceInterval,
+): PublicBillingPlanPrice | null {
+  return plan.prices.find((price) => price.interval === interval) ?? null;
 }
 
 /** The number of free trial days Stripe grants on a cardless checkout. */
@@ -59,7 +66,7 @@ export function planPrice(
   // Every column shows a figure, including the free tier: the plan's name already says "Free",
   // and repeating the word where the price goes costs the columns their shared baseline.
   if (price.unitAmount === 0) return { amount: formatAmount(price), unit: "forever" };
-  return { amount: formatAmount(price), unit: `per user / ${words.unit}` };
+  return { amount: formatAmount(price), unit: `per seat / ${words.unit}` };
 }
 
 /** A plan a customer pays for, as opposed to the mirrored Free tier. Only these carry a trial. */

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -938,8 +938,15 @@ export interface ConsumeOrganizationUsageInput {
 
 export type BillingPlanPriceInterval = "monthly" | "annual";
 
+export interface BillingPlanMarketingFeature {
+  key: string;
+  label: string;
+  tooltip: string | null;
+}
+
 export interface BillingPlanMarketing {
-  features: readonly string[];
+  features: readonly BillingPlanMarketingFeature[];
+  priceTooltips: Record<BillingPlanPriceInterval, string | null>;
 }
 
 export interface BillingPlanPriceRecord {
@@ -956,7 +963,7 @@ export interface BillingPlanPriceRecord {
  * `template` and `marketing` are `unknown` at the storage boundary, matching
  * `OrganizationEntitlementsRecord` above — both were validated once by `src/billing/` before
  * `syncBillingPlan` was called. The public plans projection re-parses `marketing`
- * (`application-runtime.ts`) and never reads `template` at all; the (future) stamping path
+ * (`src/billing/public-catalog.ts`) and never reads `template` at all; entitlement stamping
  * re-parses `template`.
  */
 export interface BillingPlanRecord {

--- a/src/e2e/harness/browser-billing.ts
+++ b/src/e2e/harness/browser-billing.ts
@@ -10,7 +10,6 @@ export interface FixtureBillingProduct {
   name: string;
   active: boolean;
   metadata: Record<string, string>;
-  marketingFeatures: string[];
 }
 
 export interface FixtureBillingPrice {
@@ -31,7 +30,7 @@ export interface FixtureBillingPrice {
  *   template to stamp; it is not an offer, and `BillingRuntime.publicCatalog` withholds it. Its
  *   zero execution limit is the enforcement floor a customer without a subscription lands on —
  *   E2E asserts it is never rendered as a plan.
- * - `hosted` is the one purchasable plan: Paseo Hub, €15 per user per month, monthly only. There
+ * - `hosted` is the one purchasable plan: Paseo Hub, €15 per seat per month, monthly only. There
  *   is no annual price, so the picker has no interval to switch between.
  *
  * Keep this in step with the live Stripe catalog. A test that needs several plans to exercise
@@ -50,7 +49,6 @@ export const FIXTURE_BILLING_PRODUCTS: readonly FixtureBillingProduct[] = [
       ent_can_invite: "false",
       ent_executions_monthly_limit: "0",
     },
-    marketingFeatures: [],
   },
   {
     id: "prod_fixture_hosted",
@@ -63,12 +61,6 @@ export const FIXTURE_BILLING_PRODUCTS: readonly FixtureBillingProduct[] = [
       ent_can_invite: "true",
       ent_executions_monthly_limit: "unlimited",
     },
-    marketingFeatures: [
-      "Unlimited daemons",
-      "GitHub, Linear, Slack, and Discord triggers",
-      "Versioned workflows and activity",
-      "Bring your own agents and inference",
-    ],
   },
 ];
 

--- a/src/e2e/harness/browser-billing.ts
+++ b/src/e2e/harness/browser-billing.ts
@@ -30,7 +30,7 @@ export interface FixtureBillingPrice {
  *   template to stamp; it is not an offer, and `BillingRuntime.publicCatalog` withholds it. Its
  *   zero execution limit is the enforcement floor a customer without a subscription lands on —
  *   E2E asserts it is never rendered as a plan.
- * - `hosted` is the one purchasable plan: Paseo Hub, €15 per seat per month, monthly only. There
+ * - `hosted` is the one purchasable plan: Hosted, €15 per seat per month, monthly only. There
  *   is no annual price, so the picker has no interval to switch between.
  *
  * Keep this in step with the live Stripe catalog. A test that needs several plans to exercise

--- a/src/routes/api/billing/plans.ts
+++ b/src/routes/api/billing/plans.ts
@@ -4,7 +4,7 @@ import { handleBillingPlans } from "../../../server/runtime.js";
 // Public, unauthenticated, read-only — the contract the marketing site consumes. Registered in
 // the route tree but only answers on a billing-configured (hosted) instance; a self-hosted
 // instance has no billing surface, so the endpoint 404s as if it were never registered. See the
-// plan's "Stripe is the plan catalog's source of truth" section and docs/public-api.md.
+// billing catalog boundary in docs/billing.md.
 export const Route = createFileRoute("/api/billing/plans")({
   server: {
     handlers: {

--- a/src/server/runtime.ts
+++ b/src/server/runtime.ts
@@ -22,7 +22,11 @@ import type { ProviderApplications } from "../provider-applications/index.js";
  * plans are an offer and what a consumer may see of them. Re-exported here so the rest of the app
  * names it without importing across the billing boundary.
  */
-export type { PublicBillingPlan, PublicBillingPlanPrice } from "../billing/index.js";
+export type {
+  PublicBillingPlan,
+  PublicBillingPlanFeature,
+  PublicBillingPlanPrice,
+} from "../billing/index.js";
 
 /** The dashboard billing section: the organization's current plan plus the catalog to upgrade
  * into. Only ever built on a billing-configured instance; the route guards on that. */


### PR DESCRIPTION
Hub now owns the customer-facing hosted plan presentation and serves it with live pricing through the public billing catalog. The hosted deployment also accepts new account registration and lets a new account create its initial organization, completing the trial entry path.

## Goals

- Keep plan names, feature copy, and optional feature/price tooltips in Hub.
- Keep price amounts and entitlement inputs independently managed, then combine them during catalog sync.
- Expose an explicit billing unit and interval-based price list through the public plans DTO.
- Make Hub's billing UI consume the same presentation returned to public clients.
- Open hosted account registration and initial organization creation.

## Non-goals

- Add another paid tier or annual price.
- Move price amounts into application copy.
- Change checkout, subscription reconciliation, or entitlement enforcement.
- Enable open registration by default for self-hosted instances.

## Why

The Hub UI and public website need one source of truth for the same offer. Price configuration is not the right home for customer-facing copy, and the public trial link must lead to an account that can reach a usable organization.

## Verification

- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npx vitest run src/billing/catalog-sync.test.ts src/billing/provisioning-entitlement.test.ts src/billing/public-catalog.test.ts src/billing/reconcile.test.ts src/billing/ui/presentation.test.tsx` — 40 tests passed
- `flyctl config validate -c fly.toml`

## Risk surface

- Public `/api/billing/plans` DTO changes shape; the website consumer lands separately.
- Catalog sync now requires a Hub-owned presentation for every configured plan slug and rejects unpresented products.
- Hosted registration and organization creation become public after deployment; self-hosted defaults remain invite-only/disabled.
