### PR TITLE
Require explicit daemon and agent selection for triggers

### DIFF
--- a/e2e/entitlements.spec.ts
+++ b/e2e/entitlements.spec.ts
@@ -89,13 +89,12 @@ test.describe("metered usage", () => {
     const reason = "Trial cap on monthly executions";
     const app = projectApp(page);
     const triggers = new OrganizationTriggers(page);
+    let daemonSlug = "";
 
     await test.step("sign up, create an organization, register a daemon, become an operator", async () => {
       await hub.signUpAs("owner", meterOwner);
       await hub.createOrganization("owner", "Acme");
-      await hub.startDaemonRegistration("owner");
-      const daemonId = await hub.approveDaemon("owner", "Slice Three Runner");
-      await hub.setDaemonSlug(daemonId, "slice-three-runner");
+      daemonSlug = await hub.connectProviderDaemon("owner", "Acme");
       await hub.grantOperator("owner");
     });
 
@@ -110,8 +109,11 @@ test.describe("metered usage", () => {
       await triggers.startNew();
       await triggers.configureManual({
         name: "deploy",
-        daemon: "slice-three-runner",
+        daemon: daemonSlug,
         cwd: "/workspace",
+        agent: "codex/gpt-5.4",
+        mode: "full-access",
+        thinking: "high",
         prompt: "${{ paseo.prompt }}",
       });
       await triggers.save("deploy");

--- a/e2e/helpers/hub.ts
+++ b/e2e/helpers/hub.ts
@@ -3281,7 +3281,12 @@ class HubUser {
         .getByRole("menu")
         .getByRole("menuitem", { name: destinationOrganization, exact: true })
         .click();
-      await expect(this.page.getByRole("alert")).toHaveText(
+      await expect(
+        this.page.getByRole("alert").filter({
+          hasText:
+            "Hub did not receive the account update. Check your connection, reload the current account state, and submit again.",
+        }),
+      ).toHaveText(
         "Hub did not receive the account update. Check your connection, reload the current account state, and submit again.",
       );
       await expect(switcher).toContainText("Acme");

--- a/e2e/helpers/triggers.ts
+++ b/e2e/helpers/triggers.ts
@@ -20,7 +20,8 @@ export class OrganizationTriggers {
     await expect(this.page.getByRole("heading", { name: "Trigger details" })).toBeVisible();
     await expect(this.page.getByRole("heading", { name: "Event & access" })).toBeVisible();
     await expect(this.page.getByRole("heading", { name: "Run target" })).toBeVisible();
-    await expect(this.page.getByRole("heading", { name: "Agent & instructions" })).toBeVisible();
+    await expect(this.page.getByRole("heading", { name: "Agent & instructions" })).toBeHidden();
+    await expect(this.page.getByLabel("Working directory")).toBeHidden();
     const topbar = this.page.locator("header.sticky");
     await expect(topbar.getByRole("button", { name: "Form" })).toBeEnabled();
     await expect(topbar.getByRole("button", { name: "YAML" })).toBeVisible();
@@ -36,6 +37,7 @@ export class OrganizationTriggers {
     users: string;
     agent: string;
     mode: string;
+    thinking: string;
     providerOptions: string;
     prompt: string;
   }) {
@@ -45,9 +47,26 @@ export class OrganizationTriggers {
     await this.page.getByRole("button", { name: "Specific people" }).click();
     await this.page.getByLabel("User IDs").fill(input.users);
     await this.selectOption("Run on daemon", input.daemon);
+    await expect(this.page.getByRole("combobox", { name: "Agent" })).toHaveAttribute(
+      "data-value",
+      "",
+    );
+    await expect(this.page.getByRole("combobox", { name: "Execution mode" })).toHaveAttribute(
+      "data-value",
+      "",
+    );
     await this.page.getByLabel("Working directory").fill(input.cwd);
     await this.selectAgent(input.agent);
+    await expect(this.page.getByRole("combobox", { name: "Execution mode" })).toHaveAttribute(
+      "data-value",
+      "",
+    );
+    await expect(this.page.getByRole("combobox", { name: "Thinking" })).toHaveAttribute(
+      "data-value",
+      "",
+    );
     await this.selectOption("Execution mode", input.mode);
+    await this.selectOption("Thinking", input.thinking);
     await this.page
       .locator("summary")
       .filter({ hasText: "Advanced provider options (JSON)" })
@@ -60,14 +79,18 @@ export class OrganizationTriggers {
     name: string;
     daemon: string;
     cwd: string;
-    agent?: string;
+    agent: string;
+    mode: string;
+    thinking: string;
     prompt: string;
   }) {
     await this.page.getByLabel("Trigger name").fill(input.name);
     await this.selectOption("When this happens", "manual.run");
     await this.selectOption("Run on daemon", input.daemon);
     await this.page.getByLabel("Working directory").fill(input.cwd);
-    if (input.agent !== undefined) await this.selectAgent(input.agent);
+    await this.selectAgent(input.agent);
+    await this.selectOption("Execution mode", input.mode);
+    await this.selectOption("Thinking", input.thinking);
     await this.page.getByLabel("Instructions", { exact: true }).fill(input.prompt);
   }
 

--- a/e2e/triggers.spec.ts
+++ b/e2e/triggers.spec.ts
@@ -1,3 +1,4 @@
+import { expect } from "@playwright/test";
 import { test } from "./app.js";
 import { OrganizationTriggers } from "./helpers/triggers.js";
 
@@ -7,6 +8,28 @@ const owner = {
   email: "trigger-owner@example.com",
   password: "trigger-owner-password",
 };
+
+test("requires daemon setup before trigger configuration", async ({ hub, page }) => {
+  await hub.signUpAs("owner", owner);
+  await hub.createOrganization("owner", "Acme");
+  const triggers = new OrganizationTriggers(page);
+
+  await triggers.open();
+  await expect(page.getByRole("alert")).toContainText("Add a daemon first");
+  await expect(page.getByRole("link", { name: "Go to Daemons" })).toHaveAttribute(
+    "href",
+    /\/o\/[^/]+\/daemons$/u,
+  );
+  await page.screenshot({ path: `${SHOTS}/00-no-daemon-callout.png`, fullPage: true });
+  await triggers.startNew();
+  await expect(page.getByText("No daemons available", { exact: true })).toBeVisible();
+  await expect(page.getByRole("combobox", { name: "Run on daemon" })).toBeHidden();
+  await expect(page.getByRole("heading", { name: "Agent & instructions" })).toBeHidden();
+  await page.screenshot({ path: `${SHOTS}/00-no-daemons.png`, fullPage: true });
+  await page.getByRole("link", { name: "Go to Daemons" }).click();
+  await expect(page).toHaveURL(/\/daemons$/u);
+  await expect(page.getByRole("heading", { name: "Daemons", level: 1 })).toBeVisible();
+});
 
 test("creates a trigger visually, preserves advanced YAML through the form, and explains legacy workflows", async ({
   hub,
@@ -26,6 +49,7 @@ test("creates a trigger visually, preserves advanced YAML through the form, and 
 
   await test.step("the common setup stays in one small form", async () => {
     await triggers.startNew();
+    await page.screenshot({ path: `${SHOTS}/01b-daemon-required.png`, fullPage: true });
     await triggers.configureSlackMention({
       name: "slack-help",
       connection: "company-slack",
@@ -34,6 +58,7 @@ test("creates a trigger visually, preserves advanced YAML through the form, and 
       users: "U123, U456",
       agent: "pi/gateway/vendor/model-v1",
       mode: "full-access",
+      thinking: "high",
       providerOptions: '{"sandbox_mode":"workspace-write"}',
       prompt: "Handle the Slack request.",
     });

--- a/src/triggers/configuration/editor.ts
+++ b/src/triggers/configuration/editor.ts
@@ -205,6 +205,7 @@ function parsePermissions(value: string): Record<string, "read" | "write" | "adm
 }
 
 function validateFormValue(value: TriggerFormValue): void {
+  if (value.daemon.trim().length === 0) throw new Error("Daemon is required.");
   if (!value.cwd.trim().startsWith("/")) {
     throw new Error("Working directory must be an absolute path.");
   }

--- a/src/triggers/form-select.tsx
+++ b/src/triggers/form-select.tsx
@@ -30,12 +30,14 @@ export function TriggerSelect({
   required?: boolean;
   onChange: (value: string) => void;
 }) {
+  const hasEmptyOption = options.some((option) => option.value === "");
   const change = useCallback(
     (nextValue: string) => onChange(nextValue === EMPTY_VALUE ? "" : nextValue),
     [onChange],
   );
+  const selectedValue = value === "" && hasEmptyOption ? EMPTY_VALUE : value;
   return (
-    <Select value={value === "" ? EMPTY_VALUE : value} onValueChange={change}>
+    <Select value={selectedValue} onValueChange={change}>
       <SelectTrigger id={id} className="w-full" aria-required={required} data-value={value}>
         <SelectValue placeholder={placeholder} />
       </SelectTrigger>

--- a/src/triggers/panel.tsx
+++ b/src/triggers/panel.tsx
@@ -4,14 +4,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useNavigate } from "@tanstack/react-router";
 import { useServerFn } from "@tanstack/react-start";
 import { AlertTriangle, ArrowLeft, Braces, Copy, FileText, LockKeyhole, Plus } from "lucide-react";
-import {
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState,
-  type FormEvent,
-  type ReactNode,
-} from "react";
+import { useLayoutEffect, useRef, useState, type FormEvent, type ReactNode } from "react";
 import { DataCell, DataRow, DataTable } from "../components/app/data-table.js";
 import { PageHeader } from "../components/app/page.js";
 import { SiteHeaderActions } from "../components/app/site-header-actions.js";
@@ -27,7 +20,6 @@ import { CodeEditor } from "../projects/configuration/code-editor.js";
 import { useRouteTenant } from "../projects/context.js";
 import type { Result } from "../contract/respond.js";
 import {
-  createTriggerYaml,
   mergeTriggerForm,
   parseEditorEvent,
   projectTriggerForm,
@@ -36,7 +28,7 @@ import {
 import { saveTrigger, triggerSnapshot, type TriggerSnapshot } from "./functions.js";
 import { daemonProviderSnapshot } from "../daemons/functions.js";
 import type { HubProviderSnapshot, HubProviderSnapshotEntry } from "../hub/protocol.js";
-import { defaultAgentSelection, defaultMode, selectedProviderModel } from "./provider-catalog.js";
+import { selectedProviderModel } from "./provider-catalog.js";
 import { AgentModelCombobox, type AgentModelOption } from "./agent-model-combobox.js";
 import { TriggerSelect, type TriggerSelectOption } from "./form-select.js";
 
@@ -85,6 +77,17 @@ export function TriggersPanel() {
           </Button>
         ) : null}
       </PageHeader>
+      {data.daemons.length === 0 ? (
+        <Alert className="mb-5">
+          <AlertTitle>Add a daemon first</AlertTitle>
+          <AlertDescription className="flex items-center justify-between gap-3">
+            <span>Triggers need a daemon to run.</span>
+            <Button asChild variant="outline" size="sm">
+              <Link to={`/o/${scope.organizationSlug}/daemons` as never}>Go to Daemons</Link>
+            </Button>
+          </AlertDescription>
+        </Alert>
+      ) : null}
       <DataTable
         label="Triggers"
         columns={TRIGGER_COLUMNS}
@@ -375,7 +378,7 @@ function useTriggerEditorState(
   onSave: (yaml: string) => void,
 ) {
   const initialForm = trigger?.draft ?? defaultForm(snapshot);
-  const initialYaml = trigger?.yaml ?? createTriggerYaml(initialForm);
+  const initialYaml = trigger?.yaml ?? "";
   const initialProjection = projectTriggerForm(initialYaml);
   const [mode, setMode] = useState<EditorMode>(
     trigger === null || (initialProjection.status === "editable" && !legacy) ? "form" : "yaml",
@@ -486,17 +489,6 @@ function TriggerForm({
     selectedDaemon?.id,
     form.cwd,
   );
-  useEffect(() => {
-    if (
-      triggerId !== undefined ||
-      form.agent !== DEFAULT_NEW_TRIGGER_AGENT ||
-      providerCatalog.entries === undefined
-    )
-      return;
-    const defaults = defaultAgentSelection(providerCatalog.entries);
-    if (defaults === undefined) return;
-    onChange({ ...form, ...defaults });
-  }, [form, onChange, providerCatalog.entries, triggerId]);
   return (
     <div className="grid gap-5">
       <FormSection
@@ -591,150 +583,173 @@ function TriggerForm({
         title="Run target"
         description="The local machine compute and repository working directory."
       >
-        <div className="grid gap-4 sm:grid-cols-2">
+        {snapshot.daemons.length === 0 ? (
+          <div className="flex items-center justify-between gap-3">
+            <p className="text-sm text-muted-foreground">No daemons available</p>
+            <Button asChild variant="outline" size="sm">
+              <Link to={`/o/${snapshot.organization.slug}/daemons` as never}>Go to Daemons</Link>
+            </Button>
+          </div>
+        ) : (
           <Field>
             <FieldLabel htmlFor="trigger-daemon">Run on daemon</FieldLabel>
             <TriggerSelect
               id="trigger-daemon"
               value={form.daemon}
               options={daemonOptions}
-              onChange={(daemon) => update("daemon", daemon)}
+              placeholder="Select a daemon"
+              onChange={(daemon) =>
+                onChange({
+                  ...form,
+                  daemon,
+                  agent: "",
+                  mode: "",
+                  thinkingOptionId: "",
+                  providerOptions: "",
+                })
+              }
               required
             />
             <FieldDescription>
               The daemon owns compute, credentials, and sandboxing.
             </FieldDescription>
           </Field>
-          <ControlledInput
-            label="Working directory"
-            value={form.cwd}
-            onChange={(value) => update("cwd", value)}
-            description="Absolute path on the daemon."
-            required
-          />
-          <ControlledInput
-            label="Maximum runtime"
-            value={form.maxRuntime}
-            onChange={(value) => update("maxRuntime", value)}
-            description="Hard deadline for the agent, for example 2h."
-            required
-          />
-          <ControlledInput
-            label="Idle timeout"
-            value={form.idleTimeout}
-            onChange={(value) => update("idleTimeout", value)}
-            description="Stop an unresponsive agent, for example 10m."
-            required
-          />
-        </div>
+        )}
+        {selectedDaemon === undefined ? null : (
+          <div className="grid gap-4 sm:grid-cols-2">
+            <ControlledInput
+              label="Working directory"
+              value={form.cwd}
+              onChange={(value) => update("cwd", value)}
+              description="Absolute path on the daemon."
+              required
+            />
+            <ControlledInput
+              label="Maximum runtime"
+              value={form.maxRuntime}
+              onChange={(value) => update("maxRuntime", value)}
+              description="Hard deadline for the agent, for example 2h."
+              required
+            />
+            <ControlledInput
+              label="Idle timeout"
+              value={form.idleTimeout}
+              onChange={(value) => update("idleTimeout", value)}
+              description="Stop an unresponsive agent, for example 10m."
+              required
+            />
+          </div>
+        )}
       </FormSection>
 
-      <FormSection
-        number="4"
-        title="Agent & instructions"
-        description="The AI coding agent model and task prompt instructions."
-      >
-        <div className="grid gap-4 sm:grid-cols-2">
-          <ProviderCatalogFields
-            form={form}
-            entries={providerCatalog.entries}
-            onChange={onChange}
-          />
-        </div>
-        {providerCatalog.loading ? (
-          <p className="text-sm text-muted-foreground" aria-busy="true">
-            Loading providers from {form.daemon}…
-          </p>
-        ) : null}
-        {providerCatalog.error === undefined ? null : (
-          <Alert variant="destructive">
-            <AlertDescription className="flex items-center justify-between gap-3">
-              <span>{providerCatalog.error}</span>
-              <Button type="button" variant="outline" size="sm" onClick={providerCatalog.refresh}>
-                Retry
-              </Button>
-            </AlertDescription>
-          </Alert>
-        )}
-        <details className="rounded-md border bg-muted/20 p-3">
-          <summary className="cursor-pointer text-sm">Advanced provider options (JSON)</summary>
-          <Field className="mt-3">
-            <FieldLabel htmlFor="trigger-provider-options" className="sr-only">
-              Advanced provider options (JSON)
-            </FieldLabel>
-            <Textarea
-              id="trigger-provider-options"
-              value={form.providerOptions}
-              onChange={(event) => update("providerOptions", event.target.value)}
-              rows={5}
-              placeholder={'{"sandbox_mode":"workspace-write"}'}
-            />
-            <FieldDescription>
-              Passed to the provider on your daemon. YAML-only agent fields remain untouched.
-            </FieldDescription>
-          </Field>
-        </details>
-        <details
-          className="rounded-md border bg-muted/20 p-3"
-          open={githubExpanded}
-          onToggle={(event) => setGithubExpanded(event.currentTarget.open)}
+      {selectedDaemon === undefined ? null : (
+        <FormSection
+          number="4"
+          title="Agent & instructions"
+          description="The AI coding agent model and task prompt instructions."
         >
-          <summary className="cursor-pointer text-sm">GitHub access</summary>
-          <div className="mt-3 grid gap-4 sm:grid-cols-2">
-            <Field>
-              <FieldLabel htmlFor="trigger-github-connection">GitHub connection</FieldLabel>
-              <TriggerSelect
-                id="trigger-github-connection"
-                value={form.githubConnection}
-                options={githubConnectionOptions}
-                onChange={(connection) => update("githubConnection", connection)}
+          <div className="grid gap-4 sm:grid-cols-2">
+            <ProviderCatalogFields
+              form={form}
+              entries={providerCatalog.entries}
+              onChange={onChange}
+            />
+          </div>
+          {providerCatalog.loading ? (
+            <p className="text-sm text-muted-foreground" aria-busy="true">
+              Loading providers from {form.daemon}…
+            </p>
+          ) : null}
+          {providerCatalog.error === undefined ? null : (
+            <Alert variant="destructive">
+              <AlertDescription className="flex items-center justify-between gap-3">
+                <span>{providerCatalog.error}</span>
+                <Button type="button" variant="outline" size="sm" onClick={providerCatalog.refresh}>
+                  Retry
+                </Button>
+              </AlertDescription>
+            </Alert>
+          )}
+          <details className="rounded-md border bg-muted/20 p-3">
+            <summary className="cursor-pointer text-sm">Advanced provider options (JSON)</summary>
+            <Field className="mt-3">
+              <FieldLabel htmlFor="trigger-provider-options" className="sr-only">
+                Advanced provider options (JSON)
+              </FieldLabel>
+              <Textarea
+                id="trigger-provider-options"
+                value={form.providerOptions}
+                onChange={(event) => update("providerOptions", event.target.value)}
+                rows={5}
+                placeholder={'{"sandbox_mode":"workspace-write"}'}
               />
               <FieldDescription>
-                Mints a short-lived, restricted GH_TOKEN for this run.
+                Passed to the provider on your daemon. YAML-only agent fields remain untouched.
               </FieldDescription>
             </Field>
-            {githubEnabled ? (
-              <>
-                <ControlledInput
-                  label="GitHub repositories"
-                  value={form.githubRepositories}
-                  onChange={(value) => update("githubRepositories", value)}
-                  description="Comma-separated owner/repository names."
-                  required
+          </details>
+          <details
+            className="rounded-md border bg-muted/20 p-3"
+            open={githubExpanded}
+            onToggle={(event) => setGithubExpanded(event.currentTarget.open)}
+          >
+            <summary className="cursor-pointer text-sm">GitHub access</summary>
+            <div className="mt-3 grid gap-4 sm:grid-cols-2">
+              <Field>
+                <FieldLabel htmlFor="trigger-github-connection">GitHub connection</FieldLabel>
+                <TriggerSelect
+                  id="trigger-github-connection"
+                  value={form.githubConnection}
+                  options={githubConnectionOptions}
+                  onChange={(connection) => update("githubConnection", connection)}
                 />
-                <ControlledInput
-                  label="GitHub token lifetime"
-                  value={form.githubDuration}
-                  onChange={(value) => update("githubDuration", value)}
-                  description="At most 1h."
-                  required
-                />
-                <Field>
-                  <FieldLabel htmlFor="trigger-github-permissions">
-                    GitHub permissions (JSON)
-                  </FieldLabel>
-                  <Textarea
-                    id="trigger-github-permissions"
-                    value={form.githubPermissions}
-                    onChange={(event) => update("githubPermissions", event.target.value)}
-                    rows={4}
-                    placeholder={'{"contents":"write","pull_requests":"write"}'}
+                <FieldDescription>
+                  Mints a short-lived, restricted GH_TOKEN for this run.
+                </FieldDescription>
+              </Field>
+              {githubEnabled ? (
+                <>
+                  <ControlledInput
+                    label="GitHub repositories"
+                    value={form.githubRepositories}
+                    onChange={(value) => update("githubRepositories", value)}
+                    description="Comma-separated owner/repository names."
+                    required
                   />
-                  <FieldDescription>
-                    Defaults to read-only repository contents when empty.
-                  </FieldDescription>
-                </Field>
-              </>
-            ) : null}
+                  <ControlledInput
+                    label="GitHub token lifetime"
+                    value={form.githubDuration}
+                    onChange={(value) => update("githubDuration", value)}
+                    description="At most 1h."
+                    required
+                  />
+                  <Field>
+                    <FieldLabel htmlFor="trigger-github-permissions">
+                      GitHub permissions (JSON)
+                    </FieldLabel>
+                    <Textarea
+                      id="trigger-github-permissions"
+                      value={form.githubPermissions}
+                      onChange={(event) => update("githubPermissions", event.target.value)}
+                      rows={4}
+                      placeholder={'{"contents":"write","pull_requests":"write"}'}
+                    />
+                    <FieldDescription>
+                      Defaults to read-only repository contents when empty.
+                    </FieldDescription>
+                  </Field>
+                </>
+              ) : null}
+            </div>
+          </details>
+          <PromptEditor value={form.prompt} onChange={(prompt) => update("prompt", prompt)} />
+          <div className="flex items-center gap-2 rounded-md border bg-muted/40 p-3 text-sm text-muted-foreground">
+            <LockKeyhole className="size-4 shrink-0 text-link" />
+            Hub launches the agent on your daemon. Keys, provider configuration, and sandboxing stay
+            on your compute.
           </div>
-        </details>
-        <PromptEditor value={form.prompt} onChange={(prompt) => update("prompt", prompt)} />
-        <div className="flex items-center gap-2 rounded-md border bg-muted/40 p-3 text-sm text-muted-foreground">
-          <LockKeyhole className="size-4 shrink-0 text-link" />
-          Hub launches the agent on your daemon. Keys, provider configuration, and sandboxing stay
-          on your compute.
-        </div>
-      </FormSection>
+        </FormSection>
+      )}
     </div>
   );
 }
@@ -928,11 +943,7 @@ function ProviderCatalogFields({
       : []),
     ...modes.map((mode) => ({ value: mode.id, label: mode.label })),
   ];
-  const providerDefault = selected.model?.defaultThinkingOptionId
-    ? `Provider default (${selected.model.defaultThinkingOptionId})`
-    : "Provider default";
   const thinkingSelectOptions = [
-    { value: "", label: providerDefault },
     ...(!thinkingKnown && form.thinkingOptionId !== ""
       ? [
           {
@@ -951,11 +962,10 @@ function ProviderCatalogFields({
           options={agentOptions}
           value={form.agent}
           onSelect={(agent) => {
-            const next = selectedProviderModel(entries, agent);
             onChange({
               ...form,
               agent,
-              mode: defaultMode(next.entry),
+              mode: "",
               thinkingOptionId: "",
             });
           }}
@@ -974,16 +984,20 @@ function ProviderCatalogFields({
         />
         <FieldDescription>Modes reported for the selected provider.</FieldDescription>
       </Field>
-      <Field>
-        <FieldLabel htmlFor="trigger-thinking">Thinking</FieldLabel>
-        <TriggerSelect
-          id="trigger-thinking"
-          value={form.thinkingOptionId}
-          options={thinkingSelectOptions}
-          onChange={(thinkingOptionId) => onChange({ ...form, thinkingOptionId })}
-        />
-        <FieldDescription>Thinking options reported for the selected model.</FieldDescription>
-      </Field>
+      {thinkingOptions.length === 0 ? null : (
+        <Field>
+          <FieldLabel htmlFor="trigger-thinking">Thinking</FieldLabel>
+          <TriggerSelect
+            id="trigger-thinking"
+            value={form.thinkingOptionId}
+            options={thinkingSelectOptions}
+            placeholder="Select a thinking option"
+            onChange={(thinkingOptionId) => onChange({ ...form, thinkingOptionId })}
+            required
+          />
+          <FieldDescription>Thinking options reported for the selected model.</FieldDescription>
+        </Field>
+      )}
     </>
   );
 }
@@ -1045,10 +1059,10 @@ function defaultForm(snapshot: TriggerSnapshot): TriggerFormValue {
     event: slack === undefined ? "manual.run" : "slack.mention",
     connection: slack?.slug ?? "",
     allowedUsers: "*",
-    daemon: snapshot.daemons[0]?.slug ?? "",
+    daemon: "",
     cwd: "/workspace",
-    agent: DEFAULT_NEW_TRIGGER_AGENT,
-    mode: "full-access",
+    agent: "",
+    mode: "",
     thinkingOptionId: "",
     providerOptions: "",
     maxRuntime: "2h",
@@ -1061,8 +1075,6 @@ function defaultForm(snapshot: TriggerSnapshot): TriggerFormValue {
       "Handle this request in the originating conversation.\n\nWhen hub.reply is available, use it for useful progress updates and your final user-facing response. Call hub.finish_execution once the request is complete.\n\nRequest:\n${{ paseo.prompt }}",
   };
 }
-
-const DEFAULT_NEW_TRIGGER_AGENT = "codex/gpt-5.4";
 
 function eventLabel(event: string): string {
   if (event === "slack.mention") return "Slack mention";

--- a/src/triggers/provider-catalog.test.ts
+++ b/src/triggers/provider-catalog.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { HubProviderSnapshotEntry } from "../hub/protocol.js";
-import { defaultAgentSelection, defaultMode, selectedProviderModel } from "./provider-catalog.js";
+import { selectedProviderModel } from "./provider-catalog.js";
 
 const entries: HubProviderSnapshotEntry[] = [
   {
@@ -28,22 +28,10 @@ const entries: HubProviderSnapshotEntry[] = [
 ];
 
 describe("trigger provider catalog", () => {
-  it("selects daemon defaults without hard-coding a provider", () => {
-    expect(defaultAgentSelection(entries)).toEqual({
-      agent: "codex/gpt-5.4",
-      mode: "full-access",
-      thinkingOptionId: "",
-    });
-  });
-
   it("resolves aliases to the model-specific thinking catalog", () => {
     expect(selectedProviderModel(entries, "codex/latest").model?.thinkingOptions).toEqual([
       { id: "xhigh", label: "Extra high" },
     ]);
-  });
-
-  it("uses the first reported mode when the provider has no explicit default", () => {
-    expect(defaultMode({ ...entries[0]!, defaultModeId: null })).toBe("read-only");
   });
 
   it("leaves configured values that are absent from the snapshot unresolved", () => {

--- a/src/triggers/provider-catalog.ts
+++ b/src/triggers/provider-catalog.ts
@@ -1,5 +1,5 @@
 import type { HubProviderSnapshotEntry } from "../hub/protocol.js";
-import { splitAgentId, type TriggerFormValue } from "./configuration/editor.js";
+import { splitAgentId } from "./configuration/editor.js";
 
 export function selectedProviderModel(
   entries: HubProviderSnapshotEntry[] | undefined,
@@ -19,27 +19,4 @@ export function selectedProviderModel(
         candidate.id === selection?.model || candidate.aliases?.includes(selection?.model ?? ""),
     ),
   };
-}
-
-export function defaultMode(entry: HubProviderSnapshotEntry | undefined): string {
-  const explicit = entry?.modes?.find((mode) => mode.id === entry.defaultModeId);
-  if (explicit !== undefined) return explicit.id;
-  return entry?.modes?.[0]?.id ?? "";
-}
-
-export function defaultAgentSelection(
-  entries: HubProviderSnapshotEntry[],
-): Pick<TriggerFormValue, "agent" | "mode" | "thinkingOptionId"> | undefined {
-  for (const entry of entries) {
-    if (entry.status !== "ready" || !entry.enabled) continue;
-    const models = (entry.models ?? []).filter((model) => model.isSelectable !== false);
-    const model = models.find((candidate) => candidate.isDefault) ?? models[0];
-    if (model === undefined) continue;
-    return {
-      agent: `${entry.provider}/${model.id}`,
-      mode: defaultMode(entry),
-      thinkingOptionId: "",
-    };
-  }
-  return undefined;
 }


### PR DESCRIPTION
Trigger setup now waits for the operator to choose a daemon and agent configuration instead of guessing from available providers. Organizations without a daemon are directed to daemon setup from both the trigger list and editor.

## Goals
- Require an explicit daemon selection for new triggers.
- Hide daemon-dependent fields until a daemon is selected.
- Require explicit model, execution mode, and thinking choices where available.
- Clear provider-dependent selections when the daemon changes.
- Guide organizations without daemons directly to daemon setup.

## Non-goals
- Change the authored YAML contract for existing triggers.
- Change daemon/provider discovery semantics.

## Why
Provider and execution defaults encode intent Hub cannot know. Trigger setup must keep those choices explicit and avoid presenting downstream configuration before its daemon context exists.

## Verification
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run db:check`
- `npm run build`
- `npx playwright test e2e/triggers.spec.ts`
- `npx playwright test e2e/entitlements.spec.ts --grep "caps executions"`

## Risk surface
Trigger form initialization, daemon-dependent rendering, selector placeholder behavior, and browser test setup.