### PR TITLE
Start trials at organization creation

### DIFF
--- a/docs/billing.md
+++ b/docs/billing.md
@@ -68,14 +68,23 @@ Nothing about this is hardcoded to one plan. Publish a second product in Stripe 
 lays out two columns; publish an annual price and the interval switch appears. What is fixed is
 that a customer only ever sees what Stripe says is for sale.
 
-## Free-tier provisioning
+## Organization provisioning and creation-time trials
 
-A hosted organization is provisioned with the free record's template resolved from the mirror
-(`BillingRuntime.provisioningEntitlement`), not the unlimited default self-hosted gets. If the
-mirror has no active free record yet — first boot before sync, or a Stripe account missing the
-product — provisioning falls back to `FREE_TIER_FALLBACK`. The fallback fails closed rather than
-open to unlimited and logs loudly so the gap gets noticed; every organization stamped from it
-re-stamps to the real template the moment it subscribes.
+A marketing entry may select the signup offer with `?plan=trial`. Hub validates that closed value
+at the page boundary, keeps it in the HTTP-only `paseo_signup_plan` cookie across account signup,
+and consumes it when the owner creates an organization. Billing owns the intent dispatch. Unknown
+values are ignored, and an absent value defaults to `trial`, so `https://hub.paseo.sh/` continues
+to start a trial until the marketing link adds the explicit parameter. A future hosted-free offer
+requires a new validated intent and billing branch, not changes to the organization-creation flow.
+
+A hosted organization is first provisioned with the free record's template resolved from the
+mirror (`BillingRuntime.provisioningEntitlement`), then its post-commit creation hook immediately
+starts and synchronously reconciles a Stripe-owned trial. The floor is the fail-closed state if
+Stripe cannot be reached during creation and the landing state after cancellation. If the mirror
+has no active free record yet — first boot before sync, or a Stripe account missing the product —
+provisioning falls back to `FREE_TIER_FALLBACK`. The fallback fails closed rather than open to
+unlimited and logs loudly so the gap gets noticed; every organization stamped from it re-stamps
+to the offered plan when trial creation or the fallback Checkout path succeeds.
 
 The billing view derives the current plan from what the organization was last _stamped_ with, not
 from a copied Stripe subscription. It reads Stripe only for the billing page, through a short,
@@ -103,12 +112,16 @@ change to; with one offer, the way out is Manage billing. Everything here is dri
 catalog, so a second product or an annual price restores the controls without a redesign — but
 nothing that has no meaning today is rendered today.
 
-The first subscribe starts a Stripe-owned 14-day trial: Checkout uses
-`payment_method_collection=if_required` and `trial_settings.end_behavior.missing_payment_method=cancel`,
-so it collects no card. Stripe subscription history determines eligibility; any former
-subscription receives ordinary paid Checkout. Customer, Checkout, and subscription metadata carry
-the organization id, and idempotency keys collapse concurrent Checkout attempts. During a trial,
-the Stripe portal remains available to add a card voluntarily.
+A new hosted organization's post-commit hook passes the stored signup intent to billing. Today's
+`trial` intent starts its Stripe-owned 14-day trial directly, with
+`trial_settings.end_behavior.missing_payment_method=cancel`, and reconciles it before the create
+request returns. No card or Checkout visit is required. The Subscribe → Checkout path remains for
+customers returning after cancellation and as the fallback when automatic trial creation failed;
+it uses `payment_method_collection=if_required` for a still-eligible first trial. Stripe
+subscription history determines eligibility, so any former subscription receives ordinary paid
+Checkout. Customer, Checkout, and subscription metadata carry the organization id, and
+idempotency keys collapse concurrent creation attempts. During a trial, the Stripe portal remains
+available to add a card voluntarily.
 
 The subscription webhook (`BillingRuntime.handleWebhook`) reconciles rather than applies. It takes
 only the subscription id from the event, then — under a per-organization advisory lock that

--- a/e2e/app.ts
+++ b/e2e/app.ts
@@ -135,6 +135,7 @@ class BuiltApplications {
         deliverCommand(server, { type: "billing-product", product }),
       cancelSubscription: (organizationId: string) =>
         deliverCommand(server, { type: "billing-cancel-subscription", organizationId }),
+      failNextTrialCreation: () => deliverCommand(server, { type: "fail-next-billing-trial" }),
       failNextAccountSetup: () => deliverCommand(server, { type: "fail-next-account-setup" }),
       accountEmailLink: async (email, kind) => {
         const link = await deliverCommandForData(server, {

--- a/e2e/billing-downgrade.spec.ts
+++ b/e2e/billing-downgrade.spec.ts
@@ -33,12 +33,12 @@ test("losing the plan keeps every seat, warns that the org is over its limit, an
   hub,
   page,
 }) => {
-  await test.step("create an organization and subscribe it to the plan", async () => {
+  test.slow();
+  await test.step("create an organization on the hosted trial", async () => {
     await hub.signUpAs("owner", downgradeOwner);
     await hub.createOrganization("owner", "Acme");
-    await hub.subscribeToPlan("owner", PLAN);
-    await hub.deliverSubscriptionWebhook("owner");
     await hub.expectCurrentPlan("owner", PLAN);
+    await hub.expectActiveTrial("owner");
   });
 
   await test.step("fill five seats: the owner plus four invited members", async () => {
@@ -76,10 +76,12 @@ test("a manual override survives a plan change while the rest re-stamps, and cle
   hub,
   page,
 }) => {
-  await test.step("start from an unsubscribed organization and become an operator", async () => {
+  test.slow();
+  await test.step("start from a trialing organization and become an operator", async () => {
     await hub.signUpAs("owner", overrideOwner);
     await hub.createOrganization("owner", "Globex");
-    await hub.expectNoSubscription("owner");
+    await hub.expectCurrentPlan("owner", PLAN);
+    await hub.expectActiveTrial("owner");
     // Overrides are operator-only now; the owner is granted the flag to hand-set the deal.
     await hub.grantOperator("owner");
   });
@@ -87,6 +89,22 @@ test("a manual override survives a plan change while the rest re-stamps, and cle
   await test.step("hand-set a three-seat override from the operator console", async () => {
     await hub.openSeatOverrideEditor("owner", { org: "Globex", max: 3, reason: seatReason });
     await hub.saveSeatOverride("owner", 3);
+    await hub.expectEntitlementCells("owner", "Globex", "Seats", {
+      granted: "Unlimited",
+      override: "3",
+      effective: "3",
+    });
+    await hub.expectEntitlementCells("owner", "Globex", "Executions this month", {
+      granted: "Unlimited",
+      override: "—",
+      effective: "Unlimited",
+    });
+    await page.screenshot({ path: `${DIR}/04-trial-override.png`, fullPage: true });
+  });
+
+  await test.step("cancel the trial: the override holds while granted values re-stamp", async () => {
+    await hub.cancelSubscription("owner");
+    await hub.expectNoSubscription("owner");
     await hub.expectEntitlementCells("owner", "Globex", "Seats", {
       granted: "1",
       override: "3",
@@ -97,38 +115,19 @@ test("a manual override survives a plan change while the rest re-stamps, and cle
       override: "—",
       effective: "0",
     });
-    await page.screenshot({ path: `${DIR}/04-floor-override.png`, fullPage: true });
-  });
-
-  await test.step("subscribe to the plan: the override holds, the untouched values re-stamp", async () => {
-    await hub.subscribeToPlan("owner", PLAN);
-    await hub.deliverSubscriptionWebhook("owner");
-    await hub.expectCurrentPlan("owner", PLAN);
-    // Seats: plan re-stamped to unlimited, but the hand-set override still wins.
-    await hub.expectEntitlementCells("owner", "Globex", "Seats", {
-      granted: "Unlimited",
-      override: "3",
-      effective: "3",
-    });
-    // Executions: never overridden, so it re-stamps from the floor's 0 to the plan's unlimited.
-    await hub.expectEntitlementCells("owner", "Globex", "Executions this month", {
-      granted: "Unlimited",
-      override: "—",
-      effective: "Unlimited",
-    });
     await page.screenshot({ path: `${DIR}/05-override-survives-restamp.png`, fullPage: true });
   });
 
-  await test.step("clear the override: the plan's unlimited seats take over, and the reset is audited", async () => {
+  await test.step("clear the override: the Free floor takes control, and the reset is audited", async () => {
     await hub.clearSeatOverride("owner", {
       org: "Globex",
       reason: clearReason,
-      expectedEffective: "Unlimited",
+      expectedEffective: "1",
     });
     await hub.expectEntitlementCells("owner", "Globex", "Seats", {
-      granted: "Unlimited",
+      granted: "1",
       override: "—",
-      effective: "Unlimited",
+      effective: "1",
     });
     await hub.expectEntitlementsAudit("owner", {
       org: "Globex",

--- a/e2e/billing-mobile.spec.ts
+++ b/e2e/billing-mobile.spec.ts
@@ -1,9 +1,7 @@
 import { test } from "./app.js";
 
-// The paywall is the one surface a customer meets before they have decided to trust the product,
-// and on a phone it is a modal inside a modal-shaped shell. This journey locks the two things
-// that break there: the picker must not push the page sideways, and the paid plan's call to
-// action must be reachable and accessible at phone width — not stranded below three tall cards.
+// A customer first meets the active trial card. After cancellation, the paywall picker must not
+// push the page sideways and its paid call to action must remain reachable at phone width.
 
 const owner = {
   name: "Nadia",
@@ -15,19 +13,19 @@ const SCREENSHOT_DIR = "e2e/screenshots/billing-mobile";
 
 test.use({ billing: true });
 
-test("the cardless trial can be started and read on a phone", async ({ hub, page }) => {
+test("the automatic cardless trial and post-trial paywall fit a phone", async ({ hub, page }) => {
   await hub.signUpAs("owner", owner);
   await hub.createOrganization("owner", "Acme");
 
-  await test.step("the plan picker fits the viewport and offers the trial", async () => {
-    await hub.expectPlanPickerFitsPhone("owner");
-    await page.screenshot({ path: `${SCREENSHOT_DIR}/01-plan-picker.png`, fullPage: true });
+  await test.step("the automatically started trial is readable on a phone", async () => {
+    await hub.expectActiveTrial("owner");
+    await page.screenshot({ path: `${SCREENSHOT_DIR}/01-active-trial.png`, fullPage: true });
   });
 
-  await test.step("starting the trial leaves a readable trial card behind", async () => {
-    await hub.choosePlan("owner", "Hosted");
-    await hub.deliverSubscriptionWebhook("owner");
-    await hub.expectActiveTrial("owner");
-    await page.screenshot({ path: `${SCREENSHOT_DIR}/02-active-trial.png`, fullPage: true });
+  await test.step("after cancellation, the paid plan picker fits the viewport", async () => {
+    await hub.cancelSubscription("owner");
+    await hub.expectNoSubscription("owner");
+    await hub.expectPlanPickerFitsPhone("owner");
+    await page.screenshot({ path: `${SCREENSHOT_DIR}/02-plan-picker.png`, fullPage: true });
   });
 });

--- a/e2e/billing-subscription.spec.ts
+++ b/e2e/billing-subscription.spec.ts
@@ -1,9 +1,8 @@
 import { test } from "./app.js";
 
-// The money test: the proof of the whole decoupled design. An organization with no subscription
-// cannot invite; a subscription webhook stamps the paid plan onto the organization; enforcement
-// then reads the organization's own record and the same invite succeeds. Replaying the webhook
-// changes nothing.
+// The money test: organization creation starts and synchronously stamps the hosted trial, so its
+// owner lands with paid-plan access. The following Stripe webhook is an idempotent replay, and a
+// terminal cancellation returns enforcement to the Free floor and exposes the paywall.
 //
 // No Stripe account and no network — the fixture Stripe client stands in for checkout, and the
 // subscription webhook is HMAC-signed with a known secret so signature verification is real.
@@ -14,46 +13,32 @@ const owner = {
   password: "nadia-billing-password",
 };
 const invitee = "teammate-billing@example.com";
+const fallbackOwner = {
+  name: "Farah",
+  email: "farah-billing-fallback@example.com",
+  password: "farah-billing-fallback-password",
+};
 
 const SLICE_6_DIR = "e2e/screenshots/slice-6";
 
 test.use({ billing: true });
 
-test("subscribing lifts an unsubscribed org's invite limit, and replaying the webhook changes nothing", async ({
+test("a new organization starts trialing, replay is a no-op, and cancellation exposes the paywall", async ({
   hub,
   page,
 }) => {
-  await test.step("sign up and create an organization with nothing to bill", async () => {
-    await hub.signUpAs("owner", owner);
+  test.slow();
+  await test.step("sign up and create an organization already trialing the hosted plan", async () => {
+    await hub.expectUnsupportedSignupPlanIgnored("owner", "bogus");
+    await hub.signUpAsWithPlanIntent("owner", owner, "trial");
+    // The validated marketing intent survives the account-creation round trip in an HTTP-only
+    // cookie, ready for the subsequent organization creation request.
+    await hub.expectSignupPlanCookie("owner", "trial");
     await hub.createOrganization("owner", "Acme");
-    // Hosted provisioning stamps the internal free entitlement record and there is no Stripe
-    // subscription. That record is enforcement, not an offer, so the billing page reads as a
-    // paywall — it never advertises the zero-execution floor as the customer's plan.
-    await hub.expectNoSubscription("owner");
-    await page.screenshot({ path: `${SLICE_6_DIR}/01-no-subscription.png`, fullPage: true });
-  });
-
-  await test.step("an organization on the one-seat floor cannot invite", async () => {
-    await hub.expectInviteLockedByPlan("owner");
-    await page.screenshot({ path: `${SLICE_6_DIR}/02-invite-locked.png`, fullPage: true });
-  });
-
-  await test.step("open the upgrade dialog and choose a paid plan", async () => {
-    // The locked control is the paywall's entrance: following it lands on Billing with the offer
-    // already open, so the customer never has to go find what to buy.
-    await hub.followInviteLockToPlans("owner");
-    await hub.expectCardlessTrialOffer("owner");
-    await page.screenshot({ path: `${SLICE_6_DIR}/03-upgrade-dialog.png`, fullPage: true });
-    await hub.choosePlan("owner", "Hosted");
-  });
-
-  await test.step("the subscription webhook stamps the paid plan and bills for one seat", async () => {
-    await hub.deliverSubscriptionWebhook("owner");
     await hub.expectCurrentPlan("owner", "Hosted");
     await hub.expectActiveTrial("owner");
-    // Post-paid seats: with only the owner, Stripe is billed for one seat.
     await hub.expectReportedSeatQuantity("owner", 1);
-    await page.screenshot({ path: `${SLICE_6_DIR}/04-hosted-plan.png`, fullPage: true });
+    await page.screenshot({ path: `${SLICE_6_DIR}/01-hosted-trial.png`, fullPage: true });
   });
 
   await test.step("the same invite now succeeds and the second seat is reported to Stripe", async () => {
@@ -61,12 +46,13 @@ test("subscribing lifts an unsubscribed org's invite limit, and replaying the we
     await hub.expectPendingInvitation("owner", invitee);
     // The pending invitation is a reserved seat: billing re-reports the count as two.
     await hub.expectReportedSeatQuantity("owner", 2);
-    await page.screenshot({ path: `${SLICE_6_DIR}/05-invite-succeeds.png`, fullPage: true });
+    await page.screenshot({ path: `${SLICE_6_DIR}/02-invite-succeeds.png`, fullPage: true });
   });
 
   await test.step("replaying the subscription webhook changes nothing", async () => {
     await hub.deliverSubscriptionWebhook("owner");
     await hub.expectCurrentPlan("owner", "Hosted");
+    await hub.expectActiveTrial("owner");
     await hub.expectPendingInvitation("owner", invitee);
   });
 
@@ -79,11 +65,25 @@ test("subscribing lifts an unsubscribed org's invite limit, and replaying the we
     // Enforcement reverts to the zero-execution floor; the customer-facing page says only that
     // there is no subscription, and offers the plan again.
     await hub.expectNoSubscription("owner");
-    await page.screenshot({ path: `${SLICE_6_DIR}/06-cancel-reverts.png`, fullPage: true });
+    await page.screenshot({ path: `${SLICE_6_DIR}/03-cancel-reverts.png`, fullPage: true });
     // The trial was consumed by the cancelled subscription, so the paywall now sells the plan
     // instead of promising another 14 free days.
     await hub.expectNoSecondTrialOffer("owner");
     await hub.openPlanDialog("owner");
-    await page.screenshot({ path: `${SLICE_6_DIR}/07-paid-paywall.png`, fullPage: true });
+    await page.screenshot({ path: `${SLICE_6_DIR}/04-paid-paywall.png`, fullPage: true });
   });
+});
+
+test("a failed creation-time trial leaves the Checkout fallback available", async ({ hub }) => {
+  await hub.failNextTrialCreation();
+  await hub.signUpAsWithPlanIntent("fallback-owner", fallbackOwner, "trial");
+  await hub.createOrganization("fallback-owner", "Fallback Co");
+
+  await hub.expectNoSubscription("fallback-owner");
+  await hub.expectInviteLockedByPlan("fallback-owner");
+  await hub.expectCardlessTrialOffer("fallback-owner");
+  await hub.choosePlan("fallback-owner", "Hosted");
+  await hub.deliverSubscriptionWebhook("fallback-owner");
+  await hub.expectCurrentPlan("fallback-owner", "Hosted");
+  await hub.expectActiveTrial("fallback-owner");
 });

--- a/e2e/helpers/hub.ts
+++ b/e2e/helpers/hub.ts
@@ -25,6 +25,11 @@ import {
 } from "../../src/e2e/harness/browser-billing.js";
 import { configurationBundleFixture } from "../../src/test-utils/configuration-bundle.js";
 import { slugify } from "../../src/slug.js";
+import {
+  SIGNUP_INTENT_COOKIE,
+  SIGNUP_INTENT_QUERY_PARAMETER,
+  type SignupIntent,
+} from "../../src/organizations/signup-intent.js";
 import { AppSetupSurface, allowClipboard } from "./apps.js";
 import { SHOTS } from "./app-evidence.js";
 import {
@@ -47,6 +52,8 @@ export interface BuiltApplication {
   setBillingProduct(product: FixtureBillingProduct): Promise<void>;
   /** Stand in for a portal cancellation: move the organization's fixture subscription to canceled. */
   cancelSubscription(organizationId: string): Promise<void>;
+  /** Arms one creation-time Stripe trial failure, exercising the Checkout fallback. */
+  failNextTrialCreation(): Promise<void>;
   /** The seat quantity billing last reported to the fixture Stripe for this organization. */
   reportedSeatQuantity(organizationId: string): Promise<number | null>;
   /** Arms one account-setup failure inside the built application, for the error/retry journey. */
@@ -270,6 +277,20 @@ export class PaseoHub {
   ): Promise<void> {
     await this.signUpAs(alias, account);
     await this.requireUser(alias).completePasswordRecovery(account, replacementPassword);
+  }
+
+  async expectUnsupportedSignupPlanIgnored(alias: string, plan: string): Promise<void> {
+    const user = await this.user(alias);
+    await user.expectUnsupportedSignupPlanIgnored(plan);
+  }
+
+  async signUpAsWithPlanIntent(alias: string, account: Account, plan: SignupIntent): Promise<void> {
+    const user = await this.user(alias);
+    await user.signUp(account, plan);
+  }
+
+  async expectSignupPlanCookie(alias: string, plan: SignupIntent): Promise<void> {
+    await this.requireUser(alias).expectSignupPlanCookie(plan);
   }
 
   async createOrganization(alias: string, name: string): Promise<void> {
@@ -1004,6 +1025,10 @@ export class PaseoHub {
   async expectReportedSeatQuantity(alias: string, quantity: number): Promise<void> {
     const organizationId = await this.organizationIdForAlias(alias);
     await expect.poll(() => this.primary.reportedSeatQuantity(organizationId)).toBe(quantity);
+  }
+
+  async failNextTrialCreation(): Promise<void> {
+    await this.primary.failNextTrialCreation();
   }
 
   async subscribeToPlan(alias: string, plan: string): Promise<void> {
@@ -2549,12 +2574,37 @@ class HubUser {
     this.navigation = new ProjectNavigation(page);
   }
 
-  async signUp(account: Account): Promise<void> {
+  async signUp(account: Account, plan?: SignupIntent): Promise<void> {
     this.email = account.email.toLowerCase();
-    if (this.page.url() === "about:blank") await this.page.goto(this.origin);
+    if (plan !== undefined) {
+      await this.page.goto(`${this.origin}/?${SIGNUP_INTENT_QUERY_PARAMETER}=${plan}`);
+    } else if (this.page.url() === "about:blank") {
+      await this.page.goto(this.origin);
+    }
     await this.submitSignUp(account);
     await this.completeEmailVerification(account.email);
     await expect(this.page.getByRole("heading", { name: "Choose an organization" })).toBeVisible();
+  }
+
+  async expectUnsupportedSignupPlanIgnored(plan: string): Promise<void> {
+    await this.page.goto(
+      `${this.origin}/?${SIGNUP_INTENT_QUERY_PARAMETER}=${encodeURIComponent(plan)}`,
+    );
+    await expect(this.page.getByRole("heading", { name: "Sign in to Paseo Hub" })).toBeVisible();
+    await expect(
+      this.context
+        .cookies(this.origin)
+        .then((cookies) => cookies.find((cookie) => cookie.name === SIGNUP_INTENT_COOKIE)),
+    ).resolves.toBeUndefined();
+  }
+
+  async expectSignupPlanCookie(plan: SignupIntent): Promise<void> {
+    await expect
+      .poll(async () => {
+        const cookies = await this.context.cookies(this.origin);
+        return cookies.find((cookie) => cookie.name === SIGNUP_INTENT_COOKIE)?.value;
+      })
+      .toBe(plan);
   }
 
   async completeBootstrapJourney(
@@ -4304,11 +4354,11 @@ class HubUser {
     expect(
       await this.page.evaluate(() => document.documentElement.scrollWidth),
     ).toBeLessThanOrEqual(viewport!.width);
-    const trial = this.page
-      .getByRole("dialog")
-      .getByRole("button", { name: `Start free trial with ${HOSTED_PLAN_NAME}` });
-    await trial.scrollIntoViewIfNeeded();
-    await expect(trial).toBeInViewport();
+    const action = this.page.getByRole("dialog").getByRole("button", {
+      name: new RegExp(`^(Start free trial with|Subscribe to) ${HOSTED_PLAN_NAME}$`, "u"),
+    });
+    await action.scrollIntoViewIfNeeded();
+    await expect(action).toBeInViewport();
     await expectAccessible(this.page);
   }
 

--- a/src/auth/account-app.tsx
+++ b/src/auth/account-app.tsx
@@ -10,6 +10,10 @@ import { InstanceSetupEntry } from "./instance-setup-entry.js";
 import { AppSetupEntry } from "../provider-applications/panel.js";
 import { PasswordChangeEntry } from "./password-change.js";
 import { EmailVerificationResult, PasswordResetEntry } from "./account-recovery.js";
+import {
+  parseSignupIntent,
+  SIGNUP_INTENT_QUERY_PARAMETER,
+} from "../organizations/signup-intent.js";
 
 export function AccountApp() {
   const authCallback = readAuthCallback();
@@ -27,13 +31,19 @@ function AccountApplication() {
   const [handoff, setHandoff] = useState(false);
   const enterHandoff = useCallback(() => setHandoff(true), []);
   const leaveHandoff = useCallback(() => setHandoff(false), []);
-  const invitation =
-    typeof window === "undefined"
-      ? undefined
-      : (new URLSearchParams(window.location.search).get("invitation") ?? undefined);
+  const search =
+    typeof window === "undefined" ? undefined : new URLSearchParams(window.location.search);
+  const invitation = search?.get("invitation") ?? undefined;
+  const signupIntent = parseSignupIntent(search?.get(SIGNUP_INTENT_QUERY_PARAMETER));
   const account = useQuery({
-    queryKey: ["account", invitation],
-    queryFn: () => loadAccount({ data: { invitation } }),
+    queryKey: ["account", invitation, signupIntent],
+    queryFn: () =>
+      loadAccount({
+        data: {
+          ...(invitation === undefined ? {} : { invitation }),
+          ...(signupIntent === undefined ? {} : { signupIntent }),
+        },
+      }),
   });
   if (account.isPending) return <LoadingEntry />;
   if (account.isError || account.data.status === "error") {

--- a/src/auth/functions.ts
+++ b/src/auth/functions.ts
@@ -1,5 +1,5 @@
 import { createServerFn } from "@tanstack/react-start";
-import { getRequest } from "@tanstack/react-start/server";
+import { deleteCookie, getCookie, getRequest, setCookie } from "@tanstack/react-start/server";
 import { isAPIError } from "better-auth/api";
 import { z } from "zod";
 import { respondOk, type Result } from "../contract/respond.js";
@@ -13,6 +13,11 @@ import {
 import { PASSWORD_MIN_LENGTH } from "./instance-policy.js";
 import { API_KEY_SCOPES, apiKeyScopeSchema } from "./api-key-contract.js";
 import { parseEntitlementDenial, type EntitlementDenialPayload } from "../entitlements/denial.js";
+import {
+  SIGNUP_INTENT_COOKIE,
+  parseSignupIntent,
+  signupIntentSchema,
+} from "../organizations/signup-intent.js";
 
 const credentialsSchema = z.object({
   email: z.string().email(),
@@ -30,7 +35,10 @@ const resetPasswordSchema = z.object({
   token: z.string().min(1),
   newPassword: z.string().min(PASSWORD_MIN_LENGTH),
 });
-const invitationSchema = z.object({ invitation: z.string().optional() });
+const accountEntrySchema = z.object({
+  invitation: z.string().optional(),
+  signupIntent: signupIntentSchema.optional(),
+});
 const initialOperatorSchema = credentialsSchema.strip();
 const createOrganizationSchema = z.object({ name: z.string().trim().min(1).max(100) });
 const selectOrganizationSchema = z.object({ organizationId: z.string().min(1) });
@@ -69,9 +77,18 @@ const apiKeyCreateResultSchema = z.object({
 });
 
 export const accountState = createServerFn({ method: "GET" })
-  .validator(invitationSchema)
+  .validator(accountEntrySchema)
   .handler(async ({ data }): Promise<Result<z.infer<typeof accountStateSchema>>> => {
     const request = getRequest();
+    if (data.signupIntent !== undefined) {
+      setCookie(SIGNUP_INTENT_COOKIE, data.signupIntent, {
+        httpOnly: true,
+        sameSite: "lax",
+        secure: new URL(request.url).protocol === "https:",
+        path: "/",
+        maxAge: 24 * 60 * 60,
+      });
+    }
     const url = new URL("/api/auth/paseo/state", request.url);
     if (data.invitation !== undefined) url.searchParams.set("invitation", data.invitation);
     try {
@@ -390,7 +407,11 @@ type CreateOrganizationCommandResult = Result<{
 export const createOrganization = createServerFn({ method: "POST" })
   .validator(createOrganizationSchema)
   .handler(async ({ data }): Promise<CreateOrganizationCommandResult> => {
-    const response = await sendAccountCommand("/api/auth/paseo/create-organization", data);
+    const signupIntent = parseSignupIntent(getCookie(SIGNUP_INTENT_COOKIE));
+    const response = await sendAccountCommand("/api/auth/paseo/create-organization", {
+      ...data,
+      ...(signupIntent === undefined ? {} : { signupIntent }),
+    });
     if (response instanceof AccountRequestError) {
       return accountTransportFailure(
         response,
@@ -406,6 +427,7 @@ export const createOrganization = createServerFn({ method: "POST" })
         response,
         "Hub couldn't create the organization. Review its name and your permissions before submitting again.",
       );
+    deleteCookie(SIGNUP_INTENT_COOKIE, { path: "/" });
     try {
       const result = z.object({ organizationSlug: z.string().min(1) }).parse(await response.json());
       return respondOk({ state: "complete", organizationSlug: result.organizationSlug });

--- a/src/auth/organization-access.ts
+++ b/src/auth/organization-access.ts
@@ -40,6 +40,11 @@ import { EntitlementDenied } from "../entitlements/catalog.js";
 import { entitlementDenialResponse } from "../entitlements/denial.js";
 import type { EntitlementsService } from "../entitlements/service.js";
 import type { InvitationMailer } from "../invitations/index.js";
+import {
+  signupIntentOrDefault,
+  signupIntentSchema,
+  type OrganizationCreatedEvent,
+} from "../organizations/signup-intent.js";
 
 const INVITATION_LIFETIME_HOURS = 48;
 
@@ -101,6 +106,9 @@ interface OrganizationAccessOptions {
   /** What a newly created organization is stamped with — unlimited self-hosted, the Free plan
    * on a billing-configured instance. Resolved per creation so a later Free-plan sync is seen. */
   provisioningEntitlements: ProvisioningEntitlementResolver;
+  /** Post-commit hook fired after an owner creates an organization. Awaited before responding,
+   * but never rolls back or fails creation if the injected integration fails. */
+  onOrganizationCreated?: (event: OrganizationCreatedEvent) => Promise<void>;
   /** Post-commit hook fired when an organization's seat count may have changed (invite, cancel,
    * accept, remove). The composition root wires billing's seat-quantity reporter here; undefined
    * self-hosted. Never blocks or fails the member action. */
@@ -142,7 +150,9 @@ interface TargetMemberRow extends QueryRow {
 }
 
 const organizationIdBody = z.object({ organizationId: z.string().min(1) }).strict();
-const createOrganizationBody = z.object({ name: z.string().trim().min(1).max(100) }).strict();
+const createOrganizationBody = z
+  .object({ name: z.string().trim().min(1).max(100), signupIntent: signupIntentSchema.optional() })
+  .strict();
 const createInvitationBody = z
   .object({ email: z.string().trim().email(), role: invitationRoleSchema })
   .strict();
@@ -329,10 +339,33 @@ export class OrganizationAccess {
       await activateSession(client, session, id);
       return created;
     });
+    await this.notifyOrganizationCreated({
+      organizationId: organization.id,
+      accountEmail: session.email,
+      accountName: session.name,
+      intent: signupIntentOrDefault(input.signupIntent),
+    });
     return Response.json(
       { organizationId: organization.id, organizationSlug: organization.slug },
       { status: 201 },
     );
+  }
+
+  private async notifyOrganizationCreated(event: OrganizationCreatedEvent): Promise<void> {
+    try {
+      await this.options.onOrganizationCreated?.(event);
+    } catch (error) {
+      // Last line of defence: hook integrations should own and report their expected failures.
+      reportFailure(
+        error,
+        {
+          operation: "organization.created.notify",
+          component: "auth",
+          organizationId: event.organizationId,
+        },
+        { kind: "upstreamUnavailable" },
+      );
+    }
   }
 
   private async selectOrganization(request: Request): Promise<Response> {

--- a/src/auth/server.ts
+++ b/src/auth/server.ts
@@ -29,6 +29,7 @@ import {
   type AccountSession,
   type OrganizationAccessValue,
 } from "./organization-access.js";
+import type { OrganizationCreatedEvent } from "../organizations/signup-intent.js";
 import { paseoOrganizationPlugin } from "./organization-policy.js";
 import type { EntitlementsService } from "../entitlements/service.js";
 import {
@@ -74,7 +75,7 @@ export interface AuthServer {
   close(): Promise<void>;
 }
 
-interface AuthServerOptions {
+export interface AuthServerOptions {
   database: DatabaseRuntime;
   locks: Locks;
   /** Owned by the composition root, injected here — auth consumes entitlements, never owns them. */
@@ -86,6 +87,9 @@ interface AuthServerOptions {
   /** How a new organization is provisioned. Defaults to unlimited (self-hosted); the composition
    * root passes a billing-backed resolver when Stripe is configured. */
   provisioningEntitlements?: ProvisioningEntitlementResolver;
+  /** Post-commit hook awaited after organization creation. Integration failures must never fail
+   * or roll back the successfully created organization. Undefined self-hosted. */
+  onOrganizationCreated?: (event: OrganizationCreatedEvent) => Promise<void>;
   /** Post-commit hook fired when a membership change alters an organization's seat count. The
    * composition root wires billing's seat-quantity reporter here; undefined self-hosted. */
   onMembershipChanged?: (organizationId: string) => Promise<void>;
@@ -228,6 +232,9 @@ export function createAuthServer(options: AuthServerOptions): AuthServer {
     instanceSetup,
     appOnboarding,
     provisioningEntitlements,
+    ...(options.onOrganizationCreated === undefined
+      ? {}
+      : { onOrganizationCreated: options.onOrganizationCreated }),
     ...(options.onMembershipChanged === undefined
       ? {}
       : { onMembershipChanged: options.onMembershipChanged }),

--- a/src/billing/index.ts
+++ b/src/billing/index.ts
@@ -11,6 +11,7 @@ import {
   type EntitlementTemplate,
 } from "../entitlements/catalog.js";
 import type { ProvisioningEntitlement } from "../organizations/provisioning.js";
+import type { OrganizationCreatedEvent } from "../organizations/signup-intent.js";
 import { reportFailure } from "../failures/index.js";
 import { logger } from "../logger.js";
 import { syncBillingCatalog } from "./catalog-sync.js";
@@ -87,8 +88,9 @@ function billingLockKey(organizationId: string): string {
 }
 
 /**
- * The internal entitlement record a hosted organization is stamped with before it pays and again
- * after it cancels. Identified by its `paseo_plan_slug` metadata, mirrored as `billing_plans.slug`
+ * The internal entitlement record a hosted organization is stamped with before its creation-time
+ * trial is reconciled, when that trial cannot be started, and after cancellation. Identified by
+ * its `paseo_plan_slug` metadata, mirrored as `billing_plans.slug`
  * — so which product carries the floor is set in the Stripe dashboard, not hardcoded here (the
  * plan's "Stripe is the source of truth" rule).
  *
@@ -103,9 +105,10 @@ const FREE_PLAN_SLUG = "free";
  * The conservative floor used only when billing is configured but the mirror has no active Free
  * plan — a first boot before the sync lands, or a Stripe account with no Free product. Not a
  * mirror of any Stripe plan: it fails closed (one seat, no invites, a small execution cap) so a
- * new organization can never get everything for free, while `provisioningEntitlement` logs loudly
+ * new organization cannot fail open to unlimited, while `provisioningEntitlement` logs loudly
  * so an operator notices and fixes the catalog. A misconfigured Stripe is recoverable — every
- * organization stamped from this floor re-stamps to the real Free plan the moment it subscribes.
+ * organization stamped from this floor re-stamps to the offered plan when its trial or fallback
+ * Checkout succeeds.
  */
 const FREE_TIER_FALLBACK: EntitlementTemplate = {
   seats: { max: 1 },
@@ -135,6 +138,14 @@ export interface CreateCheckoutInput {
   accountEmail: string | null;
   accountName: string | null;
 }
+
+export interface StartTrialInput {
+  organizationId: string;
+  accountEmail: string | null;
+  accountName: string | null;
+}
+
+export type StartSignupInput = OrganizationCreatedEvent;
 
 export interface CreatePortalInput {
   organizationId: string;
@@ -221,6 +232,56 @@ export class BillingRuntime {
     return this.freeEntitlement();
   }
 
+  /** Dispatch the validated marketing/signup intent. Keeping this decision inside billing means
+   * a future hosted-free offer adds an intent branch here without changing organization creation. */
+  async startSignup(input: StartSignupInput): Promise<void> {
+    const intent = input.intent;
+    switch (intent) {
+      case "trial":
+        await this.startTrial(input);
+        return;
+    }
+    return assertNeverSignupIntent(intent);
+  }
+
+  /**
+   * Start a new hosted organization on Stripe's cardless trial and reconcile it before returning.
+   * Provisioning has already stamped the Free floor, so every failure is fail-closed. This method
+   * owns and reports every failure rather than allowing billing to fail organization creation.
+   */
+  async startTrial(input: StartTrialInput): Promise<void> {
+    try {
+      const catalog = await this.publicCatalog();
+      if (catalog.length !== 1) {
+        throw trialStartError(`expected one public plan, found ${catalog.length}`);
+      }
+      const plan = catalog[0];
+      if (plan === undefined) throw trialStartError("public trial plan is unavailable");
+      const price = await this.resolvePlanPrice(plan.slug, "monthly");
+      const customerId = await this.resolveCustomer(input);
+      if (!this.trialEligible(await this.customerSubscriptions(customerId))) return;
+      const subscriptionId = await this.billingClient.createTrialSubscription({
+        organizationId: input.organizationId,
+        customerId,
+        priceId: price.priceId,
+        quantity: await this.seatUsage(input.organizationId),
+      });
+      this.invalidateSubscriptions(customerId);
+      const outcome = await this.database.withAdvisoryLock(
+        billingLockKey(input.organizationId),
+        () => this.reconcileSubscriptionUnderLock(subscriptionId),
+      );
+      if (outcome === "retry") throw trialStartError("created trial could not be reconciled");
+    } catch (error) {
+      reportFailure(withTrialStartCode(error), {
+        operation: "billing.trial.start",
+        component: "billing",
+        provider: "stripe",
+        organizationId: input.organizationId,
+      });
+    }
+  }
+
   /**
    * The Free plan's template from the catalog mirror — what both provisioning and a terminal
    * cancellation stamp. When no active Free plan is mirrored yet (a first boot before the sync,
@@ -275,7 +336,7 @@ export class BillingRuntime {
       quantity: await this.seatUsage(input.organizationId),
       successUrl: input.successUrl,
       cancelUrl: input.cancelUrl,
-      trial: subscriptions.length === 0,
+      trial: this.trialEligible(subscriptions),
     });
     this.invalidateSubscriptions(customerId);
     return checkout;
@@ -354,9 +415,14 @@ export class BillingRuntime {
       cancelAtPeriodEnd: live ? subscription.cancelAtPeriodEnd : false,
       currentPeriodEnd: live ? (subscription.currentPeriodEnd?.toISOString() ?? null) : null,
       trialEnd: live ? (subscription.trialEnd?.toISOString() ?? null) : null,
-      trialEligible: subscriptions.length === 0,
+      trialEligible: this.trialEligible(subscriptions),
       manageable: live,
     };
+  }
+
+  /** An organization may use the cardless trial only if it has never had a Stripe subscription. */
+  private trialEligible(subscriptions: readonly StripeSubscriptionState[]): boolean {
+    return subscriptions.length === 0;
   }
 
   async handleWebhook(request: Request): Promise<Response> {
@@ -509,7 +575,7 @@ export class BillingRuntime {
     return planStamp(entitlementsSchema.parse(plan.template), plan.id);
   }
 
-  private async resolveCustomer(input: CreateCheckoutInput): Promise<string> {
+  private async resolveCustomer(input: StartTrialInput): Promise<string> {
     const existing = await this.database.getOrganizationBillingCustomer(input.organizationId);
     if (existing !== undefined) return existing.stripeCustomerId;
     return this.billingClient.ensureCustomer({
@@ -562,6 +628,21 @@ export class BillingRuntime {
     const plans = await this.database.listBillingPlans();
     return plans.find((plan) => plan.prices.some((price) => price.id === priceId));
   }
+}
+
+function trialStartError(message: string): Error {
+  return Object.assign(new Error(message), { code: "billing_trial_start_failed" });
+}
+
+function assertNeverSignupIntent(value: never): never {
+  throw new Error(`Unhandled signup intent: ${String(value)}`);
+}
+
+function withTrialStartCode(error: unknown): Error {
+  if (error instanceof Error) {
+    return Object.assign(error, { code: "billing_trial_start_failed" });
+  }
+  return trialStartError("non-Error failure while starting trial");
 }
 
 /** The `plan_stamp` reconciliation writes onto an organization; `plan_version` is the template

--- a/src/billing/provisioning-entitlement.test.ts
+++ b/src/billing/provisioning-entitlement.test.ts
@@ -15,6 +15,7 @@ const unusedBillingClient: StripeBillingClient = {
   ensureCustomer: () => Promise.reject(new Error("unused")),
   listCustomerSubscriptions: () => Promise.reject(new Error("unused")),
   createCheckoutSession: () => Promise.reject(new Error("unused")),
+  createTrialSubscription: () => Promise.reject(new Error("unused")),
   changeSubscriptionPrice: () => Promise.reject(new Error("unused")),
   reportSeatQuantity: () => Promise.reject(new Error("unused")),
   createBillingPortalSession: () => Promise.reject(new Error("unused")),

--- a/src/billing/public-catalog.test.ts
+++ b/src/billing/public-catalog.test.ts
@@ -8,9 +8,10 @@ import type { StripeBillingClient, StripeSubscriptionState } from "./stripe-bill
 
 /**
  * The public catalog boundary. `free` is an internal entitlement record — the template a hosted
- * organization is stamped with before it pays and again after it cancels — not something a
- * customer can buy. Billing commits to that distinction here, so no consumer (the plans endpoint,
- * the billing overview, the picker) has to know the slug or re-derive the rule.
+ * organization is stamped with before its creation-time trial reconciles, on failure, and after
+ * cancellation — not something a customer can buy. Billing commits to that distinction here, so
+ * no consumer (the plans endpoint, the billing overview, the picker) has to know the slug or
+ * re-derive the rule.
  */
 
 const unusedCatalogSource: StripeCatalogSource = {
@@ -21,6 +22,7 @@ const unusedBillingClient: StripeBillingClient = {
   ensureCustomer: () => Promise.reject(new Error("unused")),
   listCustomerSubscriptions: () => Promise.reject(new Error("unused")),
   createCheckoutSession: () => Promise.reject(new Error("unused")),
+  createTrialSubscription: () => Promise.reject(new Error("unused")),
   changeSubscriptionPrice: () => Promise.reject(new Error("unused")),
   reportSeatQuantity: () => Promise.reject(new Error("unused")),
   createBillingPortalSession: () => Promise.reject(new Error("unused")),

--- a/src/billing/reconcile.test.ts
+++ b/src/billing/reconcile.test.ts
@@ -155,6 +155,9 @@ class FakeBillingClient implements StripeBillingClient {
   async createCheckoutSession(): Promise<{ url: string }> {
     throw new Error("unused");
   }
+  async createTrialSubscription(): Promise<string> {
+    throw new Error("unused");
+  }
   async changeSubscriptionPrice(input: ChangeSubscriptionPriceInput): Promise<void> {
     const state = this.subscriptions.get(input.subscriptionId);
     if (state === undefined) throw new Error("unused");

--- a/src/billing/start-trial.test.ts
+++ b/src/billing/start-trial.test.ts
@@ -92,7 +92,7 @@ function plan(
     name: slug === "hub" ? "Paseo Hub" : slug,
     template,
     templateHash: `hash-${slug}`,
-    marketing: { features: [] },
+    marketing: { features: [], priceTooltips: { monthly: null, annual: null } },
     active: true,
     prices: [
       {

--- a/src/billing/start-trial.test.ts
+++ b/src/billing/start-trial.test.ts
@@ -1,0 +1,257 @@
+import assert from "node:assert/strict";
+import { createHmac } from "node:crypto";
+import { describe, it } from "vitest";
+import { z } from "zod";
+import { createMemoryDatabase } from "../db/memory.js";
+import type { Database, SyncBillingPlanInput } from "../db/types.js";
+import type { EntitlementTemplate } from "../entitlements/catalog.js";
+import { runWithFailureTracking } from "../failures/index.js";
+import { createLogger } from "../logger.js";
+import { FailureLogStream } from "../test-utils/failure-logs.js";
+import { composeBilling, type BillingRuntime } from "./index.js";
+import type { StripeCatalogSource } from "./stripe-catalog-source.js";
+import type {
+  CreateTrialSubscriptionInput,
+  StripeBillingClient,
+  StripeSubscriptionState,
+} from "./stripe-billing-client.js";
+
+const WEBHOOK_SECRET = "whsec_trial_test";
+const FLOOR = {
+  seats: { max: 1 },
+  canInviteMembers: false,
+  meters: { "executions.monthly": { limit: 0 } },
+};
+const TRIAL_TEMPLATE = {
+  seats: { max: null },
+  canInviteMembers: true,
+  meters: { "executions.monthly": { limit: 2_000 } },
+};
+
+const unusedCatalogSource: StripeCatalogSource = {
+  listProducts: () => Promise.reject(new Error("unused")),
+  listPrices: () => Promise.reject(new Error("unused")),
+};
+
+class TrialBillingClient implements StripeBillingClient {
+  readonly subscriptions = new Map<string, StripeSubscriptionState>();
+  readonly created: CreateTrialSubscriptionInput[] = [];
+  throwOnCreate = false;
+
+  async ensureCustomer(input: { organizationId: string }): Promise<string> {
+    return `cus_${input.organizationId}`;
+  }
+
+  async listCustomerSubscriptions(customerId: string): Promise<readonly StripeSubscriptionState[]> {
+    return [...this.subscriptions.values()].filter(
+      (subscription) => subscription.customerId === customerId,
+    );
+  }
+
+  async createTrialSubscription(input: CreateTrialSubscriptionInput): Promise<string> {
+    if (this.throwOnCreate) throw new Error("Stripe unavailable");
+    this.created.push(input);
+    const id = `sub_${input.organizationId}`;
+    this.subscriptions.set(id, {
+      id,
+      customerId: input.customerId,
+      organizationId: input.organizationId,
+      priceId: input.priceId,
+      quantity: input.quantity,
+      status: "trialing",
+      currentPeriodEnd: new Date("2030-01-15T00:00:00Z"),
+      trialEnd: new Date("2030-01-15T00:00:00Z"),
+      cancelAtPeriodEnd: false,
+    });
+    return id;
+  }
+
+  async createCheckoutSession(): Promise<{ url: string }> {
+    throw new Error("unused");
+  }
+  async changeSubscriptionPrice(): Promise<void> {
+    throw new Error("unused");
+  }
+  async reportSeatQuantity(): Promise<void> {}
+  async createBillingPortalSession(): Promise<{ url: string }> {
+    throw new Error("unused");
+  }
+  async getSubscription(subscriptionId: string): Promise<StripeSubscriptionState | undefined> {
+    return this.subscriptions.get(subscriptionId);
+  }
+}
+
+function plan(
+  id: string,
+  slug: string,
+  template: EntitlementTemplate = TRIAL_TEMPLATE,
+): SyncBillingPlanInput {
+  return {
+    id,
+    slug,
+    name: slug === "hub" ? "Paseo Hub" : slug,
+    template,
+    templateHash: `hash-${slug}`,
+    marketing: { features: [] },
+    active: true,
+    prices: [
+      {
+        id: `price_${slug}_monthly`,
+        lookupKey: `${slug}_monthly`,
+        interval: "monthly",
+        unitAmount: 2_900,
+        currency: "eur",
+        active: true,
+      },
+    ],
+  };
+}
+
+async function setup(
+  publicPlans = [plan("prod_hub", "hub")],
+): Promise<{ database: Database; client: TrialBillingClient; billing: BillingRuntime }> {
+  const database = createMemoryDatabase();
+  await database.syncBillingPlan(plan("prod_free", "free", FLOOR));
+  for (const publicPlan of publicPlans) await database.syncBillingPlan(publicPlan);
+  await database.stampOrganizationEntitlements({
+    organizationId: "org_1",
+    granted: FLOOR,
+    planId: "prod_free",
+    planVersion: "floor",
+    source: "provisioning",
+    actor: null,
+    reason: null,
+  });
+  const client = new TrialBillingClient();
+  return {
+    database,
+    client,
+    billing: composeBilling({
+      config: { stripeSecretKey: "sk_test_fake", stripeWebhookSecret: WEBHOOK_SECRET },
+      database,
+      catalogSource: unusedCatalogSource,
+      billingClient: client,
+      seatUsage: () => Promise.resolve(1),
+    }),
+  };
+}
+
+function subscriptionWebhook(subscriptionId: string): Request {
+  const payload = JSON.stringify({
+    id: `evt_${subscriptionId}`,
+    type: "customer.subscription.created",
+    data: { object: { id: subscriptionId, object: "subscription" } },
+  });
+  const timestamp = Math.floor(Date.now() / 1_000);
+  const signature = createHmac("sha256", WEBHOOK_SECRET)
+    .update(`${timestamp}.${payload}`)
+    .digest("hex");
+  return new Request("http://hub.test/api/billing/webhook", {
+    method: "POST",
+    headers: { "stripe-signature": `t=${timestamp},v1=${signature}` },
+    body: payload,
+  });
+}
+
+describe("BillingRuntime.startTrial", () => {
+  it("dispatches the trial signup intent to the cardless trial", async () => {
+    const { client, billing } = await setup();
+
+    await billing.startSignup({
+      intent: "trial",
+      organizationId: "org_1",
+      accountEmail: "owner@example.com",
+      accountName: "Owner",
+    });
+
+    assert.equal(client.created.length, 1);
+    assert.equal(client.created[0]?.organizationId, "org_1");
+  });
+
+  it("creates and synchronously stamps a trial, with a replaying webhook as a no-op", async () => {
+    const { database, client, billing } = await setup();
+
+    await billing.startTrial({
+      organizationId: "org_1",
+      accountEmail: "owner@example.com",
+      accountName: "Owner",
+    });
+
+    assert.deepEqual(client.created, [
+      {
+        organizationId: "org_1",
+        customerId: "cus_org_1",
+        priceId: "price_hub_monthly",
+        quantity: 1,
+      },
+    ]);
+    assert.equal(
+      (await database.getOrganizationBillingCustomer("org_1"))?.stripeCustomerId,
+      "cus_org_1",
+    );
+    const stamped = await database.getOrganizationEntitlements("org_1");
+    assert.equal(stamped?.planId, "prod_hub");
+    assert.deepEqual(stamped?.granted, TRIAL_TEMPLATE);
+    const changes = await database.listEntitlementChanges("org_1", 10);
+    assert.equal(changes.length, 2);
+    assert.equal(changes[0]?.source, "plan_stamp");
+
+    const response = await billing.handleWebhook(subscriptionWebhook("sub_org_1"));
+    assert.equal(response.status, 200);
+    assert.equal((await database.listEntitlementChanges("org_1", 10)).length, 2);
+  });
+
+  it("does nothing when the organization already has any subscription", async () => {
+    const { client, billing } = await setup();
+    client.subscriptions.set("sub_old", {
+      id: "sub_old",
+      customerId: "cus_org_1",
+      organizationId: "org_1",
+      priceId: "price_hub_monthly",
+      quantity: 1,
+      status: "canceled",
+      currentPeriodEnd: null,
+      trialEnd: null,
+      cancelAtPeriodEnd: false,
+    });
+
+    await billing.startTrial({ organizationId: "org_1", accountEmail: null, accountName: null });
+
+    assert.equal(client.created.length, 0);
+  });
+
+  for (const [label, plans] of [
+    ["zero", []],
+    ["more than one", [plan("prod_hub", "hub"), plan("prod_team", "team")]],
+  ] as const) {
+    it(`leaves the floor and reports a failure with ${label} public plans`, async () => {
+      const { database, client, billing } = await setup([...plans]);
+      const logs = new FailureLogStream();
+
+      await runWithFailureTracking(
+        () =>
+          billing.startTrial({ organizationId: "org_1", accountEmail: null, accountName: null }),
+        createLogger(logs),
+      );
+
+      assert.equal(client.created.length, 0);
+      assert.equal((await database.getOrganizationEntitlements("org_1"))?.planId, "prod_free");
+      const [record] = logs.records();
+      assert.equal(record?.["operation"], "billing.trial.start");
+      assert.equal(
+        z.object({ code: z.string() }).parse(record?.["err"]).code,
+        "billing_trial_start_failed",
+      );
+    });
+  }
+
+  it("leaves the floor and never throws when Stripe creation fails", async () => {
+    const { database, client, billing } = await setup();
+    client.throwOnCreate = true;
+
+    await billing.startTrial({ organizationId: "org_1", accountEmail: null, accountName: null });
+
+    assert.equal((await database.getOrganizationEntitlements("org_1"))?.planId, "prod_free");
+    assert.equal((await database.listEntitlementChanges("org_1", 10)).length, 1);
+  });
+});

--- a/src/billing/stripe-billing-client.ts
+++ b/src/billing/stripe-billing-client.ts
@@ -18,6 +18,9 @@ export interface StripeBillingClient {
    * Only ever called when the organization has no subscription yet — a plan change goes through
    * `changeSubscriptionPrice`, never a second checkout. Returns its redirect URL. */
   createCheckoutSession(input: CreateCheckoutSessionInput): Promise<{ url: string }>;
+  /** Start the organization's cardless trial directly, without sending the owner through
+   * Checkout. Returns the subscription id so Hub can reconcile it before creation responds. */
+  createTrialSubscription(input: CreateTrialSubscriptionInput): Promise<string>;
   /** Move the organization's existing subscription onto `priceId` by updating its single item in
    * place. Stripe models a plan change as an update to the existing subscription, not a second
    * one, so this is the only path a change ever takes. */
@@ -50,6 +53,13 @@ export interface CreateCheckoutSessionInput {
   successUrl: string;
   cancelUrl: string;
   trial: boolean;
+}
+
+export interface CreateTrialSubscriptionInput {
+  organizationId: string;
+  customerId: string;
+  priceId: string;
+  quantity: number;
 }
 
 export interface ChangeSubscriptionPriceInput {

--- a/src/billing/stripe-client.ts
+++ b/src/billing/stripe-client.ts
@@ -8,15 +8,25 @@ import type {
   ChangeSubscriptionPriceInput,
   CreateBillingPortalSessionInput,
   CreateCheckoutSessionInput,
+  CreateTrialSubscriptionInput,
   EnsureCustomerInput,
   ReportSeatQuantityInput,
   StripeBillingClient,
   StripeSubscriptionState,
 } from "./stripe-billing-client.js";
+import { TRIAL_DAYS } from "./trial-policy.js";
 
 const PASEO_PLAN_METADATA_KEY = "paseo_plan";
 const ORGANIZATION_REFERENCE_METADATA_KEY = "organizationId";
 const LIST_PAGE_SIZE = 100;
+
+function trialSubscriptionData(organizationId: string) {
+  return {
+    trial_period_days: TRIAL_DAYS,
+    trial_settings: { end_behavior: { missing_payment_method: "cancel" as const } },
+    metadata: { [ORGANIZATION_REFERENCE_METADATA_KEY]: organizationId },
+  };
+}
 
 /**
  * The real Stripe SDK behind `StripeCatalogSource`. Fetches every product/price via the List
@@ -114,11 +124,7 @@ export function createStripeBillingClient(stripeSecretKey: string): StripeBillin
           client_reference_id: input.organizationId,
           metadata: { [ORGANIZATION_REFERENCE_METADATA_KEY]: input.organizationId },
           subscription_data: input.trial
-            ? {
-                trial_period_days: 14,
-                trial_settings: { end_behavior: { missing_payment_method: "cancel" } },
-                metadata: { [ORGANIZATION_REFERENCE_METADATA_KEY]: input.organizationId },
-              }
+            ? trialSubscriptionData(input.organizationId)
             : { metadata: { [ORGANIZATION_REFERENCE_METADATA_KEY]: input.organizationId } },
           ...(input.trial ? { payment_method_collection: "if_required" } : {}),
         },
@@ -128,6 +134,17 @@ export function createStripeBillingClient(stripeSecretKey: string): StripeBillin
       );
       if (session.url === null) throw new Error("Stripe checkout session has no redirect URL");
       return { url: session.url };
+    },
+    async createTrialSubscription(input: CreateTrialSubscriptionInput): Promise<string> {
+      const subscription = await stripe.subscriptions.create(
+        {
+          customer: input.customerId,
+          items: [{ price: input.priceId, quantity: input.quantity }],
+          ...trialSubscriptionData(input.organizationId),
+        },
+        { idempotencyKey: `trial:${input.organizationId}` },
+      );
+      return subscription.id;
     },
     async changeSubscriptionPrice(input: ChangeSubscriptionPriceInput): Promise<void> {
       // A plan change updates the existing subscription's single item onto the new price — never a

--- a/src/billing/trial-policy.ts
+++ b/src/billing/trial-policy.ts
@@ -1,0 +1,2 @@
+/** The single cardless-trial duration used by Stripe policy and billing copy. */
+export const TRIAL_DAYS = 14;

--- a/src/billing/ui/presentation.tsx
+++ b/src/billing/ui/presentation.tsx
@@ -5,6 +5,7 @@ import type {
   PublicBillingPlan,
   PublicBillingPlanPrice,
 } from "../../server/runtime.js";
+export { TRIAL_DAYS } from "../trial-policy.js";
 
 /**
  * Every word the billing surfaces render: prices, the button on each plan, and the one sentence
@@ -46,10 +47,6 @@ export function priceForInterval(
 ): PublicBillingPlanPrice | null {
   return plan.prices.find((price) => price.interval === interval) ?? null;
 }
-
-/** The number of free trial days Stripe grants on a cardless checkout. */
-export const TRIAL_DAYS = 14;
-
 export interface PlanPrice {
   /** The headline figure — "€15", "Free", or "—" when this interval has no price. */
   amount: string;

--- a/src/e2e/harness/browser-billing.ts
+++ b/src/e2e/harness/browser-billing.ts
@@ -153,6 +153,12 @@ export function fixtureSubscriptionId(organizationId: string): string {
  */
 export class FixtureStripeBillingClient {
   private readonly subscriptions = new Map<string, FixtureSubscriptionState>();
+  private failNextTrial = false;
+
+  /** Test-only: make the next creation-time trial fail before Stripe records a subscription. */
+  failNextTrialCreation(): void {
+    this.failNextTrial = true;
+  }
 
   async ensureCustomer(input: { organizationId: string }): Promise<string> {
     return `cus_fixture_${input.organizationId}`;
@@ -176,23 +182,23 @@ export class FixtureStripeBillingClient {
     successUrl: string;
     trial: boolean;
   }): Promise<{ url: string }> {
-    const id = fixtureSubscriptionId(input.organizationId);
     // Idempotent initial subscription: if one already exists, checkout does not open a second or
     // rewrite its price. A price change must go through changeSubscriptionPrice.
-    if (!this.subscriptions.has(id)) {
-      this.subscriptions.set(id, {
-        id,
-        customerId: input.customerId,
-        organizationId: input.organizationId,
-        priceId: input.priceId,
-        quantity: input.quantity,
-        status: input.trial ? "trialing" : "active",
-        currentPeriodEnd: new Date(Date.now() + FIXTURE_SUBSCRIPTION_PERIOD_MS),
-        trialEnd: input.trial ? new Date(Date.now() + 14 * 24 * 60 * 60 * 1000) : null,
-        cancelAtPeriodEnd: false,
-      });
-    }
+    this.createSubscription(input, input.trial);
     return { url: `/test/stripe-checkout?success=${encodeURIComponent(input.successUrl)}` };
+  }
+
+  async createTrialSubscription(input: {
+    organizationId: string;
+    customerId: string;
+    priceId: string;
+    quantity: number;
+  }): Promise<string> {
+    if (this.failNextTrial) {
+      this.failNextTrial = false;
+      throw new Error("fixture trial creation failed");
+    }
+    return this.createSubscription(input, true).id;
   }
 
   async changeSubscriptionPrice(input: { subscriptionId: string; priceId: string }): Promise<void> {
@@ -248,5 +254,27 @@ export class FixtureStripeBillingClient {
       if (state.id === subscriptionId) return state;
     }
     return undefined;
+  }
+
+  private createSubscription(
+    input: { organizationId: string; customerId: string; priceId: string; quantity: number },
+    trial: boolean,
+  ): FixtureSubscriptionState {
+    const id = fixtureSubscriptionId(input.organizationId);
+    const existing = this.subscriptions.get(id);
+    if (existing !== undefined) return existing;
+    const subscription = {
+      id,
+      customerId: input.customerId,
+      organizationId: input.organizationId,
+      priceId: input.priceId,
+      quantity: input.quantity,
+      status: trial ? "trialing" : "active",
+      currentPeriodEnd: new Date(Date.now() + FIXTURE_SUBSCRIPTION_PERIOD_MS),
+      trialEnd: trial ? new Date(Date.now() + 14 * 24 * 60 * 60 * 1000) : null,
+      cancelAtPeriodEnd: false,
+    };
+    this.subscriptions.set(id, subscription);
+    return subscription;
   }
 }

--- a/src/e2e/harness/browser-child.ts
+++ b/src/e2e/harness/browser-child.ts
@@ -2,7 +2,7 @@ import { readFile, writeFile } from "node:fs/promises";
 import type { IncomingMessage } from "node:http";
 import type { Duplex } from "node:stream";
 import { createApplicationRuntime } from "../../application-runtime.js";
-import { createAuthServer, type AuthServer } from "../../auth/server.js";
+import { createAuthServer, type AuthServer, type AuthServerOptions } from "../../auth/server.js";
 import { composeBilling, type BillingConfig, type BillingRuntime } from "../../billing/index.js";
 import { composeEntitlements } from "../../auth/entitlements.js";
 import { readInstanceAuthPolicy } from "../../auth/instance-policy.js";
@@ -92,6 +92,11 @@ interface BillingInspectCommand {
   id: string;
   type: "billing-inspect";
   organizationId: string;
+}
+
+interface BillingTrialFailureCommand {
+  id: string;
+  type: "fail-next-billing-trial";
 }
 
 interface AccountSetupFailureCommand {
@@ -457,13 +462,20 @@ function browserProviderPage(request: Request, publicBaseUrl: string): Response 
   );
 }
 
-/** Hosted harness: new organizations start on the Free plan and membership changes re-report
- * seats to Stripe; self-hosted keeps the unlimited default and no reporting. Kept out of `main` so
- * its branch does not push that function past the complexity cap. */
-function billingAuthOptions(billing: BillingRuntime | null) {
+/** Hosted harness: new organizations stamp the Free floor and immediately start a Stripe trial;
+ * membership changes re-report seats. Self-hosted keeps unlimited and no Stripe hooks. */
+function billingAuthOptions(
+  billing: BillingRuntime | null,
+): Partial<
+  Pick<
+    AuthServerOptions,
+    "provisioningEntitlements" | "onOrganizationCreated" | "onMembershipChanged"
+  >
+> {
   if (billing === null) return {};
   return {
     provisioningEntitlements: () => billing.provisioningEntitlement(),
+    onOrganizationCreated: (event) => billing.startSignup(event),
     onMembershipChanged: (organizationId: string) => billing.reportSeatUsage(organizationId),
   };
 }
@@ -862,7 +874,25 @@ function acceptBillingCommand(
     });
     return true;
   }
+  if (isBillingTrialFailureCommand(message)) {
+    if (billingClient === null) {
+      process.send?.({ id: message.id, ok: false, error: "billing is not configured" });
+      return true;
+    }
+    billingClient.failNextTrialCreation();
+    process.send?.({ id: message.id, ok: true });
+    return true;
+  }
   return false;
+}
+
+function isBillingTrialFailureCommand(value: unknown): value is BillingTrialFailureCommand {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    Reflect.get(value, "type") === "fail-next-billing-trial" &&
+    typeof Reflect.get(value, "id") === "string"
+  );
 }
 
 function isGitHubConfigurationCommand(value: unknown): value is GitHubConfigurationCommand {

--- a/src/index.ts
+++ b/src/index.ts
@@ -206,12 +206,13 @@ function createProductionAuthServer(
     ...(trustedClientIpHeader === undefined ? {} : { trustedClientIpHeader }),
     ...(invitationMailer === undefined ? {} : { invitationMailer }),
     ...(accountMailer === undefined ? {} : { accountMailer }),
-    // Hosted: new organizations start on the Free plan from the catalog mirror. Self-hosted
-    // (billing null) keeps the createAuthServer default, which stamps unlimited.
+    // Hosted: new organizations are stamped with the Free floor, then synchronously moved onto
+    // their Stripe trial. Self-hosted keeps the unlimited default and never touches Stripe.
     ...(billing === null
       ? {}
       : {
           provisioningEntitlements: () => billing.provisioningEntitlement(),
+          onOrganizationCreated: (event) => billing.startSignup(event),
           onMembershipChanged: (organizationId: string) => billing.reportSeatUsage(organizationId),
         }),
   });

--- a/src/organizations/signup-intent.ts
+++ b/src/organizations/signup-intent.ts
@@ -1,0 +1,26 @@
+import { z } from "zod";
+
+/** Marketing entry parameter. Add future signup offers here, then dispatch them in billing. */
+export const SIGNUP_INTENT_QUERY_PARAMETER = "plan";
+export const SIGNUP_INTENT_COOKIE = "paseo_signup_plan";
+export const signupIntentSchema = z.enum(["trial"]);
+export type SignupIntent = z.infer<typeof signupIntentSchema>;
+
+/** The post-commit signup event shared by auth and the hosted billing integration. */
+export interface OrganizationCreatedEvent {
+  organizationId: string;
+  accountEmail: string;
+  accountName: string;
+  intent: SignupIntent;
+}
+
+export const DEFAULT_SIGNUP_INTENT: SignupIntent = "trial";
+
+export function parseSignupIntent(value: unknown): SignupIntent | undefined {
+  const parsed = signupIntentSchema.safeParse(value);
+  return parsed.success ? parsed.data : undefined;
+}
+
+export function signupIntentOrDefault(value: unknown): SignupIntent {
+  return parseSignupIntent(value) ?? DEFAULT_SIGNUP_INTENT;
+}


### PR DESCRIPTION
A new hosted organization now starts its 14-day cardless trial during creation and lands with the Paseo Hub plan active. The internal Free entitlement floor remains only as the fail-closed state when Stripe cannot be reached and the landing state after cancellation.

## Goals

- Carry the validated `?plan=trial` marketing intent through signup and organization creation in an HTTP-only cookie.
- Keep the bare `https://hub.paseo.sh/` entry defaulting to the trial until the marketing link changes.
- Start and synchronously reconcile the Stripe-owned trial after organization creation commits, without allowing billing failures to roll back creation.
- Keep trial length, Stripe trial parameters, and trial eligibility policy in one home each.
- Preserve Checkout as the cardless first-trial fallback when creation-time Stripe access fails and as the paid path after a trial has been consumed.
- Keep subscription webhook replay idempotent and the Free-floor cancellation stamp intact.

The marketing CTA should switch to `https://hub.paseo.sh/?plan=trial`.

## Non-goals

- Adding a hosted free-plan intent or signup plan picker.
- Adding a Hub-owned trial clock, expiry worker, or trial database columns.
- Changing self-hosted or bootstrap-organization behavior.

## Why

The previous hosted signup provisioned only the internal Free floor, so customers landed on a billing paywall and had to discover Checkout before their trial began. Stripe remains the source of truth for the trial lifecycle; the creation request is the only new Stripe touchpoint, and failures preserve the existing Checkout fallback.

## Verification

- `npx vitest run src/billing` — 10 files, 69 tests passed.
- `npm run typecheck` — passed.
- `npm run lint` — passed with 0 warnings and 0 errors.
- `npm run format:check` — passed.
- `npm run db:check` — 45 tables, no schema changes.
- Targeted browser suite — 8 passed; the metered entitlements test has a pre-existing failure reproduced on unmodified `main` at merge-base `390b7118f690657d8e7a7018b78d939a62d65d50`.

The unrelated baseline failure is:

```text
Expected pattern: /\/triggers$/u
Received string: ".../triggers/new"
Timeout: 5000ms
```

## Risk surface

The change affects hosted signup intent persistence, the post-commit organization hook, Stripe customer/subscription creation, synchronous entitlement reconciliation, and billing browser fixtures. Unit coverage exercises successful creation, replay, duplicate subscription history, invalid public catalogs, and Stripe failure; browser coverage exercises automatic trial creation, cancellation, mobile presentation, and the Checkout fallback.
