### PR TITLE
Show daemon provider options in trigger setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ permissions:
 # companion PR creator commits it. Source-built jobs deliberately fail until it
 # is one exact 40-character SHA; mutable refs and repository variables are forbidden.
 env:
-  PASEO_E2E_COMMIT: 5f127d1b4a2c8d98fa18ef2b9c82309ab0d39750
+  PASEO_E2E_COMMIT: c16d4f14a3ec95485f37aa7fb6201b7c239d9d2a
 
 jobs:
   typecheck:

--- a/e2e/entitlements.spec.ts
+++ b/e2e/entitlements.spec.ts
@@ -112,7 +112,6 @@ test.describe("metered usage", () => {
         name: "deploy",
         daemon: "slice-three-runner",
         cwd: "/workspace",
-        agent: "codex/gpt-5.4",
         prompt: "${{ paseo.prompt }}",
       });
       await triggers.save("deploy");

--- a/e2e/entitlements.spec.ts
+++ b/e2e/entitlements.spec.ts
@@ -112,7 +112,7 @@ test.describe("metered usage", () => {
         name: "deploy",
         daemon: "slice-three-runner",
         cwd: "/workspace",
-        agent: "opencode",
+        agent: "codex/gpt-5.4",
         prompt: "${{ paseo.prompt }}",
       });
       await triggers.save("deploy");

--- a/e2e/helpers/hub.ts
+++ b/e2e/helpers/hub.ts
@@ -1894,6 +1894,12 @@ export class PaseoHub {
     return this.seedDaemon(alias, slug);
   }
 
+  /** A connected session-v1 daemon that serves the trigger editor's provider catalog. */
+  async connectProviderDaemon(alias: string, organizationName: string): Promise<string> {
+    const daemon = await this.connectBrowserDaemon(alias, organizationName, "devbox", true);
+    return daemon.slug;
+  }
+
   /** A connected app precondition for trigger-editor journeys; OAuth itself has separate specs. */
   async seedSlackConnection(alias: string, slug: string, teamName: string): Promise<void> {
     await this.queryDatabase(
@@ -2091,6 +2097,7 @@ export class PaseoHub {
     _alias: string,
     organizationName: string,
     _displayName: string,
+    providerCatalog = false,
   ): Promise<ContractDaemon> {
     const enrollmentToken = randomUUID();
     const verifier = createHash("sha256").update(enrollmentToken).digest("base64url");
@@ -2100,7 +2107,7 @@ export class PaseoHub {
        select $1, $2, id, now() + interval '10 minutes' from organization where name = $3`,
       [randomUUID(), verifier, organizationName],
     );
-    const daemon = new ContractDaemon(this.primary, this.requests);
+    const daemon = new ContractDaemon(this.primary, this.requests, undefined, providerCatalog);
     await daemon.enroll(enrollmentToken);
     await daemon.connect();
     return daemon;
@@ -5245,6 +5252,7 @@ class ContractDaemon {
     private readonly application: BuiltApplication,
     private readonly requests: APIRequestContext,
     friendlyName?: string,
+    private readonly providerCatalog = false,
   ) {
     const fallback = `daemon-${this.daemonId.slice(0, 8)}`;
     this.slug = friendlyName === undefined ? fallback : slugify(friendlyName, fallback);
@@ -5274,6 +5282,7 @@ class ContractDaemon {
       headers: {
         authorization: `Bearer ${this.credential}`,
         "x-paseo-daemon-id": this.daemonId,
+        ...(this.providerCatalog ? { "x-paseo-session-protocol": "1" } : {}),
       },
     });
     socket.on("message", (data) => this.acceptExecution(data));
@@ -5327,7 +5336,9 @@ class ContractDaemon {
   }
 
   private acceptExecution(data: RawData): void {
-    const envelope = ExecutionRequestSchema.safeParse(JSON.parse(readSocketData(data)));
+    const value: unknown = JSON.parse(readSocketData(data));
+    if (this.acceptHello(value) || this.acceptProviderRequest(value)) return;
+    const envelope = ExecutionRequestSchema.safeParse(value);
     if (!envelope.success) return;
     const request = envelope.data.message;
     const capability = request.mcpServers?.["hub"];
@@ -5354,7 +5365,113 @@ class ContractDaemon {
       }),
     );
   }
+
+  private acceptHello(value: unknown): boolean {
+    const hello = z.object({ type: z.literal("hello") }).safeParse(value);
+    if (!hello.success) return false;
+    this.socket?.send(
+      JSON.stringify({
+        type: "session",
+        message: {
+          type: "status",
+          payload: {
+            status: "server_info",
+            serverId: `browser-${this.daemonId}`,
+            permissions: ["hub.execute"],
+            features: { providersSnapshot: true },
+          },
+        },
+      }),
+    );
+    return true;
+  }
+
+  private acceptProviderRequest(value: unknown): boolean {
+    const envelope = z
+      .object({
+        type: z.literal("session"),
+        message: z.discriminatedUnion("type", [
+          z.object({
+            type: z.literal("get_providers_snapshot_request"),
+            requestId: z.string(),
+            cwd: z.string().optional(),
+          }),
+          z.object({
+            type: z.literal("refresh_providers_snapshot_request"),
+            requestId: z.string(),
+          }),
+        ]),
+      })
+      .safeParse(value);
+    if (!envelope.success) return false;
+    const request = envelope.data.message;
+    const message =
+      request.type === "refresh_providers_snapshot_request"
+        ? {
+            type: "refresh_providers_snapshot_response",
+            payload: { requestId: request.requestId, acknowledged: true },
+          }
+        : {
+            type: "get_providers_snapshot_response",
+            payload: {
+              requestId: request.requestId,
+              ...(request.cwd === undefined ? {} : { cwd: request.cwd }),
+              entries: browserProviderSnapshot,
+              generatedAt: new Date().toISOString(),
+            },
+          };
+    this.socket?.send(JSON.stringify({ type: "session", message }));
+    return true;
+  }
 }
+
+const browserProviderSnapshot = [
+  {
+    provider: "pi",
+    status: "ready",
+    enabled: true,
+    label: "Pi",
+    models: [
+      {
+        provider: "pi",
+        id: "gateway/vendor/model-v1",
+        label: "Gateway Model v1",
+        isDefault: true,
+        thinkingOptions: [
+          { id: "low", label: "Low" },
+          { id: "high", label: "High", isDefault: true },
+        ],
+        defaultThinkingOptionId: "high",
+      },
+      {
+        provider: "pi",
+        id: "gateway/vendor/model-v2",
+        label: "Gateway Model v2",
+        thinkingOptions: [{ id: "high", label: "High" }],
+      },
+    ],
+    modes: [{ id: "full-access", label: "Full access" }],
+    defaultModeId: "full-access",
+  },
+  {
+    provider: "codex",
+    status: "ready",
+    enabled: true,
+    label: "Codex",
+    models: [
+      {
+        provider: "codex",
+        id: "gpt-5.4",
+        label: "GPT-5.4",
+        isDefault: true,
+        thinkingOptions: [{ id: "high", label: "High", isDefault: true }],
+        defaultThinkingOptionId: "high",
+      },
+    ],
+    modes: [{ id: "full-access", label: "Full access" }],
+    defaultModeId: "full-access",
+  },
+] as const;
 
 type ExecutionCapability = { url: string; headers: Record<string, string> };
 

--- a/e2e/helpers/triggers.ts
+++ b/e2e/helpers/triggers.ts
@@ -40,14 +40,14 @@ export class OrganizationTriggers {
     prompt: string;
   }) {
     await this.page.getByLabel("Trigger name").fill(input.name);
-    await this.page.getByLabel("When this happens").selectOption("slack.mention");
-    await this.page.getByLabel("Connection", { exact: true }).selectOption(input.connection);
+    await this.selectOption("When this happens", "slack.mention");
+    await this.selectOption("Connection", input.connection);
     await this.page.getByRole("button", { name: "Specific people" }).click();
     await this.page.getByLabel("User IDs").fill(input.users);
-    await this.page.getByLabel("Run on daemon").selectOption(input.daemon);
+    await this.selectOption("Run on daemon", input.daemon);
     await this.page.getByLabel("Working directory").fill(input.cwd);
-    await this.page.getByLabel("Agent ID", { exact: true }).fill(input.agent);
-    await this.page.getByLabel("Execution mode", { exact: true }).fill(input.mode);
+    await this.selectAgent(input.agent);
+    await this.selectOption("Execution mode", input.mode);
     await this.page
       .locator("summary")
       .filter({ hasText: "Advanced provider options (JSON)" })
@@ -64,10 +64,10 @@ export class OrganizationTriggers {
     prompt: string;
   }) {
     await this.page.getByLabel("Trigger name").fill(input.name);
-    await this.page.getByLabel("When this happens").selectOption("manual.run");
-    await this.page.getByLabel("Run on daemon").selectOption(input.daemon);
+    await this.selectOption("When this happens", "manual.run");
+    await this.selectOption("Run on daemon", input.daemon);
     await this.page.getByLabel("Working directory").fill(input.cwd);
-    await this.page.getByLabel("Agent ID", { exact: true }).fill(input.agent);
+    await this.selectAgent(input.agent);
     await this.page.getByLabel("Instructions", { exact: true }).fill(input.prompt);
   }
 
@@ -78,7 +78,7 @@ export class OrganizationTriggers {
 
   async switchToForm() {
     await this.page.getByRole("button", { name: "Form" }).click();
-    await expect(this.page.getByLabel("Agent ID", { exact: true })).toBeVisible();
+    await expect(this.page.getByLabel("Agent", { exact: true })).toBeVisible();
   }
 
   async replaceYaml(yaml: string) {
@@ -106,8 +106,14 @@ export class OrganizationTriggers {
     providerOptions: string;
     prompt: string;
   }) {
-    await expect(this.page.getByLabel("Agent ID", { exact: true })).toHaveValue(input.agent);
-    await expect(this.page.getByLabel("Execution mode", { exact: true })).toHaveValue(input.mode);
+    await expect(this.page.getByRole("combobox", { name: "Agent" })).toHaveAttribute(
+      "data-value",
+      input.agent,
+    );
+    await expect(this.page.getByRole("combobox", { name: "Execution mode" })).toHaveAttribute(
+      "data-value",
+      input.mode,
+    );
     await this.page
       .locator("summary")
       .filter({ hasText: "Advanced provider options (JSON)" })
@@ -116,6 +122,33 @@ export class OrganizationTriggers {
       input.providerOptions,
     );
     await expect(this.page.getByLabel("Instructions", { exact: true })).toHaveValue(input.prompt);
+  }
+
+  async expectAgentSearch() {
+    const agent = this.page.getByRole("combobox", { name: "Agent" });
+    await agent.click();
+    const search = this.page.getByPlaceholder("Search models…");
+    await expect(search).toBeFocused();
+    await search.fill("gpt-5.4");
+    await expect(this.page.getByRole("option", { name: /GPT-5.4/u })).toBeVisible();
+    await expect(this.page.getByRole("option", { name: /Gateway Model v1/u })).toBeHidden();
+    await search.fill("");
+  }
+
+  async expectShadcnSelectors() {
+    await expect(
+      this.page.locator('#trigger-editor-form [data-slot="select-trigger"]'),
+    ).toHaveCount(6);
+    for (const name of [
+      "When this happens",
+      "Connection",
+      "Run on daemon",
+      "Agent",
+      "Execution mode",
+      "Thinking",
+    ]) {
+      await expect(this.page.getByRole("combobox", { name, exact: true })).toBeVisible();
+    }
   }
 
   async changePrompt(prompt: string) {
@@ -164,6 +197,24 @@ export class OrganizationTriggers {
   async captureInstructions(path: string) {
     await this.page.getByLabel("Instructions", { exact: true }).scrollIntoViewIfNeeded();
     await this.page.screenshot({ path });
+  }
+
+  async captureExpandedAgent(path: string) {
+    const agent = this.page.getByRole("combobox", { name: "Agent" });
+    await agent.scrollIntoViewIfNeeded();
+    await agent.click();
+    await expect(this.page.getByPlaceholder("Search models…")).toBeFocused();
+    await this.page.screenshot({ path });
+  }
+
+  private async selectAgent(agentId: string) {
+    await this.page.getByRole("combobox", { name: "Agent" }).click();
+    await this.page.getByRole("option").filter({ hasText: agentId }).click();
+  }
+
+  private async selectOption(label: string, value: string) {
+    await this.page.getByRole("combobox", { name: label, exact: true }).click();
+    await this.page.locator(`[role="option"][data-value=${JSON.stringify(value)}]`).click();
   }
 
   private yamlEditor() {

--- a/e2e/helpers/triggers.ts
+++ b/e2e/helpers/triggers.ts
@@ -60,14 +60,14 @@ export class OrganizationTriggers {
     name: string;
     daemon: string;
     cwd: string;
-    agent: string;
+    agent?: string;
     prompt: string;
   }) {
     await this.page.getByLabel("Trigger name").fill(input.name);
     await this.selectOption("When this happens", "manual.run");
     await this.selectOption("Run on daemon", input.daemon);
     await this.page.getByLabel("Working directory").fill(input.cwd);
-    await this.selectAgent(input.agent);
+    if (input.agent !== undefined) await this.selectAgent(input.agent);
     await this.page.getByLabel("Instructions", { exact: true }).fill(input.prompt);
   }
 

--- a/e2e/helpers/triggers.ts
+++ b/e2e/helpers/triggers.ts
@@ -209,7 +209,7 @@ export class OrganizationTriggers {
 
   private async selectAgent(agentId: string) {
     await this.page.getByRole("combobox", { name: "Agent" }).click();
-    await this.page.getByRole("option").filter({ hasText: agentId }).click();
+    await this.page.locator(`[role="option"][data-value=${JSON.stringify(agentId)}]`).click();
   }
 
   private async selectOption(label: string, value: string) {

--- a/e2e/triggers.spec.ts
+++ b/e2e/triggers.spec.ts
@@ -14,7 +14,7 @@ test("creates a trigger visually, preserves advanced YAML through the form, and 
 }) => {
   await hub.signUpAs("owner", owner);
   await hub.createOrganization("owner", "Acme");
-  await hub.seedDaemonSlug("owner", "devbox");
+  const daemon = await hub.connectProviderDaemon("owner", "Acme");
   await hub.seedSlackConnection("owner", "company-slack", "Acme Slack");
   const triggers = new OrganizationTriggers(page);
 
@@ -29,7 +29,7 @@ test("creates a trigger visually, preserves advanced YAML through the form, and 
     await triggers.configureSlackMention({
       name: "slack-help",
       connection: "company-slack",
-      daemon: "devbox",
+      daemon,
       cwd: "/workspace/acme",
       users: "U123, U456",
       agent: "pi/gateway/vendor/model-v1",
@@ -38,10 +38,13 @@ test("creates a trigger visually, preserves advanced YAML through the form, and 
       prompt: "Handle the Slack request.",
     });
     await triggers.expectMergeTagsAndAutosizing();
+    await triggers.expectAgentSearch();
+    await triggers.expectShadcnSelectors();
     await triggers.changePrompt("Handle the Slack request.");
     await page.evaluate(() => window.scrollTo({ top: 0 }));
     await triggers.capture(`${SHOTS}/02-configured-form.png`);
     await triggers.captureInstructions(`${SHOTS}/02b-agent-instructions.png`);
+    await triggers.captureExpandedAgent(`${SHOTS}/02c-expanded-model-combobox.png`);
   });
 
   await test.step("YAML mirrors the form and remains the canonical editable document", async () => {
@@ -54,7 +57,7 @@ test("creates a trigger visually, preserves advanced YAML through the form, and 
       "sandbox_mode: workspace-write",
     );
     await triggers.capture(`${SHOTS}/03-generated-yaml.png`);
-    await triggers.replaceYaml(advancedTriggerYaml);
+    await triggers.replaceYaml(advancedTriggerYaml(daemon));
     await triggers.save("slack-help");
     await triggers.expectOperationalList("slack-help");
     await triggers.capture(`${SHOTS}/04-saved-trigger-list.png`);
@@ -98,7 +101,8 @@ test("creates a trigger visually, preserves advanced YAML through the form, and 
   });
 });
 
-const advancedTriggerYaml = `# survives form edits
+function advancedTriggerYaml(daemon: string) {
+  return `# survives form edits
 name: slack-help
 enabled: true
 on:
@@ -109,7 +113,7 @@ on:
       channels: [engineering]
 run:
   target:
-    daemon: devbox
+    daemon: ${daemon}
     cwd: /workspace/acme
     worktree:
       mode: branch-off
@@ -130,6 +134,7 @@ run:
       max: 5
   auto_archive: false
 `;
+}
 
 const legacyWorkflowYaml = `name: legacy-review
 on: slack.mention

--- a/src/app.ts
+++ b/src/app.ts
@@ -73,6 +73,7 @@ export interface HubRuntimeOptions {
 
 export interface HubRuntime {
   daemonModule: DaemonModule | null;
+  connectionForDaemon(daemonId: string): import("./daemons/index.js").DaemonConnection | undefined;
   resourceCounts(): {
     recoveredExecutionSubscriptions: number;
   };
@@ -221,6 +222,8 @@ export function createHubApplication(options: HubRuntimeOptions): HubApplication
 
   const hub: HubRuntime = {
     daemonModule,
+    connectionForDaemon: (daemonId) =>
+      options.daemonConnectionForId?.(daemonId) ?? daemons?.connection(daemonId),
     resourceCounts: () => ({
       recoveredExecutionSubscriptions:
         daemonModule?.lifecycle.activeRecoveryObservationCount() ?? 0,

--- a/src/application-runtime.ts
+++ b/src/application-runtime.ts
@@ -27,6 +27,7 @@ import { ProjectDashboard } from "./projects/dashboard.js";
 import { CompositionResources } from "./composition-resources.js";
 import { TriggerDashboard } from "./triggers/dashboard.js";
 import type { ProviderApplications } from "./provider-applications/index.js";
+import { DaemonProviderCatalog } from "./daemons/provider-catalog.js";
 
 export interface ApplicationCompositionOptions {
   database: Database | null;
@@ -146,6 +147,7 @@ async function createOwnedApplicationRuntime(
             (projectId) => application.configurationForProject(projectId),
           ),
     triggerDashboard: triggerDashboardFor(options),
+    daemonProviderCatalog: daemonProviderCatalogFor(options, application.hub),
     ...entitlementSurfaces(options),
     testTriggerRoutes: options.testTriggerRoutes ?? false,
     auth: (request) => {
@@ -348,6 +350,16 @@ function triggerDashboardFor(options: ApplicationCompositionOptions): TriggerDas
   return options.database === null || options.auth === null
     ? null
     : new TriggerDashboard(options.database, options.auth);
+}
+
+function daemonProviderCatalogFor(
+  options: ApplicationCompositionOptions,
+  hub: import("./app.js").HubRuntime,
+): DaemonProviderCatalog | null {
+  if (options.database === null || options.auth === null) return null;
+  return new DaemonProviderCatalog(options.database, options.auth, (daemonId) =>
+    hub.connectionForDaemon(daemonId),
+  );
 }
 
 function providerApplicationsFor(

--- a/src/daemons/functions.ts
+++ b/src/daemons/functions.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { respondOk, type Result } from "../contract/respond.js";
 import { reportFailure, respondWithFailure } from "../failures/index.js";
 import { getApplication } from "../server/runtime.js";
+import type { HubProviderSnapshot } from "../hub/protocol.js";
 
 const daemonSchema = z.object({
   id: z.string().uuid(),
@@ -24,12 +25,44 @@ const daemonIdSchema = z.object({ daemonId: z.string().uuid() });
 const organizationScopeSchema = z.object({ organizationSlug: z.string().min(1) });
 const scopedRenameSchema = organizationScopeSchema.extend(renameSchema.shape);
 const scopedDaemonIdSchema = organizationScopeSchema.extend(daemonIdSchema.shape);
+const providerSnapshotSchema = scopedDaemonIdSchema.extend({
+  cwd: z.string().trim().min(1).optional(),
+  refresh: z.boolean().optional(),
+});
 
 export type BrowserDaemon = z.infer<typeof daemonSchema>;
 export type BrowserDaemonList = z.infer<typeof daemonListSchema>;
 export interface DaemonCommand {
   state: "complete" | "sessionExpired" | "organizationRequired";
 }
+
+export const daemonProviderSnapshot = createServerFn({ method: "GET" })
+  .validator(providerSnapshotSchema)
+  .handler(async ({ data }): Promise<Result<HubProviderSnapshot>> => {
+    try {
+      const catalog = (await getApplication()).daemonProviderCatalog;
+      if (catalog == null) throw new Error("daemon provider catalog unavailable");
+      return respondOk(
+        await catalog.read(getRequest(), {
+          organizationSlug: data.organizationSlug,
+          daemonId: data.daemonId,
+          ...(data.cwd === undefined ? {} : { cwd: data.cwd }),
+          ...(data.refresh === undefined ? {} : { refresh: data.refresh }),
+        }),
+      );
+    } catch (error) {
+      return respondWithFailure(
+        error,
+        daemonContext("daemon.provider.snapshot", data.organizationSlug, data.daemonId),
+        {
+          fallback:
+            error instanceof Error && error.message === "daemon_provider_snapshot_unsupported"
+              ? "Update Paseo on this daemon to browse its providers."
+              : "Hub couldn't load this daemon's providers. Check the daemon connection and retry.",
+        },
+      );
+    }
+  });
 
 export const daemonList = createServerFn({ method: "GET" })
   .validator(organizationScopeSchema)

--- a/src/daemons/lifecycle.test.ts
+++ b/src/daemons/lifecycle.test.ts
@@ -303,6 +303,14 @@ class AcknowledgementConnection implements DaemonConnection {
     throw new Error("not used");
   }
 
+  async getProviderSnapshot(): Promise<never> {
+    throw new Error("not used");
+  }
+
+  async refreshProviderSnapshot(): Promise<never> {
+    throw new Error("not used");
+  }
+
   async controlExecution(options: DaemonExecutionControlOptions): Promise<void> {
     this.actions.push(options.action);
   }

--- a/src/daemons/protocol.ts
+++ b/src/daemons/protocol.ts
@@ -4,6 +4,7 @@ import type {
   HubExecutionAgentSnapshot,
   HubExecutionAgentStreamEvent,
   HubExecutionControlAction,
+  HubProviderSnapshot,
 } from "../hub/protocol.js";
 
 export interface DaemonAgentSnapshot {
@@ -77,6 +78,8 @@ export type DaemonEventHandler = (event: DaemonEvent) => void | Promise<void>;
 export interface DaemonConnection {
   createAgent(options: DaemonCreateAgentOptions): Promise<DaemonAgentSnapshot>;
   controlExecution(options: DaemonExecutionControlOptions): Promise<void>;
+  getProviderSnapshot(options: { cwd?: string }): Promise<HubProviderSnapshot>;
+  refreshProviderSnapshot(options: { cwd?: string; providers?: string[] }): Promise<void>;
   on(handler: DaemonEventHandler): () => void;
 }
 

--- a/src/daemons/provider-catalog.test.ts
+++ b/src/daemons/provider-catalog.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import { describe, it } from "vitest";
+import type { AuthServer } from "../auth/server.js";
+import { createMemoryDatabase } from "../db/memory.js";
+import { enrollTestDaemon, TEST_DAEMON_ID } from "../test-utils/project-configuration.js";
+import type { DaemonConnection } from "./protocol.js";
+import { DaemonProviderCatalog } from "./provider-catalog.js";
+
+describe("daemon provider catalog", () => {
+  it("authorizes the organization and refreshes before returning its daemon snapshot", async () => {
+    const database = createMemoryDatabase({
+      memberships: [
+        {
+          userId: "user-1",
+          organizationId: "org-1",
+          organizationName: "Acme",
+          organizationSlug: "acme",
+          membershipId: "membership-1",
+          role: "member",
+        },
+      ],
+    });
+    await enrollTestDaemon(database, "org-1");
+    const calls: string[] = [];
+    const connection: DaemonConnection = {
+      createAgent: async () => {
+        throw new Error("not used");
+      },
+      controlExecution: async () => undefined,
+      on: () => () => undefined,
+      refreshProviderSnapshot: async ({ cwd }) => {
+        calls.push(`refresh:${cwd}`);
+      },
+      getProviderSnapshot: async ({ cwd }) => {
+        calls.push(`get:${cwd}`);
+        return {
+          requestId: "snapshot-1",
+          ...(cwd === undefined ? {} : { cwd }),
+          entries: [{ provider: "codex", status: "ready", enabled: true }],
+          generatedAt: "2026-09-02T12:00:00.000Z",
+        };
+      },
+    };
+    const catalog = new DaemonProviderCatalog(database, accountAuth(), (daemonId) =>
+      daemonId === TEST_DAEMON_ID ? connection : undefined,
+    );
+
+    const result = await catalog.read(new Request("https://hub.test/o/acme/triggers"), {
+      organizationSlug: "acme",
+      daemonId: TEST_DAEMON_ID,
+      cwd: "/repo",
+      refresh: true,
+    });
+
+    assert.deepEqual(calls, ["refresh:/repo", "get:/repo"]);
+    assert.equal(result.entries[0]?.provider, "codex");
+  });
+});
+
+function accountAuth(): AuthServer {
+  return {
+    handle: () => Promise.resolve(new Response()),
+    resources: () => Promise.reject(new Error("unused")),
+    resolveOrganizationAccess: () => Promise.reject(new Error("unused")),
+    resolveAccount: () =>
+      Promise.resolve({
+        session: { id: "session-1", activeOrganizationId: "org-1" },
+        account: { id: "user-1", name: "User", email: "user@example.test" },
+        isInstanceOperator: false,
+      }),
+    rejectCookieMutation: () => undefined,
+    close: () => Promise.resolve(),
+  };
+}

--- a/src/daemons/provider-catalog.ts
+++ b/src/daemons/provider-catalog.ts
@@ -1,0 +1,37 @@
+import type { AuthServer } from "../auth/server.js";
+import type { Database } from "../db/types.js";
+import { resolveRouteTenant } from "../projects/access.js";
+import type { HubProviderSnapshot } from "../hub/protocol.js";
+import type { DaemonConnection } from "./protocol.js";
+
+export class DaemonProviderCatalog {
+  constructor(
+    private readonly database: Database,
+    private readonly auth: AuthServer,
+    private readonly connectionForDaemon: (daemonId: string) => DaemonConnection | undefined,
+  ) {}
+
+  async read(
+    request: Request,
+    input: {
+      organizationSlug: string;
+      daemonId: string;
+      cwd?: string;
+      refresh?: boolean;
+    },
+  ): Promise<HubProviderSnapshot> {
+    const { tenant } = await resolveRouteTenant(this.auth, this.database, request, {
+      organizationSlug: input.organizationSlug,
+    });
+    const daemon = await this.database.findDaemonForOrganization(
+      tenant.organization.id,
+      input.daemonId,
+    );
+    if (daemon?.status !== "active") throw new Error("daemon_unavailable");
+    const connection = this.connectionForDaemon(daemon.id);
+    if (connection === undefined) throw new Error("daemon_not_connected");
+    const scope = input.cwd === undefined ? {} : { cwd: input.cwd };
+    if (input.refresh === true) await connection.refreshProviderSnapshot(scope);
+    return await connection.getProviderSnapshot(scope);
+  }
+}

--- a/src/daemons/registry.test.ts
+++ b/src/daemons/registry.test.ts
@@ -187,6 +187,36 @@ describe("daemon socket generations", () => {
     });
   });
 
+  it("reads and refreshes provider capabilities through the Hub execution session", async () => {
+    const refresh = await daemon.pendingProviderRefresh();
+    assert.deepEqual(
+      { cwd: refresh.request["cwd"], providers: refresh.request["providers"] },
+      { cwd: "/workspace", providers: ["codex"] },
+    );
+    daemon.respondProviderRefresh(refresh);
+    await refresh.promise;
+
+    const snapshot = await daemon.pendingProviderSnapshot();
+    daemon.respondProviderSnapshot(snapshot);
+
+    assert.deepEqual((await snapshot.promise).entries, [
+      {
+        provider: "codex",
+        status: "ready",
+        enabled: true,
+        models: [
+          {
+            provider: "codex",
+            id: "gpt-5.4",
+            label: "GPT-5.4",
+            thinkingOptions: [{ id: "xhigh", label: "Extra high" }],
+          },
+        ],
+        modes: [{ id: "full-access", label: "Full access" }],
+      },
+    ]);
+  });
+
   it("waits for offline presence before shutdown completes", async () => {
     daemon.holdOfflinePresence();
 

--- a/src/daemons/registry.ts
+++ b/src/daemons/registry.ts
@@ -16,6 +16,10 @@ import {
   HubExecutionAgentUpdateSchema,
   HubExecutionControlRequestSchema,
   HubExecutionControlResponseSchema,
+  GetProvidersSnapshotRequestSchema,
+  GetProvidersSnapshotResponseSchema,
+  RefreshProvidersSnapshotRequestSchema,
+  RefreshProvidersSnapshotResponseSchema,
   HubExecutionOutboundSchema,
   HubDaemonHelloSchema,
   HubDaemonServerInfoEnvelopeSchema,
@@ -29,6 +33,7 @@ import {
   type DaemonExecutionControlOptions,
   type DaemonEventHandler,
 } from "./protocol.js";
+import type { HubProviderSnapshot } from "../hub/protocol.js";
 
 interface PendingCreateRequest {
   kind: "create";
@@ -51,17 +56,35 @@ interface PendingAgentValidationRequest {
   resolve(value: { valid: true } | { valid: false; issues: readonly AgentValidationIssue[] }): void;
   reject(error: Error): void;
 }
+interface PendingProviderSnapshotRequest {
+  kind: "provider-snapshot";
+  generation: number;
+  resolve(value: HubProviderSnapshot): void;
+  reject(error: Error): void;
+}
+interface PendingProviderRefreshRequest {
+  kind: "provider-refresh";
+  generation: number;
+  resolve(): void;
+  reject(error: Error): void;
+}
 interface AgentValidationIssue {
   path: readonly (string | number)[];
   message: string;
 }
-type PendingRequest = PendingCreateRequest | PendingControlRequest | PendingAgentValidationRequest;
+type PendingRequest =
+  | PendingCreateRequest
+  | PendingControlRequest
+  | PendingAgentValidationRequest
+  | PendingProviderSnapshotRequest
+  | PendingProviderRefreshRequest;
 interface ActiveSocket {
   generation: number;
   socket: WebSocket;
   daemon: DaemonRecord;
   ready: boolean;
   presenceReady: Promise<void>;
+  providerSnapshotSupported: boolean;
 }
 
 export type DaemonSessionProtocol = "legacy" | "session-v1";
@@ -100,6 +123,7 @@ export class ActiveDaemonRegistry {
       daemon,
       ready: false,
       presenceReady: Promise.resolve(),
+      providerSnapshotSupported: false,
     };
     this.active.set(daemon.id, active);
     previous?.socket.close(4001, "replaced");
@@ -152,6 +176,8 @@ export class ActiveDaemonRegistry {
     return {
       createAgent: (options) => this.createAgent(daemonId, options),
       controlExecution: (options) => this.controlExecution(daemonId, options),
+      getProviderSnapshot: (options) => this.getProviderSnapshot(daemonId, options),
+      refreshProviderSnapshot: (options) => this.refreshProviderSnapshot(daemonId, options),
       on: (handler) => {
         const subscribers = this.subscribersFor(daemonId);
         subscribers.add(handler);
@@ -289,6 +315,58 @@ export class ActiveDaemonRegistry {
     });
   }
 
+  private getProviderSnapshot(
+    daemonId: string,
+    options: { cwd?: string },
+  ): Promise<HubProviderSnapshot> {
+    const active = this.requireProviderSnapshotConnection(daemonId);
+    const requestId = randomUUID();
+    const request = GetProvidersSnapshotRequestSchema.parse({
+      type: "get_providers_snapshot_request",
+      requestId,
+      cwd: options.cwd,
+    });
+    return new Promise((resolve, reject) => {
+      this.pendingFor(daemonId).set(requestId, {
+        kind: "provider-snapshot",
+        generation: active.generation,
+        resolve,
+        reject,
+      });
+      active.socket.send(JSON.stringify({ type: "session", message: request }));
+    });
+  }
+
+  private refreshProviderSnapshot(
+    daemonId: string,
+    options: { cwd?: string; providers?: string[] },
+  ): Promise<void> {
+    const active = this.requireProviderSnapshotConnection(daemonId);
+    const requestId = randomUUID();
+    const request = RefreshProvidersSnapshotRequestSchema.parse({
+      type: "refresh_providers_snapshot_request",
+      requestId,
+      cwd: options.cwd,
+      providers: options.providers,
+    });
+    return new Promise((resolve, reject) => {
+      this.pendingFor(daemonId).set(requestId, {
+        kind: "provider-refresh",
+        generation: active.generation,
+        resolve,
+        reject,
+      });
+      active.socket.send(JSON.stringify({ type: "session", message: request }));
+    });
+  }
+
+  private requireProviderSnapshotConnection(daemonId: string): ActiveSocket {
+    const active = this.active.get(daemonId);
+    if (!active?.ready) throw new Error("daemon_not_connected");
+    if (!active.providerSnapshotSupported) throw new Error("daemon_provider_snapshot_unsupported");
+    return active;
+  }
+
   private receive(active: ActiveSocket, raw: string): void {
     if (this.active.get(active.daemon.id)?.generation !== active.generation) return;
     const receivedAt = this.clock.nowDate().toISOString();
@@ -302,7 +380,11 @@ export class ActiveDaemonRegistry {
     }
     const serverInfo = HubDaemonServerInfoEnvelopeSchema.safeParse(value);
     if (serverInfo.success) {
-      this.acceptServerInfo(active, serverInfo.data.message.payload.permissions);
+      this.acceptServerInfo(
+        active,
+        serverInfo.data.message.payload.permissions,
+        serverInfo.data.message.payload.features?.providersSnapshot === true,
+      );
       return;
     }
     const envelope = HubExecutionOutboundSchema.safeParse(value);
@@ -315,6 +397,11 @@ export class ActiveDaemonRegistry {
     if (controlled.success) return this.receiveControl(active, controlled.data);
     const validated = HubExecutionAgentValidateResponseSchema.safeParse(message);
     if (validated.success) return this.receiveAgentValidation(active, validated.data);
+    const providerSnapshot = GetProvidersSnapshotResponseSchema.safeParse(message);
+    if (providerSnapshot.success)
+      return this.receiveProviderSnapshot(active, providerSnapshot.data);
+    const providerRefresh = RefreshProvidersSnapshotResponseSchema.safeParse(message);
+    if (providerRefresh.success) return this.receiveProviderRefresh(active, providerRefresh.data);
     const update = HubExecutionAgentUpdateSchema.safeParse(message);
     if (update.success) {
       const event = {
@@ -339,11 +426,16 @@ export class ActiveDaemonRegistry {
     this.notifySubscribers(active.daemon.id, event);
   }
 
-  private acceptServerInfo(active: ActiveSocket, permissions: readonly string[]): void {
+  private acceptServerInfo(
+    active: ActiveSocket,
+    permissions: readonly string[],
+    providerSnapshotSupported = false,
+  ): void {
     if (!samePermissions(permissions, active.daemon.permissions)) {
       active.socket.close(4403, "daemon session permissions do not match enrollment");
       return;
     }
+    active.providerSnapshotSupported = providerSnapshotSupported;
     this.markReady(active);
   }
 
@@ -436,6 +528,44 @@ export class ActiveDaemonRegistry {
     pending.resolve(
       response.payload.valid ? { valid: true } : { valid: false, issues: response.payload.issues },
     );
+  }
+
+  private receiveProviderSnapshot(
+    active: ActiveSocket,
+    response: z.infer<typeof GetProvidersSnapshotResponseSchema>,
+  ): void {
+    const requests = this.pendingFor(active.daemon.id);
+    const pending = requests.get(response.payload.requestId);
+    if (
+      !pending ||
+      pending.kind !== "provider-snapshot" ||
+      pending.generation !== active.generation
+    ) {
+      return;
+    }
+    requests.delete(response.payload.requestId);
+    pending.resolve(response.payload);
+  }
+
+  private receiveProviderRefresh(
+    active: ActiveSocket,
+    response: z.infer<typeof RefreshProvidersSnapshotResponseSchema>,
+  ): void {
+    const requests = this.pendingFor(active.daemon.id);
+    const pending = requests.get(response.payload.requestId);
+    if (
+      !pending ||
+      pending.kind !== "provider-refresh" ||
+      pending.generation !== active.generation
+    ) {
+      return;
+    }
+    requests.delete(response.payload.requestId);
+    if (!response.payload.acknowledged) {
+      pending.reject(new Error("daemon provider refresh was not acknowledged"));
+      return;
+    }
+    pending.resolve();
   }
 
   private receiveControl(

--- a/src/daemons/test-utils/daemon-registry-harness.ts
+++ b/src/daemons/test-utils/daemon-registry-harness.ts
@@ -98,6 +98,62 @@ export class DaemonRegistryHarness {
     };
   }
 
+  async pendingProviderSnapshot(cwd = "/workspace") {
+    const promise = this.connection().getProviderSnapshot({ cwd });
+    void promise.catch(() => undefined);
+    return {
+      promise,
+      request: await this.currentSocket().next("get_providers_snapshot_request"),
+    };
+  }
+
+  async pendingProviderRefresh(cwd = "/workspace") {
+    const promise = this.connection().refreshProviderSnapshot({ cwd, providers: ["codex"] });
+    void promise.catch(() => undefined);
+    return {
+      promise,
+      request: await this.currentSocket().next("refresh_providers_snapshot_request"),
+    };
+  }
+
+  respondProviderSnapshot(
+    pending: Awaited<ReturnType<DaemonRegistryHarness["pendingProviderSnapshot"]>>,
+  ): void {
+    this.currentSocket().send({
+      type: "get_providers_snapshot_response",
+      payload: {
+        requestId: pending.request.requestId,
+        cwd: pending.request["cwd"],
+        entries: [
+          {
+            provider: "codex",
+            status: "ready",
+            enabled: true,
+            models: [
+              {
+                provider: "codex",
+                id: "gpt-5.4",
+                label: "GPT-5.4",
+                thinkingOptions: [{ id: "xhigh", label: "Extra high" }],
+              },
+            ],
+            modes: [{ id: "full-access", label: "Full access" }],
+          },
+        ],
+        generatedAt: new Date().toISOString(),
+      },
+    });
+  }
+
+  respondProviderRefresh(
+    pending: Awaited<ReturnType<DaemonRegistryHarness["pendingProviderRefresh"]>>,
+  ): void {
+    this.currentSocket().send({
+      type: "refresh_providers_snapshot_response",
+      payload: { requestId: pending.request.requestId, acknowledged: true },
+    });
+  }
+
   respondAgentValidation(
     pending: Awaited<ReturnType<DaemonRegistryHarness["pendingAgentValidation"]>>,
   ): void {
@@ -422,7 +478,7 @@ class RegistrySocket {
         status: "server_info",
         serverId: "test-daemon",
         permissions,
-        features: {},
+        features: { providersSnapshot: true },
       },
     });
   }

--- a/src/e2e/harness/fault-proxy.ts
+++ b/src/e2e/harness/fault-proxy.ts
@@ -20,6 +20,7 @@ export class HubFaultProxy {
     this.createResponseDropped = resolve;
   });
   private denial: ((value: Denial) => void) | undefined;
+  private providerSnapshot: ((value: Record<string, unknown>) => void) | undefined;
   private readonly createsByExecution = new Map<string, number>();
   private readonly agentIdsByExecution = new Map<string, Set<string>>();
   private readonly createdAgentsByExecution = new Map<
@@ -35,6 +36,11 @@ export class HubFaultProxy {
   ) {
     this.server = createServer((request, response) => {
       void this.forwardHttp(request, response);
+    });
+    this.sockets.on("headers", (headers, request) => {
+      if (request.headers["x-paseo-session-protocol"] === "1") {
+        headers.push("x-paseo-session-protocol: 1");
+      }
     });
     this.server.on("upgrade", (request, socket, head) => this.upgrade(request, socket, head));
   }
@@ -70,6 +76,29 @@ export class HubFaultProxy {
       agentId,
       text: "outside Hub scope",
     });
+  }
+
+  async requestProviderSnapshot(cwd: string): Promise<Record<string, unknown>> {
+    const socket = this.daemonSocket;
+    if (!socket || socket.readyState !== WebSocket.OPEN) throw new Error("Daemon is not connected");
+    const requestId = `hub-e2e-providers-${Date.now()}`;
+    const observed = new Promise<Record<string, unknown>>((resolve, reject) => {
+      const timeout = setTimeout(
+        () => reject(new Error(`Provider snapshot was not observed\n${this.evidence()}`)),
+        10_000,
+      );
+      this.providerSnapshot = (value) => {
+        clearTimeout(timeout);
+        resolve(value);
+      };
+    });
+    socket.send(
+      JSON.stringify({
+        type: "session",
+        message: { type: "get_providers_snapshot_request", requestId, cwd },
+      }),
+    );
+    return observed;
   }
 
   private async requestDenied(message: Record<string, unknown>): Promise<Denial> {
@@ -236,7 +265,16 @@ export class HubFaultProxy {
     const message = sessionMessage(parseRecord(raw));
     this.recordDaemonEvidence(message);
     this.observeDenial(message);
+    this.observeProviderSnapshot(message);
     return this.observeCreateResponse(message);
+  }
+
+  private observeProviderSnapshot(message: Record<string, unknown> | undefined): void {
+    if (message?.["type"] !== "get_providers_snapshot_response") return;
+    const payload = recordAt(message, "payload");
+    if (payload === undefined) return;
+    this.providerSnapshot?.(payload);
+    this.providerSnapshot = undefined;
   }
 
   private recordDaemonEvidence(message: Record<string, unknown> | undefined): void {

--- a/src/e2e/harness/index.ts
+++ b/src/e2e/harness/index.ts
@@ -212,6 +212,10 @@ export class HubE2E {
     return { state: requiredString(status, "state") };
   }
 
+  requestProviderSnapshot(cwd = this.workspace): Promise<Record<string, unknown>> {
+    return this.requireProxy().requestProviderSnapshot(cwd);
+  }
+
   async deployCurrentProjectBundleWithSourceCli(): Promise<SourceCliBundleDeploymentEvidence> {
     const sourceFiles = (await currentProjectConfigurationFiles()).toSorted((left, right) =>
       left.path.localeCompare(right.path),
@@ -233,6 +237,8 @@ export class HubE2E {
     await this.requirePool().query("update daemons set slug = 'local' where id = $1", [
       connectedDaemonId,
     ]);
+    await this.requireSource().restart();
+    await this.daemonIsConnected();
     await this.seedCurrentProjectResources();
     await this.waitForBundleProviders(sourceFiles);
 

--- a/src/e2e/harness/source-paseo.ts
+++ b/src/e2e/harness/source-paseo.ts
@@ -95,6 +95,8 @@ export class SourcePaseo {
       hubOrigin,
       "--api-key",
       credential,
+      "--permission",
+      "hub.execute",
       "--host",
       this.paths.daemonHost,
       "--json",

--- a/src/e2e/hub-foundation.e2e.test.ts
+++ b/src/e2e/hub-foundation.e2e.test.ts
@@ -21,8 +21,10 @@ describeHubE2E("Paseo Hub cross-repository contract", () => {
   it("connects the source-built daemon through an enrollment token", async () => {
     const enrollment = await hub.connect();
     await hub.daemonIsConnected();
+    const providers = await hub.requestProviderSnapshot();
 
     assert.equal((await hub.status()).state, "connected");
+    assert.ok(Array.isArray(providers["entries"]));
     assert.match(
       enrollment.daemonId,
       /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u,

--- a/src/hub/protocol.test.ts
+++ b/src/hub/protocol.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import { describe, it } from "vitest";
-import { HubExecutionAgentCreateRequestSchema } from "./protocol.js";
+import {
+  GetProvidersSnapshotResponseSchema,
+  HubExecutionAgentCreateRequestSchema,
+} from "./protocol.js";
 
 describe("Hub execution create protocol", () => {
   it("accepts only structured refs for the injected Hub MCP server", () => {
@@ -34,5 +37,35 @@ describe("Hub execution create protocol", () => {
       }).success,
       false,
     );
+  });
+});
+
+describe("Hub provider snapshot protocol", () => {
+  it("keeps model thinking options and provider modes", () => {
+    const result = GetProvidersSnapshotResponseSchema.parse({
+      type: "get_providers_snapshot_response",
+      payload: {
+        requestId: "providers-1",
+        entries: [
+          {
+            provider: "codex",
+            status: "ready",
+            models: [
+              {
+                provider: "codex",
+                id: "gpt-5.4",
+                label: "GPT-5.4",
+                thinkingOptions: [{ id: "xhigh", label: "Extra high", isDefault: true }],
+              },
+            ],
+            modes: [{ id: "full-access", label: "Full access" }],
+          },
+        ],
+        generatedAt: "2026-09-02T12:00:00.000Z",
+      },
+    });
+
+    assert.equal(result.payload.entries[0]?.models?.[0]?.thinkingOptions?.[0]?.id, "xhigh");
+    assert.equal(result.payload.entries[0]?.modes?.[0]?.id, "full-access");
   });
 });

--- a/src/hub/protocol.ts
+++ b/src/hub/protocol.ts
@@ -9,7 +9,15 @@ const McpHttpServerConfigSchema = z.object({
   headers: z.record(z.string(), z.string()).optional(),
 });
 
-const JsonValueSchema: z.ZodType = z.lazy(() =>
+type WireJsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | WireJsonValue[]
+  | { [key: string]: WireJsonValue };
+
+const JsonValueSchema: z.ZodType<WireJsonValue> = z.lazy(() =>
   z.union([
     z.string(),
     z.number().finite(),
@@ -19,6 +27,50 @@ const JsonValueSchema: z.ZodType = z.lazy(() =>
     z.record(z.string(), JsonValueSchema),
   ]),
 );
+
+const ProviderSelectOptionSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  description: z.string().optional(),
+  isDefault: z.boolean().optional(),
+  metadata: z.record(z.string(), JsonValueSchema).optional(),
+});
+
+const ProviderModelSchema = z.object({
+  provider: z.string(),
+  id: z.string(),
+  aliases: z.array(z.string()).optional(),
+  isSelectable: z.boolean().optional(),
+  label: z.string(),
+  description: z.string().optional(),
+  isDefault: z.boolean().optional(),
+  metadata: z.record(z.string(), JsonValueSchema).optional(),
+  contextWindowMaxTokens: z.number().optional(),
+  thinkingOptions: z.array(ProviderSelectOptionSchema).optional(),
+  defaultThinkingOptionId: z.string().optional(),
+});
+
+const ProviderModeSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  description: z.string().optional(),
+  icon: z.string().optional(),
+  colorTier: z.string().optional(),
+});
+
+const ProviderSnapshotEntrySchema = z.object({
+  provider: z.string(),
+  status: z.enum(["ready", "loading", "error", "unavailable"]),
+  enabled: z.boolean().optional().default(true),
+  source: z.enum(["builtin", "custom"]).optional(),
+  error: z.string().optional(),
+  models: z.array(ProviderModelSchema).optional(),
+  modes: z.array(ProviderModeSchema).optional(),
+  fetchedAt: z.string().optional(),
+  label: z.string().optional(),
+  description: z.string().optional(),
+  defaultModeId: z.string().nullable().optional(),
+});
 
 const McpToolRefSchema = z
   .object({
@@ -65,6 +117,7 @@ export const HubDaemonServerInfoEnvelopeSchema = z.object({
       .object({
         status: z.literal("server_info"),
         permissions: z.array(z.string()),
+        features: z.object({ providersSnapshot: z.boolean().optional() }).optional(),
       })
       .passthrough(),
   }),
@@ -171,6 +224,37 @@ export const HubExecutionAgentValidateResponseSchema = z.object({
   }),
 });
 
+export const GetProvidersSnapshotRequestSchema = z.object({
+  type: z.literal("get_providers_snapshot_request"),
+  requestId: z.string(),
+  cwd: z.string().optional(),
+});
+
+export const GetProvidersSnapshotResponseSchema = z.object({
+  type: z.literal("get_providers_snapshot_response"),
+  payload: z.object({
+    requestId: z.string(),
+    cwd: z.string().optional(),
+    entries: z.array(ProviderSnapshotEntrySchema),
+    generatedAt: z.string(),
+  }),
+});
+
+export const RefreshProvidersSnapshotRequestSchema = z.object({
+  type: z.literal("refresh_providers_snapshot_request"),
+  requestId: z.string(),
+  cwd: z.string().optional(),
+  providers: z.array(z.string()).optional(),
+});
+
+export const RefreshProvidersSnapshotResponseSchema = z.object({
+  type: z.literal("refresh_providers_snapshot_response"),
+  payload: z.object({
+    requestId: z.string(),
+    acknowledged: z.boolean(),
+  }),
+});
+
 export const HubExecutionAgentCreateResponseSchema = z.object({
   type: z.literal("hub.execution.agent.create.response"),
   payload: z.object({
@@ -263,6 +347,8 @@ export const HubExecutionOutboundSchema = z.object({
     HubExecutionAgentStreamSchema,
     HubExecutionControlResponseSchema,
     HubExecutionAgentValidateResponseSchema,
+    GetProvidersSnapshotResponseSchema,
+    RefreshProvidersSnapshotResponseSchema,
     RpcErrorSchema,
   ]),
 });
@@ -270,3 +356,5 @@ export const HubExecutionOutboundSchema = z.object({
 export type HubExecutionAgentSnapshot = z.infer<typeof HubExecutionAgentSnapshotSchema>;
 export type HubExecutionAgentStreamEvent = z.infer<typeof HubExecutionAgentStreamEventSchema>;
 export type HubExecutionControlAction = z.infer<typeof HubExecutionControlActionSchema>;
+export type HubProviderSnapshot = z.infer<typeof GetProvidersSnapshotResponseSchema>["payload"];
+export type HubProviderSnapshotEntry = z.infer<typeof ProviderSnapshotEntrySchema>;

--- a/src/server/runtime.ts
+++ b/src/server/runtime.ts
@@ -16,6 +16,7 @@ import type { TriggerDashboard } from "../triggers/dashboard.js";
 import type { PublicApi } from "../public-api/index.js";
 import type { UsageDashboard } from "../usage/dashboard.js";
 import type { ProviderApplications } from "../provider-applications/index.js";
+import type { DaemonProviderCatalog } from "../daemons/provider-catalog.js";
 
 /**
  * The public plan catalog shape is billing's own: `src/billing/public-catalog.ts` decides which
@@ -67,6 +68,7 @@ export interface ApplicationRuntime {
   billing: BillingRuntime | null;
   projectDashboard: ProjectDashboard | null;
   triggerDashboard?: TriggerDashboard | null;
+  daemonProviderCatalog?: DaemonProviderCatalog | null;
   /** Org-scoped, read-only limits and usage. Present whenever database + browser auth are; no
    * billing dependency, so it renders on self-hosted and hosted alike. */
   usageDashboard: UsageDashboard | null;

--- a/src/triggers/agent-model-combobox.tsx
+++ b/src/triggers/agent-model-combobox.tsx
@@ -52,7 +52,7 @@ export function AgentModelCombobox({
           aria-controls={listId}
           aria-required="true"
           data-value={value}
-          className="w-full min-w-0 justify-between font-normal"
+          className="w-full min-w-0 justify-between"
         >
           <span className="truncate">{selectedLabel}</span>
           <ChevronsUpDownIcon className="size-4 shrink-0 opacity-50" />

--- a/src/triggers/agent-model-combobox.tsx
+++ b/src/triggers/agent-model-combobox.tsx
@@ -1,0 +1,102 @@
+import { useCallback, useId, useState } from "react";
+import { CheckIcon, ChevronsUpDownIcon } from "lucide-react";
+import { Button } from "../components/ui/button.js";
+import {
+  Command,
+  CommandEmpty,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "../components/ui/command.js";
+import { Popover, PopoverContent, PopoverTrigger } from "../components/ui/popover.js";
+import { cn } from "../lib/utils.js";
+
+export interface AgentModelOption {
+  value: string;
+  label: string;
+  providerLabel: string;
+  keywords: string[];
+}
+
+export function AgentModelCombobox({
+  options,
+  value,
+  onSelect,
+}: {
+  options: AgentModelOption[];
+  value: string;
+  onSelect: (value: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const listId = useId();
+  const selected = options.find((option) => option.value === value);
+  const selectedLabel =
+    selected?.label ?? (value === "" ? "Select a model" : `${value} (unavailable)`);
+  const choose = useCallback(
+    (nextValue: string) => {
+      onSelect(nextValue);
+      setOpen(false);
+    },
+    [onSelect],
+  );
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          id="trigger-agent"
+          type="button"
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          aria-controls={listId}
+          aria-required="true"
+          data-value={value}
+          className="w-full min-w-0 justify-between font-normal"
+        >
+          <span className="truncate">{selectedLabel}</span>
+          <ChevronsUpDownIcon className="size-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-(--radix-popper-anchor-width) p-0" align="start">
+        <Command>
+          <CommandInput placeholder="Search models…" />
+          <CommandList id={listId}>
+            <CommandEmpty>No models found.</CommandEmpty>
+            {options.map((option) => (
+              <AgentModelCommandItem
+                key={option.value}
+                option={option}
+                selected={option.value === value}
+                onSelect={choose}
+              />
+            ))}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function AgentModelCommandItem({
+  option,
+  selected,
+  onSelect,
+}: {
+  option: AgentModelOption;
+  selected: boolean;
+  onSelect: (value: string) => void;
+}) {
+  const choose = useCallback(() => onSelect(option.value), [onSelect, option.value]);
+  return (
+    <CommandItem value={option.value} keywords={option.keywords} onSelect={choose}>
+      <CheckIcon className={cn(selected ? "opacity-100" : "opacity-0")} />
+      <span className="min-w-0">
+        <span className="block truncate">{option.label}</span>
+        <span className="block truncate text-xs text-muted-foreground">
+          {option.providerLabel} · {option.value}
+        </span>
+      </span>
+    </CommandItem>
+  );
+}

--- a/src/triggers/form-select.tsx
+++ b/src/triggers/form-select.tsx
@@ -1,0 +1,56 @@
+import { useCallback } from "react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../components/ui/select.js";
+
+const EMPTY_VALUE = "__paseo_empty_select_value__";
+
+export interface TriggerSelectOption {
+  value: string;
+  label: string;
+  disabled?: boolean;
+}
+
+export function TriggerSelect({
+  id,
+  value,
+  options,
+  placeholder,
+  required,
+  onChange,
+}: {
+  id: string;
+  value: string;
+  options: TriggerSelectOption[];
+  placeholder?: string;
+  required?: boolean;
+  onChange: (value: string) => void;
+}) {
+  const change = useCallback(
+    (nextValue: string) => onChange(nextValue === EMPTY_VALUE ? "" : nextValue),
+    [onChange],
+  );
+  return (
+    <Select value={value === "" ? EMPTY_VALUE : value} onValueChange={change}>
+      <SelectTrigger id={id} className="w-full" aria-required={required} data-value={value}>
+        <SelectValue placeholder={placeholder} />
+      </SelectTrigger>
+      <SelectContent>
+        {options.map((option) => (
+          <SelectItem
+            key={option.value}
+            value={option.value === "" ? EMPTY_VALUE : option.value}
+            {...(option.disabled === undefined ? {} : { disabled: option.disabled })}
+            data-value={option.value}
+          >
+            {option.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/src/triggers/panel.tsx
+++ b/src/triggers/panel.tsx
@@ -1,10 +1,17 @@
-/* oxlint-disable eslint-plugin-react-perf/jsx-no-new-function-as-prop, eslint-plugin-react-perf/jsx-no-new-object-as-prop -- focused trigger screens bind one document */
+/* oxlint-disable eslint-plugin-react-perf/jsx-no-new-function-as-prop, eslint-plugin-react-perf/jsx-no-new-object-as-prop, eslint-plugin-react-perf/jsx-no-new-array-as-prop -- focused trigger screens bind one document */
 /* oxlint-disable typescript-eslint/no-unsafe-type-assertion -- generated routes cannot express server-resolved organization URLs */
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useNavigate } from "@tanstack/react-router";
 import { useServerFn } from "@tanstack/react-start";
 import { AlertTriangle, ArrowLeft, Braces, Copy, FileText, LockKeyhole, Plus } from "lucide-react";
-import { useLayoutEffect, useRef, useState, type FormEvent, type ReactNode } from "react";
+import {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type FormEvent,
+  type ReactNode,
+} from "react";
 import { DataCell, DataRow, DataTable } from "../components/app/data-table.js";
 import { PageHeader } from "../components/app/page.js";
 import { SiteHeaderActions } from "../components/app/site-header-actions.js";
@@ -27,6 +34,11 @@ import {
   type TriggerFormValue,
 } from "./configuration/editor.js";
 import { saveTrigger, triggerSnapshot, type TriggerSnapshot } from "./functions.js";
+import { daemonProviderSnapshot } from "../daemons/functions.js";
+import type { HubProviderSnapshot, HubProviderSnapshotEntry } from "../hub/protocol.js";
+import { defaultAgentSelection, defaultMode, selectedProviderModel } from "./provider-catalog.js";
+import { AgentModelCombobox, type AgentModelOption } from "./agent-model-combobox.js";
+import { TriggerSelect, type TriggerSelectOption } from "./form-select.js";
 
 type BrowserTrigger = TriggerSnapshot["triggers"][number];
 type EditorMode = "form" | "yaml";
@@ -38,6 +50,14 @@ const TRIGGER_COLUMNS = [
   { header: "Last triggered", className: "hidden xl:table-cell" },
   { header: "Status" },
 ] as const;
+
+const EVENT_OPTIONS: TriggerSelectOption[] = [
+  { value: "slack.mention", label: "Slack mention (slack.mention)" },
+  { value: "discord.mention", label: "Discord mention (discord.mention)" },
+  { value: "github.issue_comment", label: "GitHub issue comment (github.issue_comment)" },
+  { value: "linear.issue_created", label: "Linear issue created (linear.issue_created)" },
+  { value: "manual.run", label: "Manual run (manual.run)" },
+];
 
 export function TriggersPanel() {
   const tenant = useRouteTenant();
@@ -440,11 +460,43 @@ function TriggerForm({
   const githubConnections = snapshot.connections.filter(
     (connection) => connection.provider === "github",
   );
+  const connectionOptions = connections.map((connection) => ({
+    value: connection.slug,
+    label: connection.label,
+  }));
+  const daemonOptions = snapshot.daemons.map((daemon) => ({
+    value: daemon.slug,
+    label: `${daemon.slug} (${daemon.presence})`,
+  }));
+  const githubConnectionOptions = [
+    { value: "", label: "Do not inject a GitHub token" },
+    ...githubConnections.map((connection) => ({
+      value: connection.slug,
+      label: connection.label,
+    })),
+  ];
   const githubEnabled = form.githubConnection !== "";
   const [githubExpanded, setGithubExpanded] = useState(githubEnabled);
   const everyone = form.allowedUsers.trim() === "*";
   const update = <Key extends keyof TriggerFormValue>(key: Key, value: TriggerFormValue[Key]) =>
     onChange({ ...form, [key]: value });
+  const selectedDaemon = snapshot.daemons.find((daemon) => daemon.slug === form.daemon);
+  const providerCatalog = useDaemonProviderCatalog(
+    snapshot.organization.slug,
+    selectedDaemon?.id,
+    form.cwd,
+  );
+  useEffect(() => {
+    if (
+      triggerId !== undefined ||
+      form.agent !== DEFAULT_NEW_TRIGGER_AGENT ||
+      providerCatalog.entries === undefined
+    )
+      return;
+    const defaults = defaultAgentSelection(providerCatalog.entries);
+    if (defaults === undefined) return;
+    onChange({ ...form, ...defaults });
+  }, [form, onChange, providerCatalog.entries, triggerId]);
   return (
     <div className="grid gap-5">
       <FormSection
@@ -476,40 +528,24 @@ function TriggerForm({
         <div className="grid gap-4 sm:grid-cols-2">
           <Field>
             <FieldLabel htmlFor="trigger-event">When this happens</FieldLabel>
-            <select
+            <TriggerSelect
               id="trigger-event"
               value={form.event}
-              onChange={(event) => update("event", parseEditorEvent(event.target.value))}
-              className="h-9 rounded-md border bg-background px-3 text-sm"
-            >
-              <option value="slack.mention">Slack mention (slack.mention)</option>
-              <option value="discord.mention">Discord mention (discord.mention)</option>
-              <option value="github.issue_comment">
-                GitHub issue comment (github.issue_comment)
-              </option>
-              <option value="linear.issue_created">
-                Linear issue created (linear.issue_created)
-              </option>
-              <option value="manual.run">Manual run (manual.run)</option>
-            </select>
+              options={EVENT_OPTIONS}
+              onChange={(event) => update("event", parseEditorEvent(event))}
+            />
             <FieldDescription>Exactly one event launches this trigger.</FieldDescription>
           </Field>
           {form.event === "manual.run" ? null : (
             <Field>
               <FieldLabel htmlFor="trigger-connection">Connection</FieldLabel>
-              <select
+              <TriggerSelect
                 id="trigger-connection"
                 value={form.connection}
-                onChange={(event) => update("connection", event.target.value)}
-                className="h-9 rounded-md border bg-background px-3 text-sm"
+                options={connectionOptions}
+                onChange={(connection) => update("connection", connection)}
                 required
-              >
-                {connections.map((connection) => (
-                  <option key={connection.id} value={connection.slug}>
-                    {connection.label}
-                  </option>
-                ))}
-              </select>
+              />
               <FieldDescription>
                 The organization connection that receives the event.
               </FieldDescription>
@@ -558,19 +594,13 @@ function TriggerForm({
         <div className="grid gap-4 sm:grid-cols-2">
           <Field>
             <FieldLabel htmlFor="trigger-daemon">Run on daemon</FieldLabel>
-            <select
+            <TriggerSelect
               id="trigger-daemon"
               value={form.daemon}
-              onChange={(event) => update("daemon", event.target.value)}
-              className="h-9 rounded-md border bg-background px-3 text-sm"
+              options={daemonOptions}
+              onChange={(daemon) => update("daemon", daemon)}
               required
-            >
-              {snapshot.daemons.map((daemon) => (
-                <option key={daemon.id} value={daemon.slug}>
-                  {daemon.slug} ({daemon.presence})
-                </option>
-              ))}
-            </select>
+            />
             <FieldDescription>
               The daemon owns compute, credentials, and sandboxing.
             </FieldDescription>
@@ -605,27 +635,27 @@ function TriggerForm({
         description="The AI coding agent model and task prompt instructions."
       >
         <div className="grid gap-4 sm:grid-cols-2">
-          <ControlledInput
-            label="Agent ID"
-            value={form.agent}
-            onChange={(value) => update("agent", value)}
-            description="Full provider/model ID, for example codex/gpt-5.4."
-            required
-          />
-          <ControlledInput
-            label="Execution mode"
-            value={form.mode}
-            onChange={(value) => update("mode", value)}
-            description="Provider mode, for example full-access."
-            required
-          />
-          <ControlledInput
-            label="Thinking option ID"
-            value={form.thinkingOptionId}
-            onChange={(value) => update("thinkingOptionId", value)}
-            description="Leave blank to use the provider's default thinking option."
+          <ProviderCatalogFields
+            form={form}
+            entries={providerCatalog.entries}
+            onChange={onChange}
           />
         </div>
+        {providerCatalog.loading ? (
+          <p className="text-sm text-muted-foreground" aria-busy="true">
+            Loading providers from {form.daemon}…
+          </p>
+        ) : null}
+        {providerCatalog.error === undefined ? null : (
+          <Alert variant="destructive">
+            <AlertDescription className="flex items-center justify-between gap-3">
+              <span>{providerCatalog.error}</span>
+              <Button type="button" variant="outline" size="sm" onClick={providerCatalog.refresh}>
+                Retry
+              </Button>
+            </AlertDescription>
+          </Alert>
+        )}
         <details className="rounded-md border bg-muted/20 p-3">
           <summary className="cursor-pointer text-sm">Advanced provider options (JSON)</summary>
           <Field className="mt-3">
@@ -653,19 +683,12 @@ function TriggerForm({
           <div className="mt-3 grid gap-4 sm:grid-cols-2">
             <Field>
               <FieldLabel htmlFor="trigger-github-connection">GitHub connection</FieldLabel>
-              <select
+              <TriggerSelect
                 id="trigger-github-connection"
                 value={form.githubConnection}
-                onChange={(event) => update("githubConnection", event.target.value)}
-                className="h-9 rounded-md border bg-background px-3 text-sm"
-              >
-                <option value="">Do not inject a GitHub token</option>
-                {githubConnections.map((connection) => (
-                  <option key={connection.id} value={connection.slug}>
-                    {connection.label}
-                  </option>
-                ))}
-              </select>
+                options={githubConnectionOptions}
+                onChange={(connection) => update("githubConnection", connection)}
+              />
               <FieldDescription>
                 Mints a short-lived, restricted GH_TOKEN for this run.
               </FieldDescription>
@@ -873,6 +896,147 @@ function ControlledInput({
   );
 }
 
+function ProviderCatalogFields({
+  form,
+  entries,
+  onChange,
+}: {
+  form: TriggerFormValue;
+  entries: HubProviderSnapshotEntry[] | undefined;
+  onChange: (value: TriggerFormValue) => void;
+}) {
+  const selected = selectedProviderModel(entries, form.agent);
+  const agentOptions = (entries ?? []).flatMap((entry) =>
+    entry.status !== "ready" || !entry.enabled
+      ? []
+      : (entry.models ?? [])
+          .filter((model) => model.isSelectable !== false)
+          .map((model) => ({
+            value: `${entry.provider}/${model.id}`,
+            label: model.label,
+            providerLabel: entry.label ?? entry.provider,
+            keywords: [model.label, entry.label ?? entry.provider, model.id],
+          })),
+  ) satisfies AgentModelOption[];
+  const modes = selected.entry?.modes ?? [];
+  const modeKnown = modes.some((mode) => mode.id === form.mode);
+  const thinkingOptions = selected.model?.thinkingOptions ?? [];
+  const thinkingKnown = thinkingOptions.some((option) => option.id === form.thinkingOptionId);
+  const modeOptions = [
+    ...(!modeKnown && form.mode !== ""
+      ? [{ value: form.mode, label: `${form.mode} (unavailable)` }]
+      : []),
+    ...modes.map((mode) => ({ value: mode.id, label: mode.label })),
+  ];
+  const providerDefault = selected.model?.defaultThinkingOptionId
+    ? `Provider default (${selected.model.defaultThinkingOptionId})`
+    : "Provider default";
+  const thinkingSelectOptions = [
+    { value: "", label: providerDefault },
+    ...(!thinkingKnown && form.thinkingOptionId !== ""
+      ? [
+          {
+            value: form.thinkingOptionId,
+            label: `${form.thinkingOptionId} (unavailable)`,
+          },
+        ]
+      : []),
+    ...thinkingOptions.map((option) => ({ value: option.id, label: option.label })),
+  ];
+  return (
+    <>
+      <Field>
+        <FieldLabel htmlFor="trigger-agent">Agent</FieldLabel>
+        <AgentModelCombobox
+          options={agentOptions}
+          value={form.agent}
+          onSelect={(agent) => {
+            const next = selectedProviderModel(entries, agent);
+            onChange({
+              ...form,
+              agent,
+              mode: defaultMode(next.entry),
+              thinkingOptionId: "",
+            });
+          }}
+        />
+        <FieldDescription>Models reported by the selected daemon.</FieldDescription>
+      </Field>
+      <Field>
+        <FieldLabel htmlFor="trigger-mode">Execution mode</FieldLabel>
+        <TriggerSelect
+          id="trigger-mode"
+          value={form.mode}
+          options={modeOptions}
+          placeholder="Select a mode"
+          onChange={(mode) => onChange({ ...form, mode })}
+          required
+        />
+        <FieldDescription>Modes reported for the selected provider.</FieldDescription>
+      </Field>
+      <Field>
+        <FieldLabel htmlFor="trigger-thinking">Thinking</FieldLabel>
+        <TriggerSelect
+          id="trigger-thinking"
+          value={form.thinkingOptionId}
+          options={thinkingSelectOptions}
+          onChange={(thinkingOptionId) => onChange({ ...form, thinkingOptionId })}
+        />
+        <FieldDescription>Thinking options reported for the selected model.</FieldDescription>
+      </Field>
+    </>
+  );
+}
+
+function useDaemonProviderCatalog(
+  organizationSlug: string,
+  daemonId: string | undefined,
+  cwd: string,
+) {
+  const load = useServerFn(daemonProviderSnapshot);
+  const queryClient = useQueryClient();
+  const queryKey = ["daemon-provider-snapshot", organizationSlug, daemonId, cwd] as const;
+  const enabled = daemonId !== undefined && cwd.trim() !== "";
+  const query = useQuery({
+    queryKey,
+    enabled,
+    queryFn: () =>
+      load({
+        data: { organizationSlug, daemonId: daemonId!, cwd: cwd.trim(), refresh: true },
+      }),
+  });
+  const refresh = useMutation({
+    mutationFn: () =>
+      load({
+        data: { organizationSlug, daemonId: daemonId!, cwd: cwd.trim(), refresh: true },
+      }),
+    onSuccess: (result) => queryClient.setQueryData(queryKey, result),
+  });
+  const result = query.data;
+  const providerErrors =
+    result?.status === "ok"
+      ? result.data.entries
+          .filter((entry) => entry.status === "error")
+          .map((entry) => `${entry.label ?? entry.provider}: ${entry.error ?? "unavailable"}`)
+      : [];
+  return {
+    entries: result?.status === "ok" ? result.data.entries : undefined,
+    loading: (enabled && query.isPending) || refresh.isPending,
+    error: providerCatalogError(result, query.isError, providerErrors),
+    refresh: () => refresh.mutate(),
+  };
+}
+
+function providerCatalogError(
+  result: Result<HubProviderSnapshot> | undefined,
+  queryFailed: boolean,
+  providerErrors: string[],
+): string | undefined {
+  if (result?.status === "error") return result.error.message;
+  if (queryFailed) return "Hub couldn't load this daemon's providers.";
+  return providerErrors.length > 0 ? providerErrors.join(" ") : undefined;
+}
+
 function defaultForm(snapshot: TriggerSnapshot): TriggerFormValue {
   const slack = snapshot.connections.find(({ provider }) => provider === "slack");
   return {
@@ -883,7 +1047,7 @@ function defaultForm(snapshot: TriggerSnapshot): TriggerFormValue {
     allowedUsers: "*",
     daemon: snapshot.daemons[0]?.slug ?? "",
     cwd: "/workspace",
-    agent: "codex/gpt-5.4",
+    agent: DEFAULT_NEW_TRIGGER_AGENT,
     mode: "full-access",
     thinkingOptionId: "",
     providerOptions: "",
@@ -897,6 +1061,8 @@ function defaultForm(snapshot: TriggerSnapshot): TriggerFormValue {
       "Handle this request in the originating conversation.\n\nWhen hub.reply is available, use it for useful progress updates and your final user-facing response. Call hub.finish_execution once the request is complete.\n\nRequest:\n${{ paseo.prompt }}",
   };
 }
+
+const DEFAULT_NEW_TRIGGER_AGENT = "codex/gpt-5.4";
 
 function eventLabel(event: string): string {
   if (event === "slack.mention") return "Slack mention";

--- a/src/triggers/provider-catalog.test.ts
+++ b/src/triggers/provider-catalog.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import type { HubProviderSnapshotEntry } from "../hub/protocol.js";
+import { defaultAgentSelection, defaultMode, selectedProviderModel } from "./provider-catalog.js";
+
+const entries: HubProviderSnapshotEntry[] = [
+  {
+    provider: "codex",
+    label: "Codex",
+    status: "ready",
+    enabled: true,
+    defaultModeId: "full-access",
+    modes: [
+      { id: "read-only", label: "Read only" },
+      { id: "full-access", label: "Full access" },
+    ],
+    models: [
+      { provider: "codex", id: "small", label: "Small", isSelectable: false },
+      {
+        provider: "codex",
+        id: "gpt-5.4",
+        aliases: ["latest"],
+        label: "GPT-5.4",
+        isDefault: true,
+        thinkingOptions: [{ id: "xhigh", label: "Extra high" }],
+      },
+    ],
+  },
+];
+
+describe("trigger provider catalog", () => {
+  it("selects daemon defaults without hard-coding a provider", () => {
+    expect(defaultAgentSelection(entries)).toEqual({
+      agent: "codex/gpt-5.4",
+      mode: "full-access",
+      thinkingOptionId: "",
+    });
+  });
+
+  it("resolves aliases to the model-specific thinking catalog", () => {
+    expect(selectedProviderModel(entries, "codex/latest").model?.thinkingOptions).toEqual([
+      { id: "xhigh", label: "Extra high" },
+    ]);
+  });
+
+  it("uses the first reported mode when the provider has no explicit default", () => {
+    expect(defaultMode({ ...entries[0]!, defaultModeId: null })).toBe("read-only");
+  });
+
+  it("leaves configured values that are absent from the snapshot unresolved", () => {
+    expect(selectedProviderModel(entries, "codex/retired")).toEqual({
+      entry: entries[0],
+      model: undefined,
+    });
+  });
+});

--- a/src/triggers/provider-catalog.ts
+++ b/src/triggers/provider-catalog.ts
@@ -1,0 +1,45 @@
+import type { HubProviderSnapshotEntry } from "../hub/protocol.js";
+import { splitAgentId, type TriggerFormValue } from "./configuration/editor.js";
+
+export function selectedProviderModel(
+  entries: HubProviderSnapshotEntry[] | undefined,
+  agent: string,
+) {
+  let selection: { provider: string; model?: string } | undefined;
+  try {
+    selection = agent === "" ? undefined : splitAgentId(agent);
+  } catch {
+    selection = undefined;
+  }
+  const entry = entries?.find((candidate) => candidate.provider === selection?.provider);
+  return {
+    entry,
+    model: entry?.models?.find(
+      (candidate) =>
+        candidate.id === selection?.model || candidate.aliases?.includes(selection?.model ?? ""),
+    ),
+  };
+}
+
+export function defaultMode(entry: HubProviderSnapshotEntry | undefined): string {
+  const explicit = entry?.modes?.find((mode) => mode.id === entry.defaultModeId);
+  if (explicit !== undefined) return explicit.id;
+  return entry?.modes?.[0]?.id ?? "";
+}
+
+export function defaultAgentSelection(
+  entries: HubProviderSnapshotEntry[],
+): Pick<TriggerFormValue, "agent" | "mode" | "thinkingOptionId"> | undefined {
+  for (const entry of entries) {
+    if (entry.status !== "ready" || !entry.enabled) continue;
+    const models = (entry.models ?? []).filter((model) => model.isSelectable !== false);
+    const model = models.find((candidate) => candidate.isDefault) ?? models[0];
+    if (model === undefined) continue;
+    return {
+      agent: `${entry.provider}/${model.id}`,
+      mode: defaultMode(entry),
+      thinkingOptionId: "",
+    };
+  }
+  return undefined;
+}

--- a/src/workflows/reactions.test.ts
+++ b/src/workflows/reactions.test.ts
@@ -336,6 +336,12 @@ async function runTwoStepWorkflow<
       return { id: agentOptions.executionId };
     },
     controlExecution: async () => undefined,
+    getProviderSnapshot: async () => {
+      throw new Error("not used");
+    },
+    refreshProviderSnapshot: async () => {
+      throw new Error("not used");
+    },
   };
   const lifecycle = createDaemonDispatchLifecycle({
     database,


### PR DESCRIPTION
Trigger setup now loads models, execution modes, and thinking options from the selected daemon. Every selector uses the shared shadcn components, with a searchable model combobox, while YAML-only fields and unavailable authored values remain intact.

## Goals

- Read the daemon through the existing provider snapshot request and update operations
- Keep catalog access organization-scoped
- Offer a searchable shadcn model combobox
- Use shadcn selectors for event, connection, daemon, execution mode, thinking, and GitHub connection
- Preserve authored values when a daemon is offline or its catalog changes
- Surface refresh and request errors without rewriting provider configuration

## Non-goals

- Add new daemon RPCs
- Normalize provider-specific options into a lossy provider-neutral model
- Broaden Hub execution authority beyond provider snapshot access

## Why

The daemon is the source of truth for provider capabilities. Reading its snapshot avoids stale free-text IDs while preserving each provider's native configuration and execution behavior.

## Related work

Companion permission change: https://github.com/getpaseo/paseo/pull/4242

## Verification

- npm run typecheck
- npm run lint
- npm run format:check
- npm run db:check
- npm run build
- npx playwright test e2e/triggers.spec.ts --project=desktop-chromium --workers=1 (1 passed)
- source-built Hub/Paseo provider snapshot suite (6 passed)
- focused daemon catalog, protocol, registry, trigger catalog, lifecycle, and workflow tests passed
- full local suite progressed through the 94-test daemon suite and multiple PostgreSQL integration suites before the runner's five-minute termination; required CI runs the authoritative full matrix

Risk surface: daemon snapshot request lifecycle, trigger form projection and round-trip preservation, and the pinned companion Paseo permission commit.