### PR TITLE
Give connection returns one contract and one home

### DIFF
--- a/e2e/apps.spec.ts
+++ b/e2e/apps.spec.ts
@@ -599,7 +599,7 @@ test("every way a provider can send the operator back is answered in that sectio
       {
         provider: "github" as const,
         result: "something_nobody_mapped",
-        copy: "GitHub ended the connection without saying why. Nothing was connected. Start the connection again from this page.",
+        copy: "Hub couldn't finish the GitHub connection. Nothing was connected. Start the connection again from this page.",
         focus: "error" as const,
       },
     ];

--- a/e2e/helpers/hub.ts
+++ b/e2e/helpers/hub.ts
@@ -1373,6 +1373,26 @@ export class PaseoHub {
     }
   }
 
+  async proveSignedOutConnectionReturn(account: Account): Promise<void> {
+    const application = await this.startApplication({ databaseProfile: "fresh" });
+    const context = await this.browser.newContext();
+    try {
+      const user = new HubUser(application, context, await context.newPage());
+      await user.signUp(account);
+      await user.createOrganization("Signed-out return");
+      const signedOut = await user.beginProviderConnection("github");
+      const stranger = await this.browser.newContext();
+      try {
+        const returning = new HubUser(application, stranger, await stranger.newPage());
+        await returning.expectSignedOutConnectionReturn(signedOut, account, "Signed-out return");
+      } finally {
+        await stranger.close();
+      }
+    } finally {
+      await context.close();
+    }
+  }
+
   async proveProviderConnectionConflicts(account: Account): Promise<void> {
     const application = await this.startApplication({
       databaseProfile: "fresh",
@@ -4510,7 +4530,7 @@ class HubUser {
     await this.page.getByRole("button", { name: "Connect GitHub" }).click();
     await expect(this.page).toHaveURL(connectionsUrl);
     await expect(this.page.getByRole("status")).toHaveText(
-      "That provider account is already connected to another organization. Disconnect it there before trying again.",
+      "That account is already connected to another organization. Nothing was connected. Disconnect it there, or pick a different one.",
     );
     await expect(this.page.getByText("No connections", { exact: true })).toBeVisible();
     await this.expectNoProviderIdentity("acme-inc");
@@ -4521,7 +4541,7 @@ class HubUser {
     await this.page.getByRole("button", { name: "Connect Discord" }).click();
     await expect(this.page).toHaveURL(connectionsUrl);
     await expect(this.page.getByRole("status")).toHaveText(
-      "That provider account is already connected to another organization. Disconnect it there before trying again.",
+      "That account is already connected to another organization. Nothing was connected. Disconnect it there, or pick a different one.",
     );
     await expect(this.page.getByText("No connections", { exact: true })).toBeVisible();
     await this.expectNoProviderIdentity("Acme Guild");
@@ -4551,12 +4571,46 @@ class HubUser {
     await this.expectUntrustedConnectionReturnUnavailable(url);
   }
 
+  /**
+   * A return Hub cannot tie to the attempt that started it still belongs to Connections: that
+   * is the only surface that started anything, and the only one that can say what to do next.
+   */
   async expectUntrustedConnectionReturnUnavailable(url: string): Promise<void> {
     await this.page.goto(url);
-    await expect(this.page).toHaveURL(/\/o\/[^/]+\/triggers$/u);
-    await expect(this.page.getByRole("heading", { name: "Triggers", exact: true })).toBeVisible();
+    await expect(this.page).toHaveURL(/\/o\/[^/]+\/connections$/u);
+    await expect(this.page.getByRole("heading", { name: "Connections", level: 1 })).toBeVisible();
     await expect(this.page.getByRole("status")).toHaveText(
-      "This connection link is invalid, expired, or already used. Restart the connection from this Hub.",
+      "That connection link had already been used or had expired, so it was refused. Nothing was connected. Start the connection again from this page.",
+    );
+  }
+
+  /**
+   * A provider return that reaches Hub in a browser with no session. A GitHub App whose setup
+   * URL points at a host the operator never signed in to produces exactly this. It has to come
+   * back to Connections once the person signs in, saying that nothing was connected and why,
+   * instead of blaming app credentials on an unrelated page.
+   */
+  async expectSignedOutConnectionReturn(
+    url: string,
+    account: Account,
+    organizationName: string,
+  ): Promise<void> {
+    await this.page.goto(url);
+    await expect(this.page).toHaveURL(
+      /\/connections\?app=github&result=connection_unauthenticated$/u,
+    );
+    const signIn = this.page.getByRole("form", { name: "Sign in" });
+    await signIn.getByLabel("Email").fill(account.email);
+    await signIn.getByLabel("Password").fill(account.password);
+    await signIn.getByRole("button", { name: "Sign in" }).click();
+    await this.page
+      .getByRole("list", { name: "Organizations" })
+      .getByRole("button", { name: organizationName })
+      .click();
+    await expect(this.page).toHaveURL(/\/o\/[^/]+\/connections$/u);
+    await expect(this.page.getByRole("heading", { name: "Connections", level: 1 })).toBeVisible();
+    await expect(this.page.getByRole("status")).toHaveText(
+      "GitHub sent you back to a Hub address this browser isn't signed in to, so nothing was connected. Sign in there, or ask your Hub operator to check the GitHub app's callback and setup URLs, then start the connection again.",
     );
   }
 
@@ -4749,7 +4803,7 @@ class HubUser {
     await returned;
     await expect(this.page).toHaveURL(connectionsUrl);
     await expect(this.page.getByRole("status")).toHaveText(
-      "GitHub owner approval is required. Retry after approval.",
+      "A GitHub organization owner has to approve this installation. Nothing was connected. Ask an owner to approve the request, then install again.",
     );
   }
 

--- a/e2e/phase-three.spec.ts
+++ b/e2e/phase-three.spec.ts
@@ -89,6 +89,14 @@ test("fails closed for forged, expired, and replayed connection state", async ({
   });
 });
 
+test("returns a callback without a session to Connections", async ({ hub }) => {
+  await hub.proveSignedOutConnectionReturn({
+    name: "Signed-out Alice",
+    email: "signed-out-alice@example.com",
+    password: "signed-out-return-phase-three-password",
+  });
+});
+
 test("keeps provider installation and guild conflicts unavailable", async ({ hub }) => {
   await hub.proveProviderConnectionConflicts({
     name: "Conflict Alice",

--- a/src/connections/functions.ts
+++ b/src/connections/functions.ts
@@ -4,6 +4,13 @@ import { z } from "zod";
 import { respondOk, type Result } from "../contract/respond.js";
 import { respondWithFailure } from "../failures/index.js";
 import { handleConnections } from "../server/runtime.js";
+import {
+  CONNECTION_PROVIDERS,
+  connectionProviderName,
+  type ConnectionProvider,
+} from "./result-contract.js";
+
+export type { ConnectionProvider } from "./result-contract.js";
 
 const githubStatusSchema = z.discriminatedUnion("status", [
   z.object({ status: z.literal("notConfigured") }),
@@ -45,13 +52,12 @@ const scopeSchema = z.object({
   projectSlug: z.string().min(1).optional(),
 });
 const providerSchema = scopeSchema.extend({
-  provider: z.enum(["github", "discord", "slack", "linear"]),
+  provider: z.enum(CONNECTION_PROVIDERS),
 });
 const disconnectSchema = providerSchema.extend({ connectionId: z.string().uuid() });
 const startSchema = z.object({ url: z.string().url() });
 
 export type ConnectionStatus = z.infer<typeof connectionStatusSchema>;
-export type ConnectionProvider = z.infer<typeof providerSchema>["provider"];
 export type ConnectionDisconnectResult = `${ConnectionProvider}_disconnected`;
 
 export const connectionStatus = createServerFn({ method: "GET" })
@@ -81,7 +87,7 @@ export const connectionStatus = createServerFn({ method: "GET" })
 export const startConnection = createServerFn({ method: "POST" })
   .validator(providerSchema)
   .handler(async ({ data }): Promise<Result<{ url: string }>> => {
-    const name = providerName(data.provider);
+    const name = connectionProviderName(data.provider);
     try {
       const operation = CONNECTION_OPERATIONS[data.provider].start;
       const response = await handleConnections(
@@ -115,7 +121,7 @@ export const startConnection = createServerFn({ method: "POST" })
 export const disconnectConnection = createServerFn({ method: "POST" })
   .validator(disconnectSchema)
   .handler(async ({ data }): Promise<Result<{ result: ConnectionDisconnectResult }>> => {
-    const name = providerName(data.provider);
+    const name = connectionProviderName(data.provider);
     try {
       const operation = CONNECTION_OPERATIONS[data.provider].disconnect;
       const response = await handleConnections(
@@ -152,12 +158,6 @@ const CONNECTION_OPERATIONS = {
   slack: { start: "slackStart", disconnect: "slackDisconnect" },
   linear: { start: "linearStart", disconnect: "linearDisconnect" },
 } as const;
-
-function providerName(provider: ConnectionProvider): string {
-  if (provider === "github") return "GitHub";
-  if (provider === "discord") return "Discord";
-  return provider === "slack" ? "Slack" : "Linear";
-}
 
 function connectionContext(
   operation: string,

--- a/src/connections/result-contract.test.ts
+++ b/src/connections/result-contract.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import { describe, it } from "vitest";
+import {
+  CONNECTIONS_RETURN_ROUTE,
+  connectionReturnCopy,
+  connectionReturnUrl,
+  readConnectionReturn,
+  stripConnectionReturn,
+} from "./result-contract.js";
+
+describe("connection return contract", () => {
+  it("round-trips a return through the location it is carried in", () => {
+    const url = connectionReturnUrl("https://hub.test", "/o/acme/connections", {
+      provider: "github",
+      result: "connection_unavailable",
+      reference: "req-1",
+    });
+    assert.equal(
+      url.toString(),
+      "https://hub.test/o/acme/connections?app=github&result=connection_unavailable&reference=req-1",
+    );
+    assert.deepEqual(readConnectionReturn(url), {
+      provider: "github",
+      result: "connection_unavailable",
+      reference: "req-1",
+    });
+  });
+
+  it("only reads returns from providers it knows, and shows unknown results as failures", () => {
+    assert.equal(
+      readConnectionReturn(new URL("https://hub.test/o/acme/connections?result=github_connected")),
+      undefined,
+    );
+    assert.equal(
+      readConnectionReturn(new URL("https://hub.test/o/acme/connections?app=jira&result=x")),
+      undefined,
+    );
+    assert.deepEqual(
+      readConnectionReturn(
+        new URL("https://hub.test/o/acme/connections?app=slack&result=something_nobody_mapped"),
+      ),
+      { provider: "slack", result: "connection_unavailable" },
+    );
+  });
+
+  it("strips every return parameter and says whether there was one", () => {
+    const url = new URL("https://hub.test/apps?app=linear&result=linear_connected&reference=r&x=1");
+    assert.equal(stripConnectionReturn(url), true);
+    assert.equal(url.toString(), "https://hub.test/apps?x=1");
+    assert.equal(stripConnectionReturn(url), false);
+  });
+
+  it("falls back to the connections landing, never the dashboard landing", () => {
+    assert.equal(CONNECTIONS_RETURN_ROUTE, "/connections");
+  });
+
+  it("phrases every outcome with what happened and what to do next", () => {
+    assert.deepEqual(connectionReturnCopy({ provider: "github", result: "github_connected" }), {
+      tone: "success",
+      message: "GitHub connected.",
+    });
+    const unauthenticated = connectionReturnCopy({
+      provider: "github",
+      result: "connection_unauthenticated",
+    });
+    assert.equal(unauthenticated.tone, "error");
+    assert.match(unauthenticated.message, /GitHub sent you back to a Hub address/u);
+    assert.match(unauthenticated.message, /isn't signed in/u);
+    const unavailable = connectionReturnCopy({
+      provider: "discord",
+      result: "connection_unavailable",
+      reference: "req-9",
+    });
+    assert.equal(unavailable.tone, "error");
+    assert.match(unavailable.message, /^Hub couldn't finish the Discord connection\./u);
+    assert.match(unavailable.message, /quote reference req-9/u);
+  });
+});

--- a/src/connections/result-contract.ts
+++ b/src/connections/result-contract.ts
@@ -1,0 +1,192 @@
+import { z } from "zod";
+import { withReference } from "../failures/reference.js";
+
+/**
+ * What a provider sends the browser back with after an install or authorization, and where.
+ *
+ * This is the whole contract between the callback handlers and the connection surfaces: the
+ * handlers only emit values from this module, and only the connection surfaces read them. A
+ * result therefore cannot be displayed by a page that never started a connection, and a code
+ * nobody mapped cannot leak through as raw text.
+ */
+
+export const CONNECTION_PROVIDERS = ["github", "discord", "slack", "linear"] as const;
+export type ConnectionProvider = (typeof CONNECTION_PROVIDERS)[number];
+
+export const connectionResultSchema = z.enum([
+  "github_connected",
+  "discord_connected",
+  "slack_connected",
+  "linear_connected",
+  "github_disconnected",
+  "discord_disconnected",
+  "slack_disconnected",
+  "linear_disconnected",
+  "github_cancelled",
+  "discord_cancelled",
+  "slack_cancelled",
+  "linear_cancelled",
+  "github_approval_required",
+  "slack_bot_failed",
+  "provider_not_configured",
+  /** The state was forged, expired, already used, or belongs to a different session. */
+  "connection_invalid",
+  /** The provider account is already bound to another organization. */
+  "connection_conflict",
+  /** The browser that came back from the provider carried no Hub session. */
+  "connection_unauthenticated",
+  /** Hub itself failed; the reference correlates the banner with the operator log. */
+  "connection_unavailable",
+]);
+export type ConnectionResult = z.infer<typeof connectionResultSchema>;
+
+export interface ConnectionReturn {
+  provider: ConnectionProvider;
+  result: ConnectionResult;
+  /** Failure report ID, present only when the result is Hub's own fault. */
+  reference?: string;
+}
+
+export interface ConnectionReturnCopy {
+  tone: "success" | "error";
+  message: string;
+}
+
+/**
+ * Where a callback lands when the attempt that started it cannot be read, so neither the
+ * organization nor the surface is known. The connections landing forwards to the active
+ * organization's connections page; when no organization is active yet, the shell's own gates
+ * render first and the return survives in the query until a connections surface reads it.
+ * Never the dashboard landing: that is not a connections surface.
+ */
+export const CONNECTIONS_RETURN_ROUTE = "/connections";
+
+const RETURN_PARAMS = { provider: "app", result: "result", reference: "reference" } as const;
+
+/** The query the connections landing route accepts and forwards untouched. */
+export const connectionReturnSearchSchema = z.object({
+  [RETURN_PARAMS.provider]: z.string().optional(),
+  [RETURN_PARAMS.result]: z.string().optional(),
+  [RETURN_PARAMS.reference]: z.string().optional(),
+});
+
+export function connectionReturnUrl(
+  publicBaseUrl: string,
+  returnRoute: string,
+  value: ConnectionReturn,
+): URL {
+  const url = new URL(returnRoute, publicBaseUrl);
+  url.searchParams.set(RETURN_PARAMS.provider, value.provider);
+  url.searchParams.set(RETURN_PARAMS.result, value.result);
+  if (value.reference !== undefined) url.searchParams.set(RETURN_PARAMS.reference, value.reference);
+  return url;
+}
+
+/**
+ * Reads a return out of a location. Absent or malformed providers mean there is nothing to show.
+ * A result code this build does not know is still a failed connection, so it is shown as one
+ * instead of being echoed or dropped.
+ */
+export function readConnectionReturn(url: URL): ConnectionReturn | undefined {
+  const provider = z
+    .enum(CONNECTION_PROVIDERS)
+    .safeParse(url.searchParams.get(RETURN_PARAMS.provider));
+  const result = url.searchParams.get(RETURN_PARAMS.result);
+  if (!provider.success || result === null) return undefined;
+  const reference = url.searchParams.get(RETURN_PARAMS.reference);
+  return {
+    provider: provider.data,
+    result: connectionResultSchema.catch("connection_unavailable").parse(result),
+    ...(reference === null ? {} : { reference }),
+  };
+}
+
+/** Removes a return from a location. Returns whether there was one to remove. */
+export function stripConnectionReturn(url: URL): boolean {
+  const present = Object.values(RETURN_PARAMS).some((name) => url.searchParams.has(name));
+  for (const name of Object.values(RETURN_PARAMS)) url.searchParams.delete(name);
+  return present;
+}
+
+const PROVIDER_NAMES: Readonly<Record<ConnectionProvider, string>> = {
+  github: "GitHub",
+  discord: "Discord",
+  slack: "Slack",
+  linear: "Linear",
+};
+
+export function connectionProviderName(provider: ConnectionProvider): string {
+  return PROVIDER_NAMES[provider];
+}
+
+/**
+ * Every outcome says what happened, whether anything changed, and what to do next. A
+ * cancellation is neutral because nothing about it is broken.
+ */
+export function connectionReturnCopy(value: ConnectionReturn): ConnectionReturnCopy {
+  const copy = RETURN_COPY[value.result](connectionProviderName(value.provider));
+  if (value.reference === undefined) return copy;
+  return { ...copy, message: withReference(copy.message, value.reference) };
+}
+
+const RETURN_COPY: Readonly<Record<ConnectionResult, (name: string) => ConnectionReturnCopy>> = {
+  github_connected: connected,
+  discord_connected: connected,
+  slack_connected: connected,
+  linear_connected: connected,
+  github_disconnected: disconnected,
+  discord_disconnected: disconnected,
+  slack_disconnected: disconnected,
+  linear_disconnected: disconnected,
+  github_cancelled: (name) => cancelled("Installation", name),
+  slack_cancelled: (name) => cancelled("Installation", name),
+  discord_cancelled: (name) => cancelled("Authorization", name),
+  linear_cancelled: (name) => cancelled("Authorization", name),
+  github_approval_required: () => ({
+    tone: "error",
+    message:
+      "A GitHub organization owner has to approve this installation. Nothing was connected. Ask an owner to approve the request, then install again.",
+  }),
+  slack_bot_failed: () => ({
+    tone: "error",
+    message:
+      "Slack installed the app without every permission Hub needs. Nothing was saved. Reapply the manifest under Features → OAuth & Permissions, then install again.",
+  }),
+  provider_not_configured: () => ({
+    tone: "error",
+    message: "There are no saved credentials to connect yet. Verify and save the app first.",
+  }),
+  connection_invalid: () => ({
+    tone: "error",
+    message:
+      "That connection link had already been used or had expired, so it was refused. Nothing was connected. Start the connection again from this page.",
+  }),
+  connection_conflict: () => ({
+    tone: "error",
+    message:
+      "That account is already connected to another organization. Nothing was connected. Disconnect it there, or pick a different one.",
+  }),
+  connection_unauthenticated: (name) => ({
+    tone: "error",
+    message: `${name} sent you back to a Hub address this browser isn't signed in to, so nothing was connected. Sign in there, or ask your Hub operator to check the ${name} app's callback and setup URLs, then start the connection again.`,
+  }),
+  connection_unavailable: (name) => ({
+    tone: "error",
+    message: `Hub couldn't finish the ${name} connection. Nothing was connected. Start the connection again from this page.`,
+  }),
+};
+
+function connected(name: string): ConnectionReturnCopy {
+  return { tone: "success", message: `${name} connected.` };
+}
+
+function disconnected(name: string): ConnectionReturnCopy {
+  return { tone: "success", message: `${name} disconnected.` };
+}
+
+function cancelled(action: "Installation" | "Authorization", name: string): ConnectionReturnCopy {
+  return {
+    tone: "success",
+    message: `${action} cancelled at ${name}. Nothing changed. Start again when you're ready.`,
+  };
+}

--- a/src/connections/result.ts
+++ b/src/connections/result.ts
@@ -1,42 +1,28 @@
 import { useEffect, useState } from "react";
+import {
+  readConnectionReturn,
+  stripConnectionReturn,
+  type ConnectionReturn,
+} from "./result-contract.js";
 
-export function useConnectionResult() {
-  const state = useState(readConnectionResult);
-  useEffect(stripConnectionResult, []);
+/**
+ * The return a connection surface was opened with, read once on mount and cleared from the
+ * location after the router commits so a reload or the initial URL cannot replay it. The setter
+ * lets the surface report an outcome it produced itself, such as a disconnect.
+ */
+export function useConnectionReturn() {
+  const state = useState(readCurrentConnectionReturn);
+  useEffect(stripCurrentConnectionReturn, []);
   return state;
 }
 
-export function connectionResultCopy(result: string): string {
-  if (result === "github_connected") return "GitHub connected.";
-  if (result === "discord_connected") return "Discord connected.";
-  if (result === "slack_connected") return "Slack connected.";
-  if (result === "linear_connected") return "Linear connected.";
-  if (result === "github_disconnected") return "GitHub disconnected.";
-  if (result === "discord_disconnected") return "Discord disconnected.";
-  if (result === "slack_disconnected") return "Slack disconnected.";
-  if (result === "linear_disconnected") return "Linear disconnected.";
-  if (result === "github_approval_required") {
-    return "GitHub owner approval is required. Retry after approval.";
-  }
-  if (result === "provider_not_configured") return "The provider is not configured.";
-  if (result === "connection_invalid") {
-    return "This connection link is invalid, expired, or already used. Restart the connection from this Hub.";
-  }
-  if (result === "connection_conflict") {
-    return "That provider account is already connected to another organization. Disconnect it there before trying again.";
-  }
-  return "The provider connection did not complete. Restart it from Connections; if it repeats, check the app credentials and provider status.";
-}
-
-function readConnectionResult(): string | undefined {
+function readCurrentConnectionReturn(): ConnectionReturn | undefined {
   if (typeof window === "undefined") return undefined;
-  return new URL(window.location.href).searchParams.get("result") ?? undefined;
+  return readConnectionReturn(new URL(window.location.href));
 }
 
-function stripConnectionResult(): void {
+function stripCurrentConnectionReturn(): void {
   const url = new URL(window.location.href);
-  if (!url.searchParams.has("app") && !url.searchParams.has("result")) return;
-  url.searchParams.delete("app");
-  url.searchParams.delete("result");
+  if (!stripConnectionReturn(url)) return;
   window.history.replaceState(window.history.state, "", url);
 }

--- a/src/connections/shared.test.ts
+++ b/src/connections/shared.test.ts
@@ -1,8 +1,9 @@
 import assert from "node:assert/strict";
 import { Writable } from "node:stream";
 import { describe, it } from "vitest";
+import { ProductRequestError } from "../auth/organization-access.js";
 import { createLogger } from "../logger.js";
-import { connectionCallbackFailure } from "./shared.js";
+import { CONNECTIONS_RETURN_ROUTE, connectionCallbackFailure } from "./shared.js";
 
 class CaptureStream extends Writable {
   readonly chunks: string[] = [];
@@ -15,6 +16,10 @@ class CaptureStream extends Writable {
     this.chunks.push(chunk.toString());
     callback();
   }
+
+  text(): string {
+    return this.chunks.join("");
+  }
 }
 
 describe("connection callback failures", () => {
@@ -26,12 +31,15 @@ describe("connection callback failures", () => {
       error: new Error(`github oauth exchange failed: 401 ${token}`),
       provider: "github",
       phase: "authorization",
+      request: new Request("https://hub.test/api/integrations/github/callback?state=s&code=c", {
+        headers: { cookie: "session=secret" },
+      }),
       applicationBaseUrl: "https://hub.test",
       returnRoute: "/o/acme/connections",
       log: createLogger(stream),
     });
 
-    const output = stream.chunks.join("");
+    const output = stream.text();
     assert.match(output, /connection\.callback\.authorization failed/u);
     assert.match(output, /failureKind/u);
     assert.match(output, /stack/u);
@@ -40,10 +48,42 @@ describe("connection callback failures", () => {
     assert.match(output, /"type":"Error"/u);
     assert.doesNotMatch(output, /github oauth exchange failed/u);
     assert.equal(output.includes(token), false);
+    assert.equal(output.includes("session=secret"), false);
+    assert.match(output, /"host":"hub.test"/u);
+    assert.match(output, /"sessionCookiePresent":true/u);
+    assert.equal(response.status, 303);
+    const location = new URL(response.headers.get("location")!);
+    assert.equal(location.origin + location.pathname, "https://hub.test/o/acme/connections");
+    assert.equal(location.searchParams.get("app"), "github");
+    assert.equal(location.searchParams.get("result"), "connection_unavailable");
+    const reference = location.searchParams.get("reference");
+    assert.notEqual(reference, null);
+    assert.match(output, new RegExp(`"requestId":"${reference}"`, "u"));
+  });
+
+  it("names a return that reached Hub without a session, with the host it reached", () => {
+    const stream = new CaptureStream();
+
+    const response = connectionCallbackFailure({
+      error: new ProductRequestError(401, "unauthenticated"),
+      provider: "github",
+      phase: "setup",
+      request: new Request("https://hub.test/api/integrations/github/setup?state=s", {
+        headers: { host: "hub.fly.example" },
+      }),
+      applicationBaseUrl: "https://hub.test",
+      returnRoute: CONNECTIONS_RETURN_ROUTE,
+      log: createLogger(stream),
+    });
+
     assert.equal(response.status, 303);
     assert.equal(
       response.headers.get("location"),
-      "https://hub.test/o/acme/connections?app=github&result=connection_unavailable",
+      "https://hub.test/connections?app=github&result=connection_unauthenticated",
     );
+    const output = stream.text();
+    assert.match(output, /"failureKind":"authentication"/u);
+    assert.match(output, /"host":"hub.fly.example"/u);
+    assert.match(output, /"sessionCookiePresent":false/u);
   });
 });

--- a/src/connections/shared.ts
+++ b/src/connections/shared.ts
@@ -12,6 +12,14 @@ import type {
 import { logger } from "../logger.js";
 import { classifyFailure, reportFailure, type FailureKind } from "../failures/index.js";
 import { resolveRouteTenant } from "../projects/access.js";
+import {
+  CONNECTIONS_RETURN_ROUTE,
+  connectionReturnUrl,
+  type ConnectionProvider,
+  type ConnectionResult,
+} from "./result-contract.js";
+
+export { CONNECTIONS_RETURN_ROUTE } from "./result-contract.js";
 
 export const CONNECTION_ATTEMPT_LIFETIME_MINUTES = 10;
 
@@ -78,20 +86,25 @@ export function stateHash(state: string): string {
 export function connectionResult(
   publicBaseUrl: string,
   returnRoute: string,
-  result: string,
-  provider?: "github" | "discord" | "slack" | "linear",
+  result: ConnectionResult,
+  provider: ConnectionProvider,
+  reference?: string,
 ): Response {
-  const url = new URL(returnRoute, publicBaseUrl);
-  if (provider !== undefined) url.searchParams.set("app", provider);
-  url.searchParams.set("result", result);
-  return Response.redirect(url, 303);
+  return Response.redirect(
+    connectionReturnUrl(publicBaseUrl, returnRoute, {
+      provider,
+      result,
+      ...(reference === undefined ? {} : { reference }),
+    }),
+    303,
+  );
 }
 
 export async function cancelledConnectionResult(input: {
   auth: AuthServer;
   database: Database;
   request: Request;
-  provider: "github" | "discord" | "slack" | "linear";
+  provider: ConnectionProvider;
   phase:
     | "github_user_authorization"
     | "discord_authorization"
@@ -101,7 +114,7 @@ export async function cancelledConnectionResult(input: {
   applicationBaseUrl: string;
 }): Promise<Response> {
   let callbackOrigin = input.applicationBaseUrl;
-  let returnRoute = "/";
+  let returnRoute: string = CONNECTIONS_RETURN_ROUTE;
   try {
     const access = await callbackConnectionAccess(input.auth, input.request);
     const attempt = await input.database.readConnectionAttempt({
@@ -127,6 +140,7 @@ export async function cancelledConnectionResult(input: {
       error,
       provider: input.provider,
       phase: `${input.phase}_cancelled`,
+      request: input.request,
       applicationBaseUrl: callbackOrigin,
       returnRoute,
     });
@@ -135,34 +149,41 @@ export async function cancelledConnectionResult(input: {
 
 export function connectionCallbackFailure(input: {
   error: unknown;
-  provider: "github" | "discord" | "slack" | "linear";
+  provider: ConnectionProvider;
   phase: string;
+  /**
+   * The provider's redirect as it arrived. Which host it reached and whether it carried a
+   * session are the two facts that explain a return Hub could not tie to its attempt.
+   */
+  request: Request;
   applicationBaseUrl: string;
   returnRoute: string;
   log?: Pick<Logger, "warn" | "error">;
 }): Response {
   const log = input.log ?? logger;
   const kind = classifyFailure(input.error);
-  reportFailure(
+  const report = reportFailure(
     input.error,
     {
       operation: `connection.callback.${input.phase}`,
       component: "connections",
       provider: input.provider,
     },
-    { logger: log, kind },
+    { logger: log, kind, diagnostic: callbackEvidence(input.request) },
   );
+  const result = connectionCallbackResult(kind);
   return connectionResult(
     input.applicationBaseUrl,
     input.returnRoute,
-    connectionCallbackResult(kind),
+    result,
     input.provider,
+    result === "connection_unavailable" ? report.requestId : undefined,
   );
 }
 
 export function connectionActionFailure(
   error: unknown,
-  provider: "github" | "discord" | "slack" | "linear",
+  provider: ConnectionProvider,
   action: "start" | "disconnect",
 ): Response {
   const accessDenied =
@@ -186,10 +207,16 @@ export function connectionActionFailure(
   return Response.json({ error: "connection_unavailable" }, { status: 503 });
 }
 
-function connectionCallbackResult(kind: FailureKind): string {
-  if (kind === "validation" || kind === "authentication" || kind === "forbidden") {
-    return "connection_invalid";
-  }
+function callbackEvidence(request: Request): Record<string, unknown> {
+  return {
+    host: request.headers.get("host") ?? new URL(request.url).host,
+    sessionCookiePresent: request.headers.has("cookie"),
+  };
+}
+
+function connectionCallbackResult(kind: FailureKind): ConnectionResult {
+  if (kind === "authentication") return "connection_unauthenticated";
+  if (kind === "validation" || kind === "forbidden") return "connection_invalid";
   if (kind === "conflict") return "connection_conflict";
   return "connection_unavailable";
 }

--- a/src/failures/index.test.ts
+++ b/src/failures/index.test.ts
@@ -32,6 +32,13 @@ describe("failure boundary", () => {
       "rateLimited",
     );
     assert.equal(classifyFailure(new Error("boom"), 503), "internal");
+    assert.equal(
+      classifyFailure(
+        Object.assign(new Error("unauthenticated"), { status: 401, code: "unauthenticated" }),
+      ),
+      "authentication",
+    );
+    assert.equal(classifyFailure(Object.assign(new Error("missing"), { status: 404 })), "notFound");
   });
 
   it("tracks whether the active HTTP request already reported a failure", () => {

--- a/src/failures/index.ts
+++ b/src/failures/index.ts
@@ -3,6 +3,9 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import type { Logger } from "pino";
 import { respondError, type Err } from "../contract/respond.js";
 import { errorForLog, logger as defaultLogger, redact } from "../logger.js";
+import { withReference } from "./reference.js";
+
+export { withReference } from "./reference.js";
 
 export type FailureKind =
   | "validation"
@@ -139,17 +142,8 @@ export function respondWithFailure(
   });
 }
 
-/**
- * Appends the correlation ID, after the copy that is actually useful and with the one instruction
- * that makes it worth reading. A bare identifier at the end of a sentence tells the reader
- * nothing about what they are supposed to do with it.
- */
-export function withReference(message: string, requestId: string): string {
-  return `${message} If it happens again, quote reference ${requestId} when reporting it.`;
-}
-
 export function classifyFailure(error: unknown, status?: number): FailureKind {
-  const statusKind = classifyStatus(status);
+  const statusKind = classifyStatus(status ?? errorStatus(error));
   if (statusKind !== undefined) return statusKind;
   const code = errorProperty(error, "code") ?? errorProperty(error, "reason");
   const codeKind = code === undefined ? undefined : FAILURE_CODES.get(code);
@@ -166,6 +160,7 @@ const FAILURE_CODES = new Map<string, FailureKind>([
   ["invalidOrigin", "validation"],
   ["invalid_request", "validation"],
   ["authentication", "authentication"],
+  ["unauthenticated", "authentication"],
   ["unauthorized", "authentication"],
   ["forbidden", "forbidden"],
   ["notFound", "notFound"],
@@ -236,6 +231,13 @@ function errorProperty(error: unknown, property: string): string | undefined {
   if (typeof error !== "object" || error === null) return undefined;
   const value: unknown = Reflect.get(error, property);
   return typeof value === "string" ? value : undefined;
+}
+
+/** Product and upstream request errors carry the HTTP status they answered with. */
+function errorStatus(error: unknown): number | undefined {
+  if (typeof error !== "object" || error === null) return undefined;
+  const value: unknown = Reflect.get(error, "status");
+  return typeof value === "number" ? value : undefined;
 }
 
 function errorCode(error: unknown): string | undefined {

--- a/src/failures/reference.ts
+++ b/src/failures/reference.ts
@@ -1,0 +1,10 @@
+/**
+ * Appends the correlation ID, after the copy that is actually useful and with the one instruction
+ * that makes it worth reading. A bare identifier at the end of a sentence tells the reader
+ * nothing about what they are supposed to do with it.
+ *
+ * Pure so browser bundles can phrase a reference the same way the server does.
+ */
+export function withReference(message: string, requestId: string): string {
+  return `${message} If it happens again, quote reference ${requestId} when reporting it.`;
+}

--- a/src/projects/panels.tsx
+++ b/src/projects/panels.tsx
@@ -2,30 +2,21 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useNavigate } from "@tanstack/react-router";
 import { useServerFn } from "@tanstack/react-start";
-import { ChevronRight } from "lucide-react";
-import { useState, type FormEvent, type ReactNode } from "react";
+import { type FormEvent, type ReactNode } from "react";
 import { CONNECTION_MUTATION_KEY } from "../auth/tenant-mutation.js";
 import { useActiveAccount } from "../auth/active-account.js";
 import { ConfirmAction, ConfirmMenuItem } from "../components/app/confirm-action.js";
 import { DataCell, DataRow, DataTable } from "../components/app/data-table.js";
-import { EmptyState } from "../components/app/empty-state.js";
 import { PageHeader } from "../components/app/page.js";
 import { RowActions } from "../components/app/row-actions.js";
 import { Section } from "../components/app/section.js";
 import { StatusPill } from "../components/app/status-pill.js";
 import { ProviderGlyph } from "../connections/provider-glyph.js";
-import { connectionResultCopy, useConnectionResult } from "../connections/result.js";
-import { cn } from "../lib/utils.js";
+import { useConnectionReturn } from "../connections/result.js";
+import { connectionReturnCopy, type ConnectionReturnCopy } from "../connections/result-contract.js";
 import { Alert, AlertDescription } from "../components/ui/alert.js";
 import { Button } from "../components/ui/button.js";
 import { DaemonsPanel } from "../daemons/account-daemons.js";
-import {
-  Dialog,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "../components/ui/dialog.js";
 import { Field, FieldLabel } from "../components/ui/field.js";
 import { Input } from "../components/ui/input.js";
 import type { Result } from "../contract/respond.js";
@@ -51,143 +42,7 @@ import {
   type OrganizationSnapshot,
   type ProjectSnapshot,
 } from "./panel-state.js";
-import {
-  archiveProject,
-  activityRunSnapshot,
-  createProject,
-  updateProjectSlug,
-} from "./functions.js";
-export function ProjectsPanel() {
-  const tenant = useRouteTenant();
-  const queryClient = useQueryClient();
-  const scope = { organizationSlug: tenant.organization.slug };
-  const snapshot = useOrganizationSnapshot();
-  const [connectionResult] = useConnectionResult();
-  const [creating, setCreating] = useState(false);
-  const create = useProjectCommand(createProject, queryClient, scope);
-  if (!snapshot.ok) return snapshot.element;
-  const data = snapshot.data;
-  const submitCreate = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    const form = new FormData(event.currentTarget);
-    create.mutate({
-      data: {
-        ...scope,
-        name: formString(form, "name"),
-        slug: formString(form, "slug"),
-      },
-    });
-    setCreating(false);
-  };
-  return (
-    <>
-      <PageHeader title="Projects" description="Select a project to work in.">
-        {data.capabilities.manageResources ? (
-          <Button onClick={() => setCreating(true)}>New project</Button>
-        ) : null}
-      </PageHeader>
-      {connectionResult === undefined ? null : (
-        <Alert role="status" className="mb-6">
-          <AlertDescription>{connectionResultCopy(connectionResult)}</AlertDescription>
-        </Alert>
-      )}
-      <CommandError mutations={[create]} />
-      {data.projects.length === 0 ? (
-        <div className="rounded-lg border bg-card">
-          <EmptyState
-            title="No projects"
-            description="Create a project to route provider events at a daemon."
-          />
-        </div>
-      ) : (
-        <ul aria-label="Projects" className="grid gap-2">
-          {data.projects.map((project) => (
-            <li key={project.id}>
-              <ProjectCard
-                project={project}
-                to={`/o/${data.organization.slug}/projects/${project.slug}/overview`}
-              />
-            </li>
-          ))}
-        </ul>
-      )}
-      <Dialog open={creating} onOpenChange={setCreating}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>New project</DialogTitle>
-          </DialogHeader>
-          <form aria-label="Create project" className="grid gap-5" onSubmit={submitCreate}>
-            <LabeledInput label="Project name" name="name" required />
-            <LabeledInput
-              label="Project slug"
-              name="slug"
-              pattern="[a-z0-9]+(?:-[a-z0-9]+)*"
-              required
-            />
-            <DialogFooter>
-              <Button type="submit">Create project</Button>
-            </DialogFooter>
-          </form>
-        </DialogContent>
-      </Dialog>
-    </>
-  );
-}
-
-/**
- * The project chooser row. Choosing a project is the whole job of that screen, so the
- * card itself is the target rather than the name inside a cell. Archived projects keep
- * their row but lose every affordance — their routes stop resolving once archived.
- */
-function ProjectCard({
-  project,
-  to,
-}: {
-  project: OrganizationSnapshot["projects"][number];
-  to: string;
-}) {
-  const card = "flex items-center gap-4 rounded-lg border bg-card px-4 py-3.5";
-  const body = (
-    <>
-      <span
-        aria-hidden="true"
-        className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-primary/15 text-sm text-link"
-      >
-        {monogram(project.name)}
-      </span>
-      <span className="grid min-w-0 flex-1 gap-0.5">
-        <span className="flex items-center gap-2">
-          <span className="truncate group-hover:text-link">{project.name}</span>
-          {project.status === "active" ? null : <StatusPill tone="neutral">Archived</StatusPill>}
-        </span>
-        <span className="truncate font-mono text-xs text-muted-foreground">{project.slug}</span>
-      </span>
-      <span className="hidden shrink-0 text-xs text-muted-foreground sm:block">
-        Created {formatDate(project.createdAt)}
-      </span>
-    </>
-  );
-  if (project.status !== "active") {
-    return <div className={cn(card, "opacity-60")}>{body}</div>;
-  }
-  return (
-    <Link
-      to={to as never}
-      className={cn(card, "group transition-colors hover:border-primary/60 hover:bg-accent/40")}
-    >
-      {body}
-      <ChevronRight className="size-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:text-foreground" />
-    </Link>
-  );
-}
-
-function monogram(name: string) {
-  const words = name.split(/\s+/).filter((word) => word.length > 0);
-  const letters =
-    words.length > 1 ? `${words[0]?.[0] ?? ""}${words[1]?.[0] ?? ""}` : name.slice(0, 2);
-  return letters.toUpperCase();
-}
-
+import { archiveProject, activityRunSnapshot, updateProjectSlug } from "./functions.js";
 export function OrganizationConnectionsPanel() {
   const tenant = useRouteTenant();
   const { isInstanceOperator } = useActiveAccount();
@@ -199,7 +54,7 @@ export function OrganizationConnectionsPanel() {
     queryKey: ["connection-status", tenant.account.id, tenant.organization.id],
     queryFn: () => loadStatus({ data: scope }),
   });
-  const [result, setResult] = useConnectionResult();
+  const [returned, setReturned] = useConnectionReturn();
   const connect = useMutation({
     mutationKey: CONNECTION_MUTATION_KEY,
     mutationFn: useServerFn(startConnection),
@@ -209,9 +64,9 @@ export function OrganizationConnectionsPanel() {
     mutationFn: useServerFn(disconnectConnection) as (
       input: Parameters<typeof disconnectConnection>[0],
     ) => Promise<Result<{ result: ConnectionDisconnectResult }>>,
-    onSuccess: async (response) => {
+    onSuccess: async (response, variables) => {
       if (response.status !== "ok") return;
-      setResult(response.data.result);
+      setReturned({ provider: variables.data.provider, result: response.data.result });
       await Promise.all([
         invalidateOrganization(queryClient, scope.organizationSlug),
         queryClient.invalidateQueries({
@@ -256,10 +111,8 @@ export function OrganizationConnectionsPanel() {
   return (
     <>
       <PageHeader title="Connections" description="Organization provider connections." />
-      {result === undefined ? null : (
-        <Alert role="status" className="mb-6">
-          <AlertDescription>{connectionResultCopy(result)}</AlertDescription>
-        </Alert>
+      {returned === undefined ? null : (
+        <ConnectionReturnBanner copy={connectionReturnCopy(returned)} />
       )}
       <CommandError mutations={[connect, disconnect]} />
       <Section title="Connections">
@@ -718,6 +571,18 @@ function ActivityTable({
         </DataRow>
       ))}
     </DataTable>
+  );
+}
+
+function ConnectionReturnBanner({ copy }: { copy: ConnectionReturnCopy }) {
+  return (
+    <Alert
+      role="status"
+      className="mb-6"
+      {...(copy.tone === "error" ? { variant: "destructive" } : {})}
+    >
+      <AlertDescription>{copy.message}</AlertDescription>
+    </Alert>
   );
 }
 

--- a/src/provider-applications/panel.tsx
+++ b/src/provider-applications/panel.tsx
@@ -10,9 +10,11 @@ import { Alert, AlertDescription, AlertTitle } from "../components/ui/alert.js";
 import { TriangleAlert } from "lucide-react";
 import { Button } from "../components/ui/button.js";
 import type { Result } from "../contract/respond.js";
+import { connectionReturnCopy } from "../connections/result-contract.js";
+import { useConnectionReturn } from "../connections/result.js";
 import { PROVIDER_GUIDES } from "./guides.js";
 import { providerApplicationsOverview } from "./functions.js";
-import { ProviderSection, ProviderSectionLoading, type SectionReturn } from "./provider-section.js";
+import { ProviderSection, ProviderSectionLoading } from "./provider-section.js";
 import type { Provider, ProviderApplicationOverview, ProviderApplicationSurface } from "./index.js";
 
 const OVERVIEW_KEY = ["provider-applications"] as const;
@@ -43,13 +45,12 @@ function ProviderApplications({
   surface: ProviderApplicationSurface;
   organizationId: string;
 }) {
-  const [returned] = useState(readAppReturn);
+  const [returned] = useConnectionReturn();
   const [open, setOpen] = useState<Partial<Record<Provider, boolean>>>(() =>
     returned === undefined ? {} : { [returned.provider]: true },
   );
   const query = useProviderApplicationsOverview();
   const section = useRef<HTMLDivElement>(null);
-  useEffect(stripAppReturn, []);
   useEffect(() => {
     if (returned !== undefined) section.current?.scrollIntoView({ block: "start" });
   }, [returned]);
@@ -88,7 +89,7 @@ function ProviderApplications({
             open={open[guide.provider] ?? false}
             onOpenChange={(next) => setOpen((current) => ({ ...current, [guide.provider]: next }))}
             {...(returned?.provider === guide.provider
-              ? { returned: returned.outcome }
+              ? { returned: connectionReturnCopy(returned) }
               : { returned: undefined })}
           />
         </div>
@@ -234,103 +235,4 @@ export function AppsPanel() {
       </div>
     </>
   );
-}
-
-interface AppReturn {
-  provider: Provider;
-  outcome: SectionReturn;
-}
-
-/**
- * Every outcome a provider can send an operator back with. Each one says what happened and what
- * to do next; a cancellation is neutral because nothing about it is broken.
- */
-const RETURN_MESSAGES: Readonly<Record<string, SectionReturn>> = {
-  github_connected: { tone: "success", message: "GitHub connected." },
-  slack_connected: { tone: "success", message: "Slack connected." },
-  discord_connected: { tone: "success", message: "Discord connected." },
-  linear_connected: { tone: "success", message: "Linear connected." },
-  github_cancelled: {
-    tone: "success",
-    message: "Installation cancelled at GitHub. Nothing changed. Start again when you're ready.",
-  },
-  slack_cancelled: {
-    tone: "success",
-    message: "Installation cancelled at Slack. Nothing changed. Start again when you're ready.",
-  },
-  discord_cancelled: {
-    tone: "success",
-    message: "Authorization cancelled at Discord. Nothing changed. Start again when you're ready.",
-  },
-  linear_cancelled: {
-    tone: "success",
-    message: "Authorization cancelled at Linear. Nothing changed. Start again when you're ready.",
-  },
-  github_approval_required: {
-    tone: "error",
-    message:
-      "A GitHub organization owner has to approve this installation. Nothing was connected. Ask an owner to approve the request, then install again.",
-  },
-  slack_bot_failed: {
-    tone: "error",
-    message:
-      "Slack installed the app without every permission Hub needs. Nothing was saved. Reapply the manifest under Features → OAuth & Permissions, then install again.",
-  },
-  provider_not_configured: {
-    tone: "error",
-    message: "There are no saved credentials to connect yet. Verify and save the app first.",
-  },
-  connection_invalid: {
-    tone: "error",
-    message:
-      "That connection link had already been used or had expired, so it was refused. Nothing was connected. Start the connection again from this page.",
-  },
-  connection_conflict: {
-    tone: "error",
-    message:
-      "That account is already connected to another organization. Nothing was connected. Disconnect it there, or pick a different one.",
-  },
-};
-
-/**
- * Reads the outcome an install or authorization came back with. The identity itself is read from
- * the refreshed overview — the query only says which section to open and what happened.
- */
-function readAppReturn(): AppReturn | undefined {
-  if (typeof window === "undefined") return undefined;
-  const url = new URL(window.location.href);
-  const provider = url.searchParams.get("app");
-  const result = url.searchParams.get("result");
-  if (
-    provider !== "github" &&
-    provider !== "slack" &&
-    provider !== "discord" &&
-    provider !== "linear"
-  ) {
-    return undefined;
-  }
-  if (result === null) return undefined;
-  return {
-    provider,
-    outcome: RETURN_MESSAGES[result] ?? {
-      tone: "error",
-      message: `${providerName(provider)} ended the connection without saying why. Nothing was connected. Start the connection again from this page.`,
-    },
-  };
-}
-
-function providerName(provider: Provider): string {
-  if (provider === "github") return "GitHub";
-  if (provider === "slack") return "Slack";
-  if (provider === "linear") return "Linear";
-  return "Discord";
-}
-
-/** Clear callback state after the router commits, so its initial URL cannot restore the query. */
-function stripAppReturn(): void {
-  const url = new URL(window.location.href);
-  if (!url.searchParams.has("app") && !url.searchParams.has("result")) return;
-  url.searchParams.delete("app");
-  url.searchParams.delete("result");
-  window.history.replaceState(window.history.state, "", url);
 }

--- a/src/providers/discord/index.ts
+++ b/src/providers/discord/index.ts
@@ -4,6 +4,7 @@ import { reportFailure } from "../../failures/index.js";
 import type { ProviderConnectionRegistration, ProviderRegistration } from "../registration.js";
 import {
   CONNECTION_ATTEMPT_LIFETIME_MINUTES,
+  CONNECTIONS_RETURN_ROUTE,
   callbackConnectionAccess,
   cancelledConnectionResult,
   connectionAccess,
@@ -275,14 +276,15 @@ async function completeAuthorization(
   }
   if (state === null || code === null || client === undefined) {
     return connectionCallbackFailure({
+      request,
       error: new ProviderCallbackError("invalid_callback"),
       provider: "discord",
       phase: "authorization",
       applicationBaseUrl: options.applicationBaseUrl,
-      returnRoute: "/",
+      returnRoute: CONNECTIONS_RETURN_ROUTE,
     });
   }
-  let returnRoute = "/";
+  let returnRoute: string = CONNECTIONS_RETURN_ROUTE;
   let callbackOrigin = options.applicationBaseUrl;
   try {
     const access = await callbackConnectionAccess(options.auth, request);
@@ -301,6 +303,7 @@ async function completeAuthorization(
         access,
       });
       return connectionCallbackFailure({
+        request,
         error: new ProviderCallbackError("Discord did not verify the selected server"),
         provider: "discord",
         phase: "authorization",
@@ -312,6 +315,7 @@ async function completeAuthorization(
     return connectionResult(callbackOrigin, attempt.returnRoute, "discord_connected", "discord");
   } catch (error) {
     return connectionCallbackFailure({
+      request,
       error,
       provider: "discord",
       phase: "authorization",

--- a/src/providers/github/index.ts
+++ b/src/providers/github/index.ts
@@ -7,6 +7,7 @@ import { logger } from "../../logger.js";
 import type { ProviderConnectionRegistration, ProviderRegistration } from "../registration.js";
 import {
   CONNECTION_ATTEMPT_LIFETIME_MINUTES,
+  CONNECTIONS_RETURN_ROUTE,
   callbackConnectionAccess,
   cancelledConnectionResult,
   connectionAccess,
@@ -383,13 +384,14 @@ async function completeSetup(
   const action = url.searchParams.get("setup_action");
   if (state === null || client === undefined)
     return connectionCallbackFailure({
+      request,
       error: new GitHubCallbackError("invalid setup callback"),
       provider: "github",
       phase: "setup",
       applicationBaseUrl: options.applicationBaseUrl,
-      returnRoute: "/",
+      returnRoute: CONNECTIONS_RETURN_ROUTE,
     });
-  let returnRoute = "/";
+  let returnRoute: string = CONNECTIONS_RETURN_ROUTE;
   let callbackOrigin = options.applicationBaseUrl;
   try {
     const access = await callbackConnectionAccess(options.auth, request);
@@ -415,6 +417,7 @@ async function completeSetup(
     }
     if ((action !== "install" && action !== "update") || installationId === undefined) {
       return connectionCallbackFailure({
+        request,
         error: new GitHubCallbackError("invalid setup result"),
         provider: "github",
         phase: "setup",
@@ -441,6 +444,7 @@ async function completeSetup(
     );
   } catch (error) {
     return connectionCallbackFailure({
+      request,
       error,
       provider: "github",
       phase: "setup",
@@ -471,14 +475,15 @@ async function completeAuthorization(
   }
   if (state === null || code === null || client === undefined) {
     return connectionCallbackFailure({
+      request,
       error: new GitHubCallbackError("invalid authorization callback"),
       provider: "github",
       phase: "authorization",
       applicationBaseUrl: options.applicationBaseUrl,
-      returnRoute: "/",
+      returnRoute: CONNECTIONS_RETURN_ROUTE,
     });
   }
-  let returnRoute = "/";
+  let returnRoute: string = CONNECTIONS_RETURN_ROUTE;
   let callbackOrigin = options.applicationBaseUrl;
   try {
     const access = await callbackConnectionAccess(options.auth, request);
@@ -504,6 +509,7 @@ async function completeAuthorization(
         access,
       });
       return connectionCallbackFailure({
+        request,
         error: new GitHubCallbackError("installation verification rejected"),
         provider: "github",
         phase: "authorization",
@@ -515,6 +521,7 @@ async function completeAuthorization(
     return connectionResult(callbackOrigin, attempt.returnRoute, "github_connected", "github");
   } catch (error) {
     return connectionCallbackFailure({
+      request,
       error,
       provider: "github",
       phase: "authorization",

--- a/src/providers/github/registration.test.ts
+++ b/src/providers/github/registration.test.ts
@@ -2,7 +2,10 @@ import assert from "node:assert/strict";
 import { createHmac } from "node:crypto";
 import { describe, it } from "vitest";
 import type { AuthServer } from "../../auth/server.js";
-import type { OrganizationAccessValue } from "../../auth/organization-access.js";
+import {
+  ProductRequestError,
+  type OrganizationAccessValue,
+} from "../../auth/organization-access.js";
 import { createMemoryDatabase } from "../../db/memory.js";
 import {
   createActiveProjectConfiguration,
@@ -413,6 +416,34 @@ describe("GitHub registration", () => {
     );
   });
 
+  it("returns a setup callback that carries no session to the connections landing", async () => {
+    const registration = createGitHubRegistration({
+      database: createMemoryDatabase(),
+      auth: new SignedOutAuth(),
+      applicationBaseUrl: "https://hub.test",
+      publicBaseUrl: "https://hub.test",
+      configuration: githubConfiguration(),
+      appAuth: githubAuth(),
+      connectionClient: new GitHubClientFake(),
+      reactionClient: {
+        createReaction: () => Promise.resolve({ id: 1 }),
+        deleteReaction: () => Promise.resolve(),
+      },
+    });
+
+    const response = await registration.connection.actions["setup"]!(
+      new Request(
+        "https://hub.test/api/integrations/github/setup?state=s&setup_action=install&installation_id=42",
+      ),
+    );
+
+    assert.equal(response.status, 303);
+    assert.equal(
+      response.headers.get("location"),
+      "https://hub.test/connections?app=github&result=connection_unauthenticated",
+    );
+  });
+
   it("keeps provider runtime active without browser authentication", async () => {
     const registration = createGitHubRegistration({
       database: createMemoryDatabase(),
@@ -642,6 +673,13 @@ class RegistrationAuth implements AuthServer {
   }
   close(): Promise<void> {
     return Promise.resolve();
+  }
+}
+
+/** The browser that came back from GitHub carries no Hub session at all. */
+class SignedOutAuth extends RegistrationAuth {
+  override resolveAccount(): Promise<never> {
+    return Promise.reject(new ProductRequestError(401, "unauthenticated"));
   }
 }
 

--- a/src/providers/linear/index.ts
+++ b/src/providers/linear/index.ts
@@ -1,6 +1,7 @@
 import type { AuthServer } from "../../auth/server.js";
 import {
   CONNECTION_ATTEMPT_LIFETIME_MINUTES,
+  CONNECTIONS_RETURN_ROUTE,
   callbackConnectionAccess,
   cancelledConnectionResult,
   connectionAccess,
@@ -320,9 +321,16 @@ async function completeAuthorization(
     });
   }
   if (state === null || code === null || client === undefined) {
-    return connectionResult(options.applicationBaseUrl, "/", "connection_unavailable");
+    return connectionCallbackFailure({
+      request,
+      error: new LinearCallbackError(),
+      provider: "linear",
+      phase: "authorization",
+      applicationBaseUrl: options.applicationBaseUrl,
+      returnRoute: CONNECTIONS_RETURN_ROUTE,
+    });
   }
-  let returnRoute = "/";
+  let returnRoute: string = CONNECTIONS_RETURN_ROUTE;
   let callbackOrigin = options.applicationBaseUrl;
   try {
     const access = await callbackConnectionAccess(options.auth, request);
@@ -353,12 +361,20 @@ async function completeAuthorization(
     return connectionResult(callbackOrigin, attempt.returnRoute, "linear_connected", "linear");
   } catch (error) {
     return connectionCallbackFailure({
+      request,
       error,
       provider: "linear",
       phase: "authorization",
       applicationBaseUrl: callbackOrigin,
       returnRoute,
     });
+  }
+}
+
+class LinearCallbackError extends Error {
+  readonly code = "invalidInput";
+  constructor() {
+    super("invalid Linear callback");
   }
 }
 

--- a/src/providers/slack/index.ts
+++ b/src/providers/slack/index.ts
@@ -1,6 +1,7 @@
 import type { AuthServer } from "../../auth/server.js";
 import {
   CONNECTION_ATTEMPT_LIFETIME_MINUTES,
+  CONNECTIONS_RETURN_ROUTE,
   callbackConnectionAccess,
   cancelledConnectionResult,
   connectionAccess,
@@ -339,14 +340,15 @@ async function completeAuthorization(
   }
   if (state === null || code === null || client === undefined) {
     return connectionCallbackFailure({
+      request,
       error: new SlackCallbackError(),
       provider: "slack",
       phase: "authorization",
       applicationBaseUrl: options.applicationBaseUrl,
-      returnRoute: "/",
+      returnRoute: CONNECTIONS_RETURN_ROUTE,
     });
   }
-  let returnRoute = "/";
+  let returnRoute: string = CONNECTIONS_RETURN_ROUTE;
   let callbackOrigin = options.applicationBaseUrl;
   try {
     const access = await callbackConnectionAccess(options.auth, request);
@@ -391,6 +393,7 @@ async function completeAuthorization(
       return connectionResult(callbackOrigin, returnRoute, "slack_bot_failed", "slack");
     }
     return connectionCallbackFailure({
+      request,
       error,
       provider: "slack",
       phase: "authorization",

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -22,6 +22,7 @@ import { Route as ApiOpenapiDotjsonRouteImport } from './routes/api/openapi[.]js
 import { Route as ApiSplatRouteImport } from './routes/api/$'
 import { Route as ShellTriggersRouteImport } from './routes/_shell/triggers'
 import { Route as ShellOperatorRouteImport } from './routes/_shell/operator'
+import { Route as ShellConnectionsRouteImport } from './routes/_shell/connections'
 import { Route as ShellCliLoginRouteImport } from './routes/_shell/cli-login'
 import { Route as ShellAppsRouteImport } from './routes/_shell/apps'
 import { Route as ApiV1CliAuthorizationsRouteImport } from './routes/api/v1/cli-authorizations'
@@ -116,6 +117,11 @@ const ShellTriggersRoute = ShellTriggersRouteImport.update({
 const ShellOperatorRoute = ShellOperatorRouteImport.update({
   id: '/operator',
   path: '/operator',
+  getParentRoute: () => ShellRoute,
+} as any)
+const ShellConnectionsRoute = ShellConnectionsRouteImport.update({
+  id: '/connections',
+  path: '/connections',
   getParentRoute: () => ShellRoute,
 } as any)
 const ShellCliLoginRoute = ShellCliLoginRouteImport.update({
@@ -302,6 +308,7 @@ export interface FileRoutesByFullPath {
   '/webhook': typeof WebhookRoute
   '/apps': typeof ShellAppsRoute
   '/cli-login': typeof ShellCliLoginRoute
+  '/connections': typeof ShellConnectionsRoute
   '/operator': typeof ShellOperatorRoute
   '/triggers': typeof ShellTriggersRoute
   '/api/$': typeof ApiSplatRoute
@@ -346,6 +353,7 @@ export interface FileRoutesByTo {
   '/webhook': typeof WebhookRoute
   '/apps': typeof ShellAppsRoute
   '/cli-login': typeof ShellCliLoginRoute
+  '/connections': typeof ShellConnectionsRoute
   '/operator': typeof ShellOperatorRoute
   '/triggers': typeof ShellTriggersRoute
   '/api/$': typeof ApiSplatRoute
@@ -391,6 +399,7 @@ export interface FileRoutesById {
   '/webhook': typeof WebhookRoute
   '/_shell/apps': typeof ShellAppsRoute
   '/_shell/cli-login': typeof ShellCliLoginRoute
+  '/_shell/connections': typeof ShellConnectionsRoute
   '/_shell/operator': typeof ShellOperatorRoute
   '/_shell/triggers': typeof ShellTriggersRoute
   '/api/$': typeof ApiSplatRoute
@@ -439,6 +448,7 @@ export interface FileRouteTypes {
     | '/webhook'
     | '/apps'
     | '/cli-login'
+    | '/connections'
     | '/operator'
     | '/triggers'
     | '/api/$'
@@ -483,6 +493,7 @@ export interface FileRouteTypes {
     | '/webhook'
     | '/apps'
     | '/cli-login'
+    | '/connections'
     | '/operator'
     | '/triggers'
     | '/api/$'
@@ -527,6 +538,7 @@ export interface FileRouteTypes {
     | '/webhook'
     | '/_shell/apps'
     | '/_shell/cli-login'
+    | '/_shell/connections'
     | '/_shell/operator'
     | '/_shell/triggers'
     | '/api/$'
@@ -688,6 +700,13 @@ declare module '@tanstack/react-router' {
       path: '/operator'
       fullPath: '/operator'
       preLoaderRoute: typeof ShellOperatorRouteImport
+      parentRoute: typeof ShellRoute
+    }
+    '/_shell/connections': {
+      id: '/_shell/connections'
+      path: '/connections'
+      fullPath: '/connections'
+      preLoaderRoute: typeof ShellConnectionsRouteImport
       parentRoute: typeof ShellRoute
     }
     '/_shell/cli-login': {
@@ -958,6 +977,7 @@ const ShellOOrganizationSlugTriggersRouteWithChildren =
 interface ShellRouteChildren {
   ShellAppsRoute: typeof ShellAppsRoute
   ShellCliLoginRoute: typeof ShellCliLoginRoute
+  ShellConnectionsRoute: typeof ShellConnectionsRoute
   ShellOperatorRoute: typeof ShellOperatorRoute
   ShellTriggersRoute: typeof ShellTriggersRoute
   ShellIndexRoute: typeof ShellIndexRoute
@@ -971,6 +991,7 @@ interface ShellRouteChildren {
 const ShellRouteChildren: ShellRouteChildren = {
   ShellAppsRoute: ShellAppsRoute,
   ShellCliLoginRoute: ShellCliLoginRoute,
+  ShellConnectionsRoute: ShellConnectionsRoute,
   ShellOperatorRoute: ShellOperatorRoute,
   ShellTriggersRoute: ShellTriggersRoute,
   ShellIndexRoute: ShellIndexRoute,

--- a/src/routes/_shell/connections.tsx
+++ b/src/routes/_shell/connections.tsx
@@ -1,0 +1,26 @@
+/* oxlint-disable typescript-eslint/no-unsafe-type-assertion -- the generated route type cannot express a server-resolved organization slug */
+import { createFileRoute, Navigate } from "@tanstack/react-router";
+import { useActiveAccount } from "../../auth/active-account.js";
+import { connectionReturnSearchSchema } from "../../connections/result-contract.js";
+
+/**
+ * The connections landing. A provider callback that could not be tied to the attempt that
+ * started it does not know which organization to return to, so it returns here; the active
+ * organization's connections page is the only place that reads what it carries.
+ */
+export const Route = createFileRoute("/_shell/connections")({
+  validateSearch: connectionReturnSearchSchema,
+  component: ConnectionsLanding,
+});
+
+function ConnectionsLanding() {
+  const account = useActiveAccount();
+  const search = Route.useSearch();
+  return (
+    <Navigate
+      to={`/o/${account.organization.slug}/connections` as never}
+      search={search as never}
+      replace
+    />
+  );
+}

--- a/src/routes/_shell/index.tsx
+++ b/src/routes/_shell/index.tsx
@@ -1,22 +1,13 @@
 /* oxlint-disable typescript-eslint/no-unsafe-type-assertion -- the generated route type cannot express a server-resolved organization slug */
 import { createFileRoute } from "@tanstack/react-router";
 import { Navigate } from "@tanstack/react-router";
-import { z } from "zod";
 import { useActiveAccount } from "../../auth/active-account.js";
 
 export const Route = createFileRoute("/_shell/")({
-  validateSearch: z.object({ result: z.string().optional() }),
   component: DashboardLanding,
 });
 
 function DashboardLanding() {
   const account = useActiveAccount();
-  const search = Route.useSearch();
-  return (
-    <Navigate
-      to={`/o/${account.organization.slug}/triggers` as never}
-      search={search as never}
-      replace
-    />
-  );
+  return <Navigate to={`/o/${account.organization.slug}/triggers` as never} replace />;
 }

--- a/src/triggers/panel.tsx
+++ b/src/triggers/panel.tsx
@@ -11,7 +11,6 @@ import { SiteHeaderActions } from "../components/app/site-header-actions.js";
 import { RelativeTime } from "../components/app/relative-time.js";
 import { StatusPill } from "../components/app/status-pill.js";
 import { ProviderGlyph } from "../connections/provider-glyph.js";
-import { connectionResultCopy, useConnectionResult } from "../connections/result.js";
 import { Alert, AlertDescription, AlertTitle } from "../components/ui/alert.js";
 import { Button } from "../components/ui/button.js";
 import { Field, FieldDescription, FieldLabel } from "../components/ui/field.js";
@@ -44,7 +43,6 @@ export function TriggersPanel() {
   const tenant = useRouteTenant();
   const scope = { organizationSlug: tenant.organization.slug };
   const snapshot = useTriggerSnapshot(scope.organizationSlug);
-  const [connectionResult] = useConnectionResult();
   const navigate = useNavigate();
   if (snapshot.isPending) return <div aria-busy="true">Loading triggers…</div>;
   if (snapshot.isError || snapshot.data.status === "error") {
@@ -67,11 +65,6 @@ export function TriggersPanel() {
           </Button>
         ) : null}
       </PageHeader>
-      {connectionResult === undefined ? null : (
-        <Alert role="status" className="mb-6">
-          <AlertDescription>{connectionResultCopy(connectionResult)}</AlertDescription>
-        </Alert>
-      )}
       <DataTable
         label="Triggers"
         columns={TRIGGER_COLUMNS}


### PR DESCRIPTION
A failed provider connection now returns to Connections with accurate, actionable copy instead of showing an app-credentials warning on Triggers.

## Goals

- Keep every provider callback return on the Connections surface that started it.
- Represent callback outcomes with one closed contract and one copy table.
- Distinguish callbacks that arrive without a Hub session from internal connection failures.
- Correlate internal failures with a safe log reference and callback diagnostics.

## Non-goals

- Why the callback arrived without a session is deliberately out of scope and is still being verified separately by the maintainer (likely the GitHub App's Setup URL host).

## Why

Three independent display problems combined into the reported symptom:

- Unread connection attempts fell back to `/`, whose dashboard redirect forwarded the result into Triggers.
- A 401 request error was classified as internal, producing unhelpful copy that told the operator to check app credentials.
- Connection outcomes were owned by two divergent copy tables, so the Apps and Connections surfaces could disagree.

This change gives callback returns one contract, routes unknown-organization returns through a Connections landing, classifies unauthenticated callbacks explicitly, and removes connection-result rendering from unrelated surfaces.

## Verification

- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- Unit tests excluding container-backed integration and E2E files
- Focused connection/failure/provider tests: 19 passed
- Production build
- Selected browser suite: Apps, Triggers, and dashboard navigation passed
- Isolated state-boundary and signed-out return journeys: 2 passed under the standard timeout

## Risk surface

This changes provider callback redirect URLs, callback failure classification and copy, shell search forwarding, and which UI surfaces consume connection results. It does not change provider credential setup, session creation, or database schema.
