### PR TITLE
Guide locked member invites to the right remedy

### DIFF
--- a/docs/entitlements.md
+++ b/docs/entitlements.md
@@ -93,6 +93,21 @@ flags. It maps to one wire shape, `EntitlementDenialPayload`
 (`encodeEntitlementDenialFailureReason`/`decodeEntitlementDenialFailureReason`). Nothing catches
 and reshapes a denial per call site.
 
+Lock the control when the UI can see the denial coming. Shared primitives in
+`src/entitlements/ui/` read the cached organization limits, distinguish exhausted headroom from
+an existing overage, render a locked action, and link it to the deployment's remedy — the plan
+picker (`/o/:slug/settings/billing?plans=true`, open on arrival) on a billing-configured instance,
+the Usage page otherwise, since self-hosted has nothing to buy and the limit is the operator's to
+raise. The call site still owns its policy check and the sentence naming the limit: a boolean flag
+and a numeric cap need not pretend to be the same rule.
+
+Keep a locked control as a live link rather than a disabled button: a disabled control leads
+nowhere and explains nothing. The server-side denial message stays as the fallback for the race,
+and remains the only path for denials no control can anticipate.
+
+The Team page reaches the picker by URL rather than by rendering it, because `src/billing/` may
+not be imported outside its boundary (docs/billing.md). Any future locked control does the same.
+
 ## Fail closed
 
 Enforcement must fail closed. An early version threaded `EntitlementsService` as an optional

--- a/e2e/billing-downgrade.spec.ts
+++ b/e2e/billing-downgrade.spec.ts
@@ -28,7 +28,6 @@ const invitees = [
   "three-downgrade@example.com",
   "four-downgrade@example.com",
 ];
-const sixthInvitee = "five-downgrade@example.com";
 
 test("losing the plan keeps every seat, warns that the org is over its limit, and blocks a new invite", async ({
   hub,
@@ -59,9 +58,9 @@ test("losing the plan keeps every seat, warns that the org is over its limit, an
     await page.screenshot({ path: `${DIR}/02-over-limit-banner.png`, fullPage: true });
   });
 
-  await test.step("a sixth invite is refused — the floor blocks growth past the cap", async () => {
-    await hub.expectInviteBlockedByPlan("owner", sixthInvitee);
-    await page.screenshot({ path: `${DIR}/03-invite-blocked.png`, fullPage: true });
+  await test.step("a sixth invite is locked — the floor blocks growth past the cap", async () => {
+    await hub.expectInviteLockedByPlan("owner");
+    await page.screenshot({ path: `${DIR}/03-invite-locked.png`, fullPage: true });
   });
 });
 

--- a/e2e/billing-subscription.spec.ts
+++ b/e2e/billing-subscription.spec.ts
@@ -14,7 +14,6 @@ const owner = {
   password: "nadia-billing-password",
 };
 const invitee = "teammate-billing@example.com";
-const afterCancelInvitee = "post-cancel-billing@example.com";
 
 const SLICE_6_DIR = "e2e/screenshots/slice-6";
 
@@ -35,11 +34,14 @@ test("subscribing lifts an unsubscribed org's invite limit, and replaying the we
   });
 
   await test.step("an organization on the one-seat floor cannot invite", async () => {
-    await hub.expectInviteBlockedByPlan("owner", invitee);
-    await page.screenshot({ path: `${SLICE_6_DIR}/02-invite-blocked.png`, fullPage: true });
+    await hub.expectInviteLockedByPlan("owner");
+    await page.screenshot({ path: `${SLICE_6_DIR}/02-invite-locked.png`, fullPage: true });
   });
 
   await test.step("open the upgrade dialog and choose a paid plan", async () => {
+    // The locked control is the paywall's entrance: following it lands on Billing with the offer
+    // already open, so the customer never has to go find what to buy.
+    await hub.followInviteLockToPlans("owner");
     await hub.expectCardlessTrialOffer("owner");
     await page.screenshot({ path: `${SLICE_6_DIR}/03-upgrade-dialog.png`, fullPage: true });
     await hub.choosePlan("owner", "Hosted");
@@ -73,7 +75,7 @@ test("subscribing lifts an unsubscribed org's invite limit, and replaying the we
     // canceled state and stamps the free floor, so paid entitlements do not outlive the
     // subscription.
     await hub.cancelSubscription("owner");
-    await hub.expectInviteBlockedByPlan("owner", afterCancelInvitee);
+    await hub.expectInviteLockedByPlan("owner");
     // Enforcement reverts to the zero-execution floor; the customer-facing page says only that
     // there is no subscription, and offers the plan again.
     await hub.expectNoSubscription("owner");

--- a/e2e/entitlements.spec.ts
+++ b/e2e/entitlements.spec.ts
@@ -9,7 +9,6 @@ const owner = {
   password: "amara-entitlements-password",
 };
 const secondMember = "bela-entitlements@example.com";
-const thirdMember = "cyrus-entitlements@example.com";
 const meterOwner = {
   name: "Deo",
   email: "deo-entitlements@example.com",
@@ -67,9 +66,11 @@ test("an operator caps seats, a blocked invite explains itself, and the audit tr
     await hub.inviteMember("owner", secondMember, "member");
   });
 
-  await test.step("a third invite is refused with a message that names the limit", async () => {
-    await hub.expectInviteRefusedBySeatLimit("owner", thirdMember, { limit: 2, current: 2 });
-    await page.screenshot({ path: `${SLICE_2_DIR}/03-invite-refused.png`, fullPage: true });
+  await test.step("a third invite is locked, and the lock names the limit", async () => {
+    await hub.expectInviteLockedBySeatLimit("owner", { limit: 2, current: 2 });
+    await page.screenshot({ path: `${SLICE_2_DIR}/03-invite-locked.png`, fullPage: true });
+    // Self-hosted there is no plan to buy, so the lock leads to the page that names the limit.
+    await hub.followInviteLockToUsage("owner");
   });
 
   await test.step("the operator audit trail records who capped seats and why", async () => {

--- a/e2e/helpers/hub.ts
+++ b/e2e/helpers/hub.ts
@@ -1042,8 +1042,12 @@ export class PaseoHub {
     await this.requireUser(alias).expectPlanPickerFitsPhone();
   }
 
-  async expectInviteBlockedByPlan(alias: string, email: string): Promise<void> {
-    await this.requireUser(alias).expectInviteBlockedByPlan(email);
+  async expectInviteLockedByPlan(alias: string): Promise<void> {
+    await this.requireUser(alias).expectInviteLockedByPlan();
+  }
+
+  async followInviteLockToPlans(alias: string): Promise<void> {
+    await this.requireUser(alias).followInviteLockToPlans();
   }
 
   async expectPendingInvitation(alias: string, email: string): Promise<void> {
@@ -1123,12 +1127,15 @@ export class PaseoHub {
     await this.requireUser(alias).expectMeterUsage(expected);
   }
 
-  async expectInviteRefusedBySeatLimit(
+  async expectInviteLockedBySeatLimit(
     alias: string,
-    email: string,
     expected: { limit: number; current: number },
   ): Promise<void> {
-    await this.requireUser(alias).expectInviteRefusedBySeatLimit(email, expected);
+    await this.requireUser(alias).expectInviteLockedBySeatLimit(expected);
+  }
+
+  async followInviteLockToUsage(alias: string): Promise<void> {
+    await this.requireUser(alias).followInviteLockToUsage();
   }
 
   async expectEntitlementsAudit(
@@ -3705,6 +3712,11 @@ class HubUser {
       .parse(await this.page.evaluate(() => navigator.clipboard.readText()));
   }
 
+  /** The invite control in its locked state: a link out to the remedy, not a disabled button. */
+  private lockedInvite(): Locator {
+    return this.page.getByRole("link", { name: "Invite member" });
+  }
+
   private async openInvitationForm(): Promise<Locator> {
     await this.page.getByRole("button", { name: "Invite member" }).click();
     const form = this.page.getByRole("form", { name: "Invite team member" });
@@ -4089,20 +4101,27 @@ class HubUser {
     );
   }
 
-  async expectInviteRefusedBySeatLimit(
-    email: string,
-    expected: { limit: number; current: number },
-  ): Promise<void> {
+  /**
+   * A full cap locks the invite control instead of letting an owner fill in a form the server
+   * will refuse, and the lock names the limit it hit.
+   */
+  async expectInviteLockedBySeatLimit(expected: { limit: number; current: number }): Promise<void> {
     await this.refreshOrganizationSection("Team");
-    const form = await this.openInvitationForm();
-    await form.getByLabel("Invitee email").fill(email);
-    await form.getByRole("button", { name: "Create invitation" }).click();
-    await expect(form).toBeHidden();
-    const alert = this.page.getByRole("alert");
-    await expect(alert).toContainText("Seat limit reached");
-    await expect(alert).toContainText(`${expected.current} of ${expected.limit} seats`);
-    await expect(alert).toContainText("Usage page");
-    await expect(this.invitationRow(email)).toHaveCount(0);
+    await expect(this.lockedInvite()).toHaveAttribute(
+      "title",
+      `Seat limit reached — ${expected.current} of ${expected.limit} seats are in use. See the Usage page for its limits.`,
+    );
+    await expect(this.page.getByRole("button", { name: "Invite member" })).toHaveCount(0);
+    await expectAccessible(this.page);
+  }
+
+  /** Self-hosted there is nothing to buy, so the lock leads to the page that names the limit. */
+  async followInviteLockToUsage(): Promise<void> {
+    await this.refreshOrganizationSection("Team");
+    await this.lockedInvite().click();
+    await expect(
+      this.page.getByRole("heading", { name: "Usage", exact: true, level: 1 }),
+    ).toBeVisible();
   }
 
   async expectEntitlementsAudit(expected: {
@@ -4293,16 +4312,31 @@ class HubUser {
     await expectAccessible(this.page);
   }
 
-  async expectInviteBlockedByPlan(email: string): Promise<void> {
+  async expectInviteLockedByPlan(): Promise<void> {
     await this.refreshOrganizationSection("Team");
-    const form = await this.openInvitationForm();
-    await form.getByLabel("Invitee email").fill(email);
-    await form.getByRole("button", { name: "Create invitation" }).click();
-    await expect(form).toBeHidden();
-    const alert = this.page.getByRole("alert");
-    await expect(alert).toContainText("Inviting members isn't enabled");
-    await expect(this.invitationRow(email)).toHaveCount(0);
+    await expect(this.lockedInvite()).toHaveAttribute(
+      "title",
+      "Inviting members isn't enabled for this organization. See the plans available to this organization.",
+    );
+    await expect(this.page.getByRole("button", { name: "Invite member" })).toHaveCount(0);
     await expectAccessible(this.page);
+  }
+
+  /** Hosted, the lock is the paywall's entrance: it lands on Billing with the offer already open. */
+  async followInviteLockToPlans(): Promise<void> {
+    await this.refreshOrganizationSection("Team");
+    await this.lockedInvite().click();
+    // The open picker is modal, so the page behind it is out of the accessibility tree: the URL
+    // is what says where the lock landed.
+    await expect(this.page).toHaveURL(/\/settings\/billing\?plans=true$/u);
+    const dialog = this.page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+    await expectAccessible(this.page);
+    await this.page.keyboard.press("Escape");
+    await expect(dialog).toHaveCount(0);
+    await expect(
+      this.page.getByRole("heading", { name: "Billing", exact: true, level: 1 }),
+    ).toBeVisible();
   }
 
   async expectPendingInvitation(email: string): Promise<void> {

--- a/src/auth/team.tsx
+++ b/src/auth/team.tsx
@@ -33,6 +33,8 @@ import { useActiveAccount } from "./active-account.js";
 import { cancelInvitation, changeMemberRole, createInvitation, removeMember } from "./functions.js";
 import type { Result } from "../contract/respond.js";
 import { ACCOUNT_MUTATION_KEY, useAccountMutationPending } from "./account-mutation.js";
+import type { UsageLimitsView } from "../usage/dashboard.js";
+import { atLimit, LockedAction, useOrganizationLimits } from "../entitlements/ui/index.js";
 
 type AccountCommandResult = Result<{
   state: "sessionExpired" | "organizationRequired" | "complete";
@@ -82,6 +84,8 @@ export function Team() {
   const [inviting, setInviting] = useState(false);
   const invite = useCallback(() => setInviting(true), []);
   const busy = useAccountMutationPending();
+  const limits = useOrganizationLimits(account.capabilities.manageMembers);
+  const limit = limits === undefined ? null : inviteLimit(limits);
   const activeAccount = useMemo(() => ({ ...account, busy }), [account, busy]);
 
   return (
@@ -92,10 +96,13 @@ export function Team() {
         description={`People with access to ${account.organization.name}.`}
       >
         {account.capabilities.manageMembers && (
-          <Button type="button" onClick={invite} disabled={busy}>
-            <Plus aria-hidden="true" />
-            Invite member
-          </Button>
+          <LockedAction
+            limit={limit}
+            label="Invite member"
+            icon={Plus}
+            onPress={invite}
+            busy={busy}
+          />
         )}
       </PageHeader>
       <Section title="Members">
@@ -115,6 +122,18 @@ export function Team() {
       )}
     </>
   );
+}
+
+/**
+ * The limit the organization has run into, or null while it may still invite. The flag is
+ * reported ahead of the seat cap: an organization with invitations turned off is not short of
+ * seats.
+ */
+function inviteLimit(limits: UsageLimitsView): string | null {
+  if (!limits.canInviteMembers) return "Inviting members isn't enabled for this organization.";
+  const { seats } = limits;
+  if (!atLimit(seats)) return null;
+  return `Seat limit reached — ${seats.used} of ${seats.limit} seats are in use.`;
 }
 
 function InvitationDialog({

--- a/src/billing/ui/panel.tsx
+++ b/src/billing/ui/panel.tsx
@@ -18,7 +18,7 @@ import { NO_SUBSCRIPTION, subscriptionSummary, type SubscriptionSummary } from "
 
 type PortalResult = Awaited<ReturnType<typeof billingPortal>>;
 
-export function BillingPanel() {
+export function BillingPanel({ openPlans }: { openPlans: boolean }) {
   const tenant = useRouteTenant();
   const load = useServerFn(billingOverview);
   const query = useQuery({
@@ -39,7 +39,13 @@ export function BillingPanel() {
       </Alert>
     );
   }
-  return <BillingContent overview={query.data.data} slug={tenant.organization.slug} />;
+  return (
+    <BillingContent
+      overview={query.data.data}
+      slug={tenant.organization.slug}
+      openPlans={openPlans}
+    />
+  );
 }
 
 /**
@@ -47,9 +53,21 @@ export function BillingPanel() {
  * out to Stripe. The bands share a card so the page reads as a single object rather than a stack
  * of unrelated boxes, and each band owns its own padding so nothing collides.
  */
-function BillingContent({ overview, slug }: { overview: BillingOverviewView; slug: string }) {
+function BillingContent({
+  overview,
+  slug,
+  openPlans,
+}: {
+  overview: BillingOverviewView;
+  slug: string;
+  openPlans: boolean;
+}) {
   const { subscription, plans, canManage } = overview;
-  const [dialogOpen, setDialogOpen] = useState(false);
+  const action = planPickerAction({ canManage, subscription, plans });
+  // The picker only opens on arrival when there is one to open: a member who follows the link
+  // from a locked control lands on the page and reads it, rather than facing a dialog offering
+  // a purchase they cannot make.
+  const [dialogOpen, setDialogOpen] = useState(openPlans && action !== null);
   const openDialog = useCallback(() => setDialogOpen(true), []);
   const closeDialog = useCallback(() => setDialogOpen(false), []);
   const summary = subscriptionSummary(subscription);
@@ -67,11 +85,7 @@ function BillingContent({ overview, slug }: { overview: BillingOverviewView; slu
       </PageHeader>
       <Section title="Plan">
         <div className="overflow-hidden rounded-xl border bg-card text-card-foreground">
-          <PlanIdentity
-            summary={summary}
-            action={planPickerAction({ canManage, subscription, plans })}
-            onOpenPicker={openDialog}
-          />
+          <PlanIdentity summary={summary} action={action} onOpenPicker={openDialog} />
           {currentPlan !== undefined && <PlanIncludes plan={currentPlan} />}
           {canManage && subscription.manageable && <PortalBand slug={slug} />}
         </div>

--- a/src/entitlements/ui/index.tsx
+++ b/src/entitlements/ui/index.tsx
@@ -1,0 +1,82 @@
+/* oxlint-disable typescript-eslint/no-unsafe-type-assertion -- dynamic remedy URLs are validated by their route owners */
+import { Link } from "@tanstack/react-router";
+import { useQuery } from "@tanstack/react-query";
+import { useServerFn } from "@tanstack/react-start";
+import { Lock, type LucideIcon } from "lucide-react";
+import { Button } from "../../components/ui/button.js";
+import { useRouteTenant } from "../../projects/context.js";
+import { billingConfigured } from "../../server/capabilities.js";
+import type { UsageLimitsView } from "../../usage/dashboard.js";
+import { usageSnapshot } from "../../usage/functions.js";
+export { atLimit, overLimit } from "../../usage/limits.js";
+
+export function useOrganizationLimits(enabled = true): UsageLimitsView | undefined {
+  const tenant = useRouteTenant();
+  const load = useServerFn(usageSnapshot);
+  const query = useQuery({
+    queryKey: ["usage", tenant.account.id, tenant.organization.id],
+    queryFn: () => load({ data: { organizationSlug: tenant.organization.slug } }),
+    enabled,
+  });
+
+  return query.data?.status === "ok" ? query.data.data.limits : undefined;
+}
+
+export interface EntitlementRemedy {
+  href: string;
+  clause: string;
+}
+
+/** The place this deployment gives an organization to raise or understand its limits. */
+export function useEntitlementRemedy(enabled = true): EntitlementRemedy {
+  const tenant = useRouteTenant();
+  const load = useServerFn(billingConfigured);
+  const billing = useQuery({
+    queryKey: ["billing-configured"],
+    queryFn: () => load(),
+    staleTime: Number.POSITIVE_INFINITY,
+    enabled,
+  });
+  const base = `/o/${tenant.organization.slug}/settings`;
+
+  if (billing.data?.configured === true) {
+    return {
+      href: `${base}/billing?plans=true`,
+      clause: "See the plans available to this organization.",
+    };
+  }
+  return { href: `${base}/usage`, clause: "See the Usage page for its limits." };
+}
+
+export function LockedAction({
+  limit,
+  label,
+  icon: Icon,
+  onPress,
+  busy = false,
+}: {
+  limit: string | null;
+  label: string;
+  icon: LucideIcon;
+  onPress: () => void;
+  busy?: boolean;
+}) {
+  const remedy = useEntitlementRemedy(limit !== null);
+
+  if (limit === null) {
+    return (
+      <Button type="button" onClick={onPress} disabled={busy}>
+        <Icon aria-hidden="true" />
+        {label}
+      </Button>
+    );
+  }
+  return (
+    <Button asChild>
+      <Link to={remedy.href as never} title={`${limit} ${remedy.clause}`}>
+        <Lock aria-hidden="true" />
+        {label}
+      </Link>
+    </Button>
+  );
+}

--- a/src/routes/_shell/o/$organizationSlug/settings/billing.tsx
+++ b/src/routes/_shell/o/$organizationSlug/settings/billing.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute, notFound } from "@tanstack/react-router";
+import { z } from "zod";
 import { BillingPanel } from "../../../../../billing/ui/panel.js";
 import { billingConfigured } from "../../../../../server/capabilities.js";
 
@@ -10,9 +11,17 @@ import { billingConfigured } from "../../../../../server/capabilities.js";
 // so it is exempted from the src/billing/ import boundary in oxlint.json, which lets the whole
 // feature (server + UI) live under src/billing/ and be deleted as one directory.
 export const Route = createFileRoute("/_shell/o/$organizationSlug/settings/billing")({
+  // `?plans` arrives from surfaces that hit a plan limit — the locked invite control on Team — so
+  // the picker is open on arrival instead of asking the customer to find it again.
+  validateSearch: z.object({ plans: z.boolean().optional() }),
   loader: async () => {
     const { configured } = await billingConfigured();
     if (!configured) throw notFound();
   },
-  component: BillingPanel,
+  component: BillingRoute,
 });
+
+function BillingRoute() {
+  const { plans } = Route.useSearch();
+  return <BillingPanel openPlans={plans === true} />;
+}

--- a/src/usage/limits.test.ts
+++ b/src/usage/limits.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { atLimit, overLimit } from "./limits.js";
+
+describe("usage limit predicates", () => {
+  it("treats unlimited measures as neither at nor over their limit", () => {
+    const measure = { used: 100, limit: null };
+    expect(atLimit(measure)).toBe(false);
+    expect(overLimit(measure)).toBe(false);
+  });
+
+  it("distinguishes exhausted headroom from an existing overage", () => {
+    expect(atLimit({ used: 2, limit: 2 })).toBe(true);
+    expect(overLimit({ used: 2, limit: 2 })).toBe(false);
+    expect(atLimit({ used: 3, limit: 2 })).toBe(true);
+    expect(overLimit({ used: 3, limit: 2 })).toBe(true);
+  });
+});

--- a/src/usage/limits.ts
+++ b/src/usage/limits.ts
@@ -1,0 +1,11 @@
+import type { UsageMeasure } from "./dashboard.js";
+
+/** Whether adding one more unit would exceed this measure. */
+export function atLimit(measure: UsageMeasure): boolean {
+  return measure.limit !== null && measure.used >= measure.limit;
+}
+
+/** Whether current use is already beyond this measure. */
+export function overLimit(measure: UsageMeasure): boolean {
+  return measure.limit !== null && measure.used > measure.limit;
+}

--- a/src/usage/panel.tsx
+++ b/src/usage/panel.tsx
@@ -13,6 +13,7 @@ import type { EntitlementChangeSource } from "../db/types.js";
 import { useRouteTenant } from "../projects/context.js";
 import type { UsageDashboard, UsageMeasure } from "./dashboard.js";
 import { usageSnapshot } from "./functions.js";
+import { overLimit } from "./limits.js";
 
 type Snapshot = Awaited<ReturnType<UsageDashboard["snapshot"]>>;
 
@@ -120,7 +121,7 @@ const LIMITS_EMPTY = { title: "No limits" };
  * operator's to raise. Renders nothing while within the seat limit.
  */
 function SeatOverLimitBanner({ seats }: { seats: UsageMeasure }) {
-  if (seats.limit === null || seats.used <= seats.limit) return null;
+  if (!overLimit(seats)) return null;
   return (
     <Alert aria-label="Over limit" className="border-warning/40 bg-warning-surface">
       <TriangleAlert className="text-warning" />


### PR DESCRIPTION
People who cannot invite another member now see a locked “Invite member” action that takes them directly to the appropriate remedy: the plan picker on Hosted or Usage limits when self-hosted. The entitlement UI now exposes reusable building blocks so future paywalled controls share the presentation and remedy without sharing their policy logic.

## Goals

- Show invite limits before a rejected submission.
- Open the existing plan picker directly on billing-configured deployments.
- Point self-hosted deployments to their Usage limits instead of a nonexistent purchase flow.
- Standardize cached limit reads, limit predicates, remedy selection, and locked-action presentation.
- Keep each feature's boolean or numeric entitlement decision at its call site.

## Non-goals

- Generalize entitlement policies into a registry or DSL.
- Replace server-side enforcement or denial messages.
- Add an in-place billing dialog outside the billing module.

## Why

Entitlement policies differ: some are flags and some compare usage with a cap. The reusable seam is the UI behavior after a surface decides it is blocked. Centralizing that seam prevents each call site from inventing paywall behavior or accidentally linking self-hosted users to a hosted-only route.

## Verification

- `npm run format:check`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npx vitest run src/usage/limits.test.ts`
- 16 affected desktop Chromium E2E tests across billing subscription, billing downgrade, entitlements, dashboard, and invitation flows
- The daemon-backed metered-usage E2E remains locally unavailable because its source daemon connection setup fails before the Hub workflow begins.

## Risk surface

The change touches organization Team and Usage settings, the hosted Billing route search state, and shared E2E helpers. Server enforcement is unchanged.