### PR TITLE
fix(linear): comment history query declares its variables with the types Linear expects

### DIFF
--- a/src/providers/linear/client.test.ts
+++ b/src/providers/linear/client.test.ts
@@ -153,6 +153,10 @@ describe("Linear connection client", () => {
     });
     assert.equal(requests[0]?.authorization, "Bearer access-token");
     const request = graphqlRequest(requests[0]?.body ?? "{}");
+    // The issue filter compares an ID; Linear rejects a String variable in that position.
+    assert.match(request.query, /\$issueId: ID!/u);
+    assert.match(request.query, /issue: \{ id: \{ eq: \$issueId \} \}/u);
+    assert.match(request.query, /\$before: DateTimeOrDuration!/u);
     assert.match(request.query, /last: 49/u);
     assert.match(request.query, /orderBy: createdAt/u);
     assert.match(request.query, /createdAt: \{ lt: \$before \}/u);

--- a/src/providers/linear/client.ts
+++ b/src/providers/linear/client.ts
@@ -352,7 +352,7 @@ export function createLinearApiClient(options: {
     async readIssueComments(input) {
       const result = IssueCommentHistoryResponseSchema.parse(
         await graphql(request, await accessTokenFor(input.linearOrganizationId), {
-          query: `query PaseoIssueCommentHistory($issueId: String!, $before: DateTime!) {
+          query: `query PaseoIssueCommentHistory($issueId: ID!, $before: DateTimeOrDuration!) {
             comments(
               last: ${LINEAR_ISSUE_COMMENT_CONTEXT_LIMIT}
               orderBy: createdAt


### PR DESCRIPTION
`PaseoIssueCommentHistory` declares `$issueId: String!` and `$before: DateTime!`, but uses them where Linear's schema expects `ID` (`IDComparator.eq`) and `DateTimeOrDuration` (`DateComparator.lt`). Linear rejects the document at validation time:

```
Variable "$issueId" of type "String!" used in position expecting type "ID"
```

So every comment-thread hydration fails (`linear.issue.history.hydrate failed` on each comment run) and the agent answers without the previous turns of the thread. Observed on a self-hosted hub against a real workspace; replaying the same query with `ID!` and `DateTimeOrDuration!` succeeds. `PaseoComment` keeps `String!`, since `CommentCreateInput.issueId` is a `String`.

The `DateTimeOrDuration` half is already in #88 (reported there earlier); this PR makes the query valid on `main` on its own and merges cleanly ahead of or after #88. Test asserts both variable types and the filter position.

Validation: `vitest run src/providers/linear/client.test.ts` (8 passed), `oxfmt --check`, `oxlint` on the two files.