### PR TITLE
Offer help and count down the trial in the sidebar

### DIFF
--- a/docs/billing.md
+++ b/docs/billing.md
@@ -21,6 +21,14 @@ The coupling runs one direction: `billing` calls
 `entitlements.stamp(organizationId, template, provenance)`. `src/entitlements/` never imports
 `src/billing/`.
 
+A surface that needs one billing-derived fact but is not the billing surface asks for that fact
+alone, through `src/server/capabilities.ts`. Both probes there follow the same shape: the answer
+is a boolean or a number resolved by the composition root, never a subscription, a status, or a
+plan, and the self-hosted answer is a truthful "no" rather than an error. That is what lets the
+dashboard shell gate the Billing nav entry and count down a trial while still deleting cleanly
+with `src/billing/`. Widening one of these into a view is how the boundary gets lost — a surface
+that needs the subscription needs the billing page.
+
 ## Plan catalog
 
 Stripe is the source of truth for prices and entitlement inputs. Hub owns the customer-facing

--- a/e2e/billing-subscription.spec.ts
+++ b/e2e/billing-subscription.spec.ts
@@ -37,6 +37,8 @@ test("a new organization starts trialing, replay is a no-op, and cancellation ex
     await hub.createOrganization("owner", "Acme");
     await hub.expectCurrentPlan("owner", "Hosted");
     await hub.expectActiveTrial("owner");
+    // The countdown is ambient: the owner reads it from the sidebar without opening billing.
+    await hub.expectTrialReminder("owner");
     await hub.expectReportedSeatQuantity("owner", 1);
     await page.screenshot({ path: `${SLICE_6_DIR}/01-hosted-trial.png`, fullPage: true });
   });
@@ -65,6 +67,8 @@ test("a new organization starts trialing, replay is a no-op, and cancellation ex
     // Enforcement reverts to the zero-execution floor; the customer-facing page says only that
     // there is no subscription, and offers the plan again.
     await hub.expectNoSubscription("owner");
+    // And the countdown goes with it, rather than counting down a trial nobody is on.
+    await hub.expectNoTrialReminder("owner");
     await page.screenshot({ path: `${SLICE_6_DIR}/03-cancel-reverts.png`, fullPage: true });
     // The trial was consumed by the cancelled subscription, so the paywall now sells the plan
     // instead of promising another 14 free days.

--- a/e2e/helpers/hub.ts
+++ b/e2e/helpers/hub.ts
@@ -1063,6 +1063,14 @@ export class PaseoHub {
     await this.requireUser(alias).expectNoSecondTrialOffer();
   }
 
+  async expectTrialReminder(alias: string): Promise<void> {
+    await this.requireUser(alias).expectTrialReminder();
+  }
+
+  async expectNoTrialReminder(alias: string): Promise<void> {
+    await this.requireUser(alias).expectNoTrialReminder();
+  }
+
   async expectPlanPickerFitsPhone(alias: string): Promise<void> {
     await this.requireUser(alias).expectPlanPickerFitsPhone();
   }
@@ -3894,13 +3902,11 @@ class HubUser {
     const identity = this.page.getByText(this.accountEmail, { exact: true });
     await expect(identity).toBeVisible();
     const organization = this.page.getByRole("button", { name: "Organization" });
-    const account = this.page.getByRole("button", { name: this.accountEmail });
 
     await this.page.keyboard.press("Tab");
     await expect(organization).toBeFocused();
     await this.tabThroughOrganizationDestinations();
-    await this.page.keyboard.press("Tab");
-    await expect(account).toBeFocused();
+    await this.tabThroughSidebarFooter();
 
     await expect(organization).toContainText("Owner");
     await organization.focus();
@@ -3923,15 +3929,13 @@ class HubUser {
     await this.openOrganizationSection("Team");
     await this.page.reload();
     const organization = this.page.getByRole("button", { name: "Organization" });
-    const account = this.page.getByRole("button", { name: this.accountEmail });
     const invite = this.page.getByRole("button", { name: "Invite member" });
     await expect(invite).toBeVisible();
 
     await this.page.keyboard.press("Tab");
     await expect(organization).toBeFocused();
     await this.tabThroughOrganizationDestinations();
-    await this.page.keyboard.press("Tab");
-    await expect(account).toBeFocused();
+    await this.tabThroughSidebarFooter();
 
     await invite.focus();
     await this.page.keyboard.press("Enter");
@@ -4002,6 +4006,18 @@ class HubUser {
       await this.page.keyboard.press("Tab");
       await expect(this.page.getByRole("link", { name: destination, exact: true })).toBeFocused();
     }
+  }
+
+  /**
+   * The footer's stops after the destinations: Help, then the account menu. A trial reminder
+   * precedes Help when the organization is trialing, which this harness never is — the browser
+   * fixtures that configure billing do not drive the sidebar by keyboard.
+   */
+  private async tabThroughSidebarFooter(): Promise<void> {
+    await this.page.keyboard.press("Tab");
+    await expect(this.page.getByRole("button", { name: "Help", exact: true })).toBeFocused();
+    await this.page.keyboard.press("Tab");
+    await expect(this.page.getByRole("button", { name: this.accountEmail })).toBeFocused();
   }
 
   async navigateToConnectionsFromMobileSidebar(): Promise<void> {
@@ -4256,6 +4272,23 @@ class HubUser {
     await expect(plan.getByRole("button", { name: "Choose a plan" })).toHaveCount(0);
     await expect(plan).not.toContainText("run workflows");
     await expectAccessible(this.page);
+  }
+
+  /**
+   * The sidebar's ambient countdown. The day count is Stripe's to decide, so this pins the
+   * sentence rather than a number — what matters is that it is there and reads as days left.
+   */
+  async expectTrialReminder(): Promise<void> {
+    await expect(this.trialReminder()).toBeVisible();
+  }
+
+  /** No trial, no countdown. A paid, free, or cancelled organization is told nothing. */
+  async expectNoTrialReminder(): Promise<void> {
+    await expect(this.trialReminder()).toHaveCount(0);
+  }
+
+  private trialReminder(): Locator {
+    return this.page.getByRole("link", { name: /^\d+ days? left in trial$/u });
   }
 
   /** The picker offering the cardless trial, exactly: a badge, the offer, and the action. */

--- a/src/application-runtime.ts
+++ b/src/application-runtime.ts
@@ -338,6 +338,17 @@ async function createOwnedApplicationRuntime(
       });
       return { url: portal?.url ?? null };
     },
+    // Unlike the rest of the billing surface this one answers rather than refuses when billing is
+    // absent: the dashboard sidebar asks it on every organization, hosted or not, and "no trial"
+    // is the truthful answer on a self-hosted instance.
+    organizationTrial: async (request, organizationSlug) => {
+      const { billing, database } = options;
+      if (billing === null || database === null) return { daysLeft: null };
+      const { tenant } = await resolveRouteTenant(requireAuth(options), database, request, {
+        organizationSlug,
+      });
+      return { daysLeft: await billing.trialRemaining(tenant.organization.id) };
+    },
     providerRequest: (name, request) =>
       requests.get(name)?.(request) ?? Promise.resolve(new Response("Not Found", { status: 404 })),
     stop: () => ownership.close(),

--- a/src/auth/dashboard-shell.tsx
+++ b/src/auth/dashboard-shell.tsx
@@ -80,6 +80,8 @@ import type { Result } from "../contract/respond.js";
 import { ACCOUNT_MUTATION_KEY, useAccountMutationError } from "./account-mutation.js";
 import { useTenantContextMutationPending } from "./tenant-mutation.js";
 import { RouteTenantProvider, useOptionalRouteTenant } from "../projects/context.js";
+import { SidebarHelp } from "./sidebar-help.js";
+import { TrialNotice } from "./trial-notice.js";
 
 type RouteTenant = NonNullable<ReturnType<typeof useOptionalRouteTenant>>;
 
@@ -301,6 +303,8 @@ function AppSidebar({
       </SidebarContent>
       <SidebarFooter>
         <SidebarMenu>
+          <TrialNotice organizationSlug={organization.slug} />
+          <SidebarHelp />
           <SidebarMenuItem>
             <AccountMenu
               email={account.account.email}

--- a/src/auth/sidebar-help.tsx
+++ b/src/auth/sidebar-help.tsx
@@ -1,0 +1,59 @@
+import { CircleQuestionMark } from "lucide-react";
+import { Popover, PopoverContent, PopoverTrigger } from "../components/ui/popover.js";
+import { SidebarMenuButton, SidebarMenuItem } from "../components/ui/sidebar.js";
+
+const DISCORD_INVITE = "https://discord.gg/jz8T2uahpH";
+const SUPPORT_EMAIL = "hello@paseo.sh";
+const LINK = "underline underline-offset-4 hover:text-link";
+
+/**
+ * The two places a Hub user can reach a human. Kept as its own component because it is the only
+ * part of Help worth reading twice: the popover around it is a Radix default.
+ */
+export function HelpChannels() {
+  return (
+    <div className="grid gap-2 text-sm">
+      <p>
+        Join the{" "}
+        <a href={DISCORD_INVITE} target="_blank" rel="noreferrer" className={LINK}>
+          Paseo Discord
+        </a>{" "}
+        and ask in #paseo-hub.
+      </p>
+      <p>
+        Or email{" "}
+        <a href={`mailto:${SUPPORT_EMAIL}`} className={LINK}>
+          {SUPPORT_EMAIL}
+        </a>
+        .
+      </p>
+    </div>
+  );
+}
+
+/**
+ * Help sits in the sidebar footer rather than a page: it is asked from wherever you got stuck,
+ * and a popover answers there instead of taking the destination away. It reads as a destination
+ * (icon, label, tooltip when collapsed) so it needs no explaining next to the ones above it.
+ */
+export function SidebarHelp() {
+  return (
+    <SidebarMenuItem>
+      <Popover>
+        <PopoverTrigger asChild>
+          <SidebarMenuButton
+            size="sm"
+            tooltip="Help"
+            className="text-muted-foreground data-[state=open]:bg-sidebar-accent"
+          >
+            <CircleQuestionMark aria-hidden="true" />
+            <span>Help</span>
+          </SidebarMenuButton>
+        </PopoverTrigger>
+        <PopoverContent align="start" side="top" sideOffset={4} aria-label="Help" className="w-64">
+          <HelpChannels />
+        </PopoverContent>
+      </Popover>
+    </SidebarMenuItem>
+  );
+}

--- a/src/auth/sidebar-support.test.tsx
+++ b/src/auth/sidebar-support.test.tsx
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, it } from "vitest";
+import { SidebarMenu, SidebarProvider } from "../components/ui/sidebar.js";
+import { HelpChannels, SidebarHelp } from "./sidebar-help.js";
+import { trialNoticeLabel } from "./trial-notice.js";
+
+function footerMarkup(): string {
+  return renderToStaticMarkup(
+    <SidebarProvider>
+      <SidebarMenu>
+        <SidebarHelp />
+      </SidebarMenu>
+    </SidebarProvider>,
+  );
+}
+
+describe("the sidebar help item", () => {
+  it("names itself and stays shut until it is asked", () => {
+    const markup = footerMarkup();
+
+    assert.match(markup, /Help/u);
+    assert.match(markup, /aria-expanded="false"/u);
+    // Nothing about support is on screen before the popover opens.
+    assert.doesNotMatch(markup, /discord/iu);
+    assert.doesNotMatch(markup, /paseo\.sh/u);
+  });
+});
+
+describe("the help popover's copy", () => {
+  it("offers the Discord channel and the mailbox, each as a working link", () => {
+    const markup = renderToStaticMarkup(<HelpChannels />);
+
+    assert.match(markup, /href="https:\/\/discord\.gg\/[A-Za-z0-9]+"/u);
+    assert.match(markup, /#paseo-hub/u);
+    assert.match(markup, /href="mailto:hello@paseo\.sh"/u);
+    assert.match(markup, />hello@paseo\.sh</u);
+  });
+
+  it("opens Discord in a new tab without handing it this session", () => {
+    const markup = renderToStaticMarkup(<HelpChannels />);
+
+    assert.match(markup, /target="_blank"[^>]*rel="noreferrer"/u);
+  });
+});
+
+describe("the trial reminder's copy", () => {
+  it("counts days, and one day as a day", () => {
+    assert.equal(trialNoticeLabel(12), "12 days left in trial");
+    assert.equal(trialNoticeLabel(1), "1 day left in trial");
+    assert.equal(trialNoticeLabel(0), "0 days left in trial");
+  });
+});

--- a/src/auth/trial-notice.tsx
+++ b/src/auth/trial-notice.tsx
@@ -1,0 +1,48 @@
+/* oxlint-disable typescript-eslint/no-unsafe-type-assertion -- the billing route is addressed by a server-resolved organization slug */
+import { useCallback } from "react";
+import { Link } from "@tanstack/react-router";
+import { useQuery } from "@tanstack/react-query";
+import { useServerFn } from "@tanstack/react-start";
+import { Clock } from "lucide-react";
+import { SidebarMenuButton, SidebarMenuItem, useSidebar } from "../components/ui/sidebar.js";
+import { organizationTrial } from "../server/capabilities.js";
+
+/** "12 days left in trial" — the entire reminder, and the reason a count of 1 is not "1 days". */
+export function trialNoticeLabel(daysLeft: number): string {
+  return `${daysLeft} ${daysLeft === 1 ? "day" : "days"} left in trial`;
+}
+
+/**
+ * The sidebar's trial countdown. It renders only while a trial is actually running: the probe
+ * answers null for a paid, free, cancelled, or self-hosted organization, so there is no billing
+ * state for this to read and no way for it to invent a trial that does not exist. The reminder
+ * leads to Billing, the only place the trial can be acted on.
+ */
+export function TrialNotice({ organizationSlug }: { organizationSlug: string }) {
+  const load = useServerFn(organizationTrial);
+  const trial = useQuery({
+    queryKey: ["organization-trial", organizationSlug],
+    queryFn: () => load({ data: { organizationSlug } }),
+    staleTime: 5 * 60 * 1000,
+  });
+  const { isMobile, setOpenMobile } = useSidebar();
+  // On compact the sidebar is an overlay covering the destination; client-side navigation has to
+  // dismiss it the way the destinations above do.
+  const navigate = useCallback(() => {
+    if (isMobile) setOpenMobile(false);
+  }, [isMobile, setOpenMobile]);
+  const daysLeft = trial.data?.daysLeft ?? null;
+
+  if (daysLeft === null) return null;
+  const label = trialNoticeLabel(daysLeft);
+  return (
+    <SidebarMenuItem>
+      <SidebarMenuButton asChild size="sm" tooltip={label} className="text-muted-foreground">
+        <Link to={`/o/${organizationSlug}/settings/billing` as never} onClick={navigate}>
+          <Clock aria-hidden="true" />
+          <span>{label}</span>
+        </Link>
+      </SidebarMenuButton>
+    </SidebarMenuItem>
+  );
+}

--- a/src/billing/index.ts
+++ b/src/billing/index.ts
@@ -22,6 +22,7 @@ import type { StripeBillingClient, StripeSubscriptionState } from "./stripe-bill
 import { selectActivePlanPrice } from "./plan-prices.js";
 import { publicBillingPlans, type PublicBillingPlan } from "./public-catalog.js";
 import { HUB_PLAN_PRESENTATIONS, type BillingPlanPresentations } from "./plan-presentation.js";
+import { trialDaysRemaining } from "./trial-policy.js";
 
 /** The organization's live seat count (members + pending invitations). Injected by the
  * composition root — the count reads Better Auth tables the `Database` interface does not model,
@@ -423,6 +424,15 @@ export class BillingRuntime {
   /** An organization may use the cardless trial only if it has never had a Stripe subscription. */
   private trialEligible(subscriptions: readonly StripeSubscriptionState[]): boolean {
     return subscriptions.length === 0;
+  }
+
+  /**
+   * Days left in this organization's trial, or null when it is not on one. The whole answer for
+   * an ambient countdown: a caller receives a number and never learns that a subscription, a
+   * status vocabulary, or Stripe are involved.
+   */
+  async trialRemaining(organizationId: string): Promise<number | null> {
+    return trialDaysRemaining(await this.subscriptionSnapshot(organizationId));
   }
 
   async handleWebhook(request: Request): Promise<Response> {

--- a/src/billing/trial-policy.test.ts
+++ b/src/billing/trial-policy.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { describe, it } from "vitest";
+import { trialDaysRemaining } from "./trial-policy.js";
+
+const NOW = new Date("2026-09-03T12:00:00.000Z");
+
+function subscription(
+  status: string | null,
+  trialEnd: string | null,
+): { status: string | null; trialEnd: string | null } {
+  return { status, trialEnd };
+}
+
+describe("days left in a trial", () => {
+  it("counts the days a trialing organization has left", () => {
+    assert.equal(trialDaysRemaining(subscription("trialing", "2026-09-15T12:00:00.000Z"), NOW), 12);
+  });
+
+  it("counts a part-finished day as a whole one, so a trial never reads as already over", () => {
+    assert.equal(trialDaysRemaining(subscription("trialing", "2026-09-04T03:00:00.000Z"), NOW), 1);
+    assert.equal(trialDaysRemaining(subscription("trialing", "2026-09-03T12:00:01.000Z"), NOW), 1);
+  });
+
+  it("floors at zero rather than counting backwards past a lapsed trial", () => {
+    assert.equal(trialDaysRemaining(subscription("trialing", "2026-08-20T12:00:00.000Z"), NOW), 0);
+  });
+
+  it("reports no trial for every state that is not one", () => {
+    // Paid, lapsed, and never-subscribed all have to answer the same way: the sidebar decides
+    // visibility on this one value, so anything but null here is a misleading countdown.
+    for (const status of ["active", "past_due", "canceled", "unpaid", "incomplete_expired", null]) {
+      assert.equal(
+        trialDaysRemaining(subscription(status, "2026-09-15T12:00:00.000Z"), NOW),
+        null,
+        `${status ?? "no subscription"} reported a trial`,
+      );
+    }
+  });
+
+  it("reports no trial when the status says trialing but no end date came back", () => {
+    assert.equal(trialDaysRemaining(subscription("trialing", null), NOW), null);
+    assert.equal(trialDaysRemaining(subscription("trialing", "not a date"), NOW), null);
+  });
+});

--- a/src/billing/trial-policy.ts
+++ b/src/billing/trial-policy.ts
@@ -1,2 +1,20 @@
 /** The single cardless-trial duration used by Stripe policy and billing copy. */
 export const TRIAL_DAYS = 14;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Days left before a trial ends, or null when the organization is not on one — paid, free,
+ * cancelled, and never-subscribed all answer null here so no surface has to re-derive "is this a
+ * trial" from a status string. A partial day counts as a whole one: the final hours of a trial
+ * read "1 day left", never "0 days left".
+ */
+export function trialDaysRemaining(
+  subscription: { status: string | null; trialEnd: string | null },
+  now: Date = new Date(),
+): number | null {
+  if (subscription.status !== "trialing" || subscription.trialEnd === null) return null;
+  const endsAt = Date.parse(subscription.trialEnd);
+  if (Number.isNaN(endsAt)) return null;
+  return Math.max(0, Math.ceil((endsAt - now.getTime()) / DAY_MS));
+}

--- a/src/daemons/test-utils/hub-harness.ts
+++ b/src/daemons/test-utils/hub-harness.ts
@@ -1692,6 +1692,7 @@ export class HubHarness {
       billingOverview: () => Promise.reject(new Error("billing is not configured")),
       billingCheckout: () => Promise.reject(new Error("billing is not configured")),
       billingPortal: () => Promise.reject(new Error("billing is not configured")),
+      organizationTrial: () => Promise.resolve({ daysLeft: null }),
       providerRequest: () => Promise.resolve(new Response("Not Found", { status: 404 })),
       stop: () => hub.stop(),
     }));

--- a/src/e2e/harness/hub-child.ts
+++ b/src/e2e/harness/hub-child.ts
@@ -229,6 +229,7 @@ async function main(): Promise<void> {
     billingOverview: () => Promise.reject(new Error("billing is not configured")),
     billingCheckout: () => Promise.reject(new Error("billing is not configured")),
     billingPortal: () => Promise.reject(new Error("billing is not configured")),
+    organizationTrial: () => Promise.resolve({ daysLeft: null }),
     providerRequest: () => Promise.resolve(new Response("Not Found", { status: 404 })),
     async stop() {
       await hub?.stop();

--- a/src/server/capabilities.ts
+++ b/src/server/capabilities.ts
@@ -1,5 +1,21 @@
 import { createServerFn } from "@tanstack/react-start";
-import { isBillingConfigured } from "./runtime.js";
+import { getRequest } from "@tanstack/react-start/server";
+import { z } from "zod";
+import {
+  handleOrganizationTrial,
+  isBillingConfigured,
+  type OrganizationTrialView,
+} from "./runtime.js";
+
+/**
+ * Narrow reads the dashboard needs about a hosted feature it must not import. Each resolves
+ * through the composition root, so `src/billing/` stays behind its boundary and a caller here
+ * learns a boolean or a number — never a plan, a status, or that Stripe exists.
+ */
+
+const organizationScopeSchema = z
+  .object({ organizationSlug: z.string().trim().min(1).max(100) })
+  .strict();
 
 /**
  * Whether the hosted billing feature is mounted on this instance. A capability probe, not billing
@@ -10,3 +26,12 @@ import { isBillingConfigured } from "./runtime.js";
 export const billingConfigured = createServerFn({ method: "GET" }).handler(
   async (): Promise<{ configured: boolean }> => ({ configured: await isBillingConfigured() }),
 );
+
+/** Days left in the organization's trial, for the sidebar's reminder. Null on every state that
+ * is not a running trial, self-hosted included, so the reminder needs no second probe. */
+export const organizationTrial = createServerFn({ method: "GET" })
+  .validator(organizationScopeSchema)
+  .handler(
+    async ({ data }): Promise<OrganizationTrialView> =>
+      handleOrganizationTrial(getRequest(), data.organizationSlug),
+  );

--- a/src/server/runtime.ts
+++ b/src/server/runtime.ts
@@ -46,6 +46,15 @@ export interface BillingCheckoutInput {
 }
 
 /**
+ * A countdown, and nothing more. `null` is every state that is not a running trial — paid, free,
+ * cancelled, and every self-hosted instance alike — so a consumer decides visibility on the one
+ * field and can never render a trial the organization is not on.
+ */
+export interface OrganizationTrialView {
+  daysLeft: number | null;
+}
+
+/**
  * Thrown when a member without the manage-resources capability tries to open checkout or the
  * billing portal — the `authorizeReference` intent, wired to `OrganizationAccess`. Lives here
  * (a composition root) so both `application-runtime.ts` (the thrower) and the billing UI server
@@ -109,6 +118,9 @@ export interface ApplicationRuntime {
   billingCheckout(request: Request, input: BillingCheckoutInput): Promise<{ url: string }>;
   /** A Stripe billing-portal URL, or null when the organization has no subscription to manage. */
   billingPortal(request: Request, organizationSlug: string): Promise<{ url: string | null }>;
+  /** Days left in the organization's trial, or null when it is not on one. Self-hosted always
+   * answers null, so the dashboard shell can render a countdown without knowing billing exists. */
+  organizationTrial(request: Request, organizationSlug: string): Promise<OrganizationTrialView>;
   providerRequest(name: string, request: Request): Promise<Response>;
   connectionStatus(request: Request): Promise<Response>;
   connectionAction(request: Request, provider: string, action: string): Promise<Response>;
@@ -183,6 +195,13 @@ export async function handleBillingPortal(
   organizationSlug: string,
 ): Promise<{ url: string | null }> {
   return (await getApplication()).billingPortal(request, organizationSlug);
+}
+
+export async function handleOrganizationTrial(
+  request: Request,
+  organizationSlug: string,
+): Promise<OrganizationTrialView> {
+  return (await getApplication()).organizationTrial(request, organizationSlug);
 }
 
 export async function handleProviderRequest(name: string, request: Request): Promise<Response> {


### PR DESCRIPTION
Every authenticated dashboard now has a **Help** item at the bottom of the sidebar, just above the account menu. It opens a small popover with the two ways to reach a human: the Paseo Discord (`#paseo-hub`) and `hello@paseo.sh`. When the organization is trialing, a **"N days left in trial"** row sits above Help and leads to Billing.

## Goals

- Help in the sidebar footer, immediately above the account item, opening an accessible popover.
- Popover copy names the Discord channel and the mailbox, both as working links, and nothing else.
- A trial countdown immediately above Help while — and only while — the organization is trialing.
- Compact, consistent with the existing sidebar: collapsed icon rail, tooltips, and the mobile drawer.
- The sidebar does not reach into Stripe and does not learn billing's shapes.

## Non-goals

- No help centre, docs search, ticketing, or in-app chat. Two links.
- No trial banner, modal, or nag on any page. The countdown is ambient and stays in the sidebar.
- No copy for trial *expiry* — a lapsed trial is a Billing-page concern, and cancellation already has a surface.
- No change to how trials start, reconcile, or stamp entitlements.

## The why

The interesting decision is how the sidebar learns it is on a trial. `src/billing/` is behind an oxlint import boundary that only the composition roots and the billing dashboard route may cross, and "delete `src/billing/`, the app still runs" is a real test — so the shell cannot import `billingOverview`, and putting the countdown in `src/billing/ui/` would not help because the shell still could not mount it.

The existing `billingConfigured` probe in `src/server/capabilities.ts` already solved this shape once: a narrow core-side question, resolved through the composition root, answering a boolean the shell can act on. `organizationTrial` is the second one, and returns days or `null`.

`null` covers paid, free, cancelled, unpaid, never-subscribed, *and* every self-hosted instance — where billing is absent, the probe answers "no trial" rather than throwing. That collapses the whole "don't show misleading trial UI" requirement into one field the consumer cannot misread. Threading `status` and `trialEnd` up to the sidebar would have meant re-deriving "is this a trial" in a view, which is exactly how a free-tier org ends up counting down.

The alternative — putting the trial on the tenant context the sidebar already reads — was rejected: it would make every route change wait on a billing read and couple `src/projects/` to Stripe.

## Risk surface

- **`Application` gained a method.** Two harness stubs updated (`src/daemons/test-utils/hub-harness.ts`, `src/e2e/harness/hub-child.ts`). Anything else implementing `ApplicationRuntime` would fail typecheck; typecheck is clean.
- **Sidebar tab order changed.** Help sits between Settings and the account menu. Two desktop keyboard-order helpers in `e2e/helpers/hub.ts` asserted a single Tab from Settings to the account; they now tab the footer explicitly. This is the most likely place for a CI surprise.
- **One extra request per organization.** `organizationTrial` runs `resolveRouteTenant` and, when billing is configured, `subscriptionSnapshot` — which is behind billing's existing single-flight Stripe cache. Cached client-side for 5 minutes. Self-hosted returns before any of it.
- **Billing E2E now renders a sidebar row** on trialing organizations. Existing billing assertions are scoped to the plan section, so no collisions expected, but the billing screenshots will show the new row.
- **`src/billing/` still deletes cleanly** — the coupling is one method on `BillingRuntime`, reached only from the composition root.

## Verification

- `npx vitest run src/billing/trial-policy.test.ts src/auth/sidebar-support.test.tsx src/typography-policy.test.ts src/billing/ui/presentation.test.tsx --bail=1` → 24 passed.
  - `trialDaysRemaining`: day counting, partial day rounds up, floor at zero, `null` for `active`/`past_due`/`canceled`/`unpaid`/`incomplete_expired`/no-subscription, `null` for trialing-without-an-end-date.
  - Help: trigger is named and closed on first paint, popover copy carries the Discord link with `rel="noreferrer"`, `#paseo-hub`, and the `mailto:`.
  - Trial copy: `1 day` vs `N days`.
- `npm run typecheck` (node + start + e2e), `npm run lint`, `npm run format:check` → clean.
- **E2E added, not run locally.** `e2e/billing-subscription.spec.ts` (the money test) now asserts the reminder appears on the freshly trialing organization and is gone after cancellation. That suite needs `PASEO_E2E_WORKTREE` pointed at a `getpaseo/paseo` checkout, so CI is its first real run.
- **Manual, against a local embedded-DB instance:** desktop 1440×900, mobile 390×844, and the collapsed icon rail. Popover opens and closes in the mobile drawer, Escape closes the popover before the sheet. The trial row was exercised behind a temporary local stub returning a fixed day count, since no Stripe key is configured locally; the stub is not in this branch.

## Follow-up

The public Hub docs live in the main Paseo repo under `public-docs/hub/` and do not yet mention either surface. Worth a separate PR there once this lands.
