### PR TITLE
Guide daemon setup from the empty state

### DIFF
--- a/e2e/helpers/hub.ts
+++ b/e2e/helpers/hub.ts
@@ -3650,7 +3650,14 @@ class HubUser {
     await expect(this.page).toHaveURL(/\/o\/[^/]+\/daemons$/u);
     await expect(sidebar).toBeHidden();
     await expect(this.page.getByRole("heading", { name: "Daemons", exact: true })).toBeVisible();
-    await expect(this.page.getByText("No daemons registered", { exact: true })).toBeVisible();
+    await expect(this.page.getByText("No daemons connected", { exact: true })).toBeVisible();
+    await expect(
+      this.page.getByText(`paseo hub login ${this.origin}`, { exact: true }),
+    ).toBeVisible();
+    await expect(this.page.getByRole("link", { name: "How to connect a daemon" })).toHaveAttribute(
+      "href",
+      "https://paseo.sh/docs/hub/daemons",
+    );
     const width = await this.page.getByRole("main").evaluate(() => ({
       document: document.documentElement.scrollWidth,
       viewport: document.documentElement.clientWidth,

--- a/src/components/app/data-table.tsx
+++ b/src/components/app/data-table.tsx
@@ -27,7 +27,7 @@ export function DataTable({
 }: {
   label: string;
   columns: readonly DataColumn[];
-  empty: { title: string; description?: string };
+  empty: { title: string; description?: string; action?: ReactNode };
   isEmpty: boolean;
   children: ReactNode;
 }) {
@@ -61,7 +61,9 @@ export function DataTable({
                 <EmptyState
                   title={empty.title}
                   {...(empty.description === undefined ? {} : { description: empty.description })}
-                />
+                >
+                  {empty.action}
+                </EmptyState>
               </TableCell>
             </TableRow>
           ) : (

--- a/src/components/app/empty-state.tsx
+++ b/src/components/app/empty-state.tsx
@@ -1,12 +1,27 @@
+import type { ReactNode } from "react";
+
 /**
- * The one empty state: a short noun phrase and a line of context.
+ * The one empty state: a short noun phrase, a line of context, and — when there is exactly one
+ * thing to do next — the way to do it.
  */
-export function EmptyState({ title, description }: { title: string; description?: string }) {
+export function EmptyState({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description?: string;
+  /** The single next step: a command to copy, a link to the docs, a button. */
+  children?: ReactNode;
+}) {
   return (
     <div className="grid justify-items-center gap-2 px-6 py-12 text-center">
       <p className="text-sm">{title}</p>
       {description === undefined ? null : (
         <p className="max-w-md text-sm text-balance text-muted-foreground">{description}</p>
+      )}
+      {children === undefined ? null : (
+        <div className="mt-4 grid w-full max-w-md justify-items-center gap-3">{children}</div>
       )}
     </div>
   );

--- a/src/daemons/account-daemons.tsx
+++ b/src/daemons/account-daemons.tsx
@@ -1,7 +1,9 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useServerFn } from "@tanstack/react-start";
+import { BookOpen } from "lucide-react";
 import { useCallback, useState, type FormEvent } from "react";
 import { ConfirmMenuItem } from "../components/app/confirm-action.js";
+import { CopyField } from "../components/app/copy-field.js";
 import { DataCell, DataRow, DataTable, type DataColumn } from "../components/app/data-table.js";
 import { PageHeader } from "../components/app/page.js";
 import { RowActions } from "../components/app/row-actions.js";
@@ -28,6 +30,7 @@ import {
 } from "./functions.js";
 import type { Result } from "../contract/respond.js";
 import { DAEMON_MUTATION_KEY } from "../auth/tenant-mutation.js";
+import { daemonLoginCommand } from "./handoff.js";
 import { daemonsQueryKey, refreshDaemons } from "./status.js";
 
 const DAEMON_COLUMNS: readonly DataColumn[] = [
@@ -39,10 +42,39 @@ const DAEMON_COLUMNS: readonly DataColumn[] = [
   { header: "Registered" },
   { header: "", align: "end" },
 ];
+const DAEMON_DOCS_URL = "https://paseo.sh/docs/hub/daemons";
 const DAEMONS_EMPTY = {
-  title: "No daemons registered",
-  description: "Run paseo hub connect with this Hub URL to register one.",
+  title: "No daemons connected",
+  description:
+    "Hub runs your workflows on machines you own. Log in from the machine where your code lives and the CLI offers to connect it.",
+  action: <ConnectDaemonHint />,
 };
+
+/**
+ * The same handoff the operator saw during setup, for the operator who skipped it: the exact
+ * command with this Hub's address already in it, and the page that explains the rest.
+ */
+function ConnectDaemonHint() {
+  // The address the operator reached this Hub at is the address their daemon has to be told.
+  // An empty table is only reached after a client-side query settles, so there is no server
+  // render standing between this and a window.
+  const origin = typeof window === "undefined" ? undefined : window.location.origin;
+  return (
+    <>
+      {origin === undefined ? null : (
+        <div className="w-full text-left">
+          <CopyField label="Command" value={daemonLoginCommand(origin)} />
+        </div>
+      )}
+      <Button asChild variant="outline" size="sm">
+        <a href={DAEMON_DOCS_URL} target="_blank" rel="noreferrer">
+          <BookOpen aria-hidden="true" />
+          How to connect a daemon
+        </a>
+      </Button>
+    </>
+  );
+}
 
 export function DaemonsPanel({
   accountId,


### PR DESCRIPTION
Operators who have not connected a daemon now see the exact `paseo hub login` command for the Hub they are viewing, plus a direct link to the daemon setup guide.

## Goals

- Explain why a Hub needs a connected daemon.
- Present the correct, copyable login command using the current Hub origin.
- Link directly to the daemon connection documentation.
- Keep the empty state usable without horizontal overflow on mobile.

## Non-goals

- Change daemon enrollment or login behavior.
- Redesign populated daemon management.
- Add a second onboarding workflow.

## Why

The previous empty state instructed operators to run `paseo hub connect`, which does not read like an executable CLI path and did not point to the setup documentation. Reusing the existing login-command builder keeps the empty state aligned with onboarding, including the hosted Hub shorthand.

## Verification

- Typecheck, lint, formatting, and production build pass locally.
- The daemon handoff unit suite passes (11 tests).
- Browser coverage now checks the exact login command, docs link, and mobile width.
- The updated page was exercised in Chromium against a fresh local Hub and captured for visual review.

The complete local unit suite could not finish cleanly because this machine has no available container runtime; the failures were confined to PostgreSQL/Testcontainers integration tests. CI provides the required runtime.

## Risk surface

Low. The behavior is limited to empty data tables and the daemon list when it has no rows. The shared empty-state component gains an optional action slot; existing callers render unchanged.