### PR TITLE
Draw loading states as the page you are waiting for

### DIFF
--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,0 +1,17 @@
+import { prebuildPaseoArtifacts, resolvePaseoWorktree } from "../src/e2e/harness/source-paseo.js";
+
+/**
+ * Packs and installs the Paseo source once, before any worker starts.
+ *
+ * Tests that enroll a daemon call `SourcePaseo.start()`, which packs six workspaces and installs
+ * the tarballs. Done from inside a test, that work spends the test's own 120s budget, and on a
+ * loaded runner it was enough to exhaust it — one arbitrary daemon test timing out per run. Built
+ * here it costs nothing that a test is timed against, and every worker inherits the result.
+ *
+ * Suites that never reach for the source checkout leave `PASEO_E2E_WORKTREE` unset; there is
+ * nothing to build for them and nothing to fail.
+ */
+export default async function globalSetup(): Promise<void> {
+  if (!process.env["PASEO_E2E_WORKTREE"]) return;
+  await prebuildPaseoArtifacts(resolvePaseoWorktree());
+}

--- a/e2e/prebuilt-source.spec.ts
+++ b/e2e/prebuilt-source.spec.ts
@@ -1,0 +1,16 @@
+import { existsSync } from "node:fs";
+import { expect, test } from "@playwright/test";
+
+/**
+ * The daemon suites depend on the source being packed before any worker starts. Without this,
+ * the first daemon test in each worker pays for the build inside its own timeout, which is how
+ * an arbitrary daemon test ends up timing out on a loaded runner.
+ */
+test("hands every worker a source tree that was packed before the run", () => {
+  test.skip(!process.env["PASEO_E2E_WORKTREE"], "no source checkout under test");
+
+  const packages = process.env["PASEO_E2E_PACKAGES"];
+
+  expect(packages, "global setup must publish the packed source to its workers").toBeTruthy();
+  expect(existsSync(`${packages!}/node_modules/.bin/paseo`)).toBe(true);
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,6 +2,7 @@ import { defineConfig, devices } from "@playwright/test";
 
 export default defineConfig({
   testDir: "./e2e",
+  globalSetup: "./e2e/global-setup.ts",
   fullyParallel: true,
   // Each test owns a PostgreSQL container and a Hub process. Half of the CI runner's
   // available CPUs leaves headroom for those services; two workers was the highest

--- a/src/auth/account-states.tsx
+++ b/src/auth/account-states.tsx
@@ -32,7 +32,16 @@ export function LoadingEntry() {
       className="flex min-h-svh flex-col items-center justify-center gap-6 bg-background p-6"
     >
       <ProductMark />
-      <Skeleton className="h-1 w-40" />
+      {/* The card whichever screen wins will be, held open at its own size so the mark
+          does not jump up the page when the account resolves. */}
+      <div className="grid w-full max-w-sm gap-6 rounded-lg border bg-card p-6 shadow-sm">
+        <div className="grid gap-2">
+          <Skeleton className="h-5 w-44" />
+          <Skeleton className="h-4 w-60 max-w-full" />
+        </div>
+        <Skeleton className="h-9 w-full" />
+        <Skeleton className="h-9 w-full" />
+      </div>
     </main>
   );
 }

--- a/src/auth/api-key-panel.tsx
+++ b/src/auth/api-key-panel.tsx
@@ -9,9 +9,10 @@ import {
   type ChangeEvent,
   type FormEvent,
   type FocusEvent,
+  type ReactNode,
 } from "react";
 import { ConfirmMenuItem } from "../components/app/confirm-action.js";
-import { DataCell, DataRow, DataTable } from "../components/app/data-table.js";
+import { DataCell, DataRow, DataTable, DataTableSkeleton } from "../components/app/data-table.js";
 import { PageHeader } from "../components/app/page.js";
 import { RowActions } from "../components/app/row-actions.js";
 import { StatusPill } from "../components/app/status-pill.js";
@@ -110,6 +111,23 @@ const CLI_COLUMNS = [
   { header: "", align: "end" as const },
 ];
 
+/** The second table on the page, under its own heading, in both its loaded and pending states. */
+function CliLoginsSection({ children }: { children: ReactNode }) {
+  return (
+    <section className="mt-10 grid gap-4" aria-labelledby="cli-logins-heading">
+      <div>
+        <h2 id="cli-logins-heading" className="text-lg">
+          CLI logins
+        </h2>
+        <p className="text-muted-foreground text-sm">
+          Durable terminal credentials created through browser approval.
+        </p>
+      </div>
+      {children}
+    </section>
+  );
+}
+
 export function ApiKeys() {
   const account = useActiveAccount();
   const queryClient = useQueryClient();
@@ -194,7 +212,20 @@ export function ApiKeys() {
       </>
     );
   }
-  if (snapshot.isPending) return <p aria-busy="true">Loading API keys…</p>;
+  if (snapshot.isPending) {
+    return (
+      <>
+        <PageHeader
+          title="API keys"
+          description={`Machine access for ${account.organization.name}.`}
+        />
+        <DataTableSkeleton label="API keys" columns={TABLE_COLUMNS} />
+        <CliLoginsSection>
+          <DataTableSkeleton label="CLI logins" columns={CLI_COLUMNS} rows={1} />
+        </CliLoginsSection>
+      </>
+    );
+  }
   if (snapshot.isError || snapshot.data.status === "error") {
     return (
       <Alert variant="destructive">
@@ -257,15 +288,7 @@ export function ApiKeys() {
           />
         ))}
       </DataTable>
-      <section className="mt-10 grid gap-4" aria-labelledby="cli-logins-heading">
-        <div>
-          <h2 id="cli-logins-heading" className="text-lg">
-            CLI logins
-          </h2>
-          <p className="text-muted-foreground text-sm">
-            Durable terminal credentials created through browser approval.
-          </p>
-        </div>
+      <CliLoginsSection>
         <DataTable
           label="CLI logins"
           columns={CLI_COLUMNS}
@@ -281,7 +304,7 @@ export function ApiKeys() {
             />
           ))}
         </DataTable>
-      </section>
+      </CliLoginsSection>
       <ApiKeyDialog
         open={creating}
         onOpenChange={close}

--- a/src/auth/dashboard-shell.tsx
+++ b/src/auth/dashboard-shell.tsx
@@ -52,7 +52,7 @@ import {
   DropdownMenuTrigger,
 } from "../components/ui/dropdown-menu.js";
 import { Separator } from "../components/ui/separator.js";
-import { Skeleton } from "../components/ui/skeleton.js";
+import { PanelSkeleton } from "../components/app/loading.js";
 import {
   Sidebar,
   SidebarContent,
@@ -79,7 +79,12 @@ import { FormField } from "./form-field.js";
 import type { Result } from "../contract/respond.js";
 import { ACCOUNT_MUTATION_KEY, useAccountMutationError } from "./account-mutation.js";
 import { useTenantContextMutationPending } from "./tenant-mutation.js";
-import { RouteTenantProvider, useOptionalRouteTenant } from "../projects/context.js";
+import { Alert, AlertDescription, AlertTitle } from "../components/ui/alert.js";
+import {
+  RouteTenantProvider,
+  useOptionalRouteTenant,
+  useRouteTenantStatus,
+} from "../projects/context.js";
 import { SidebarHelp } from "./sidebar-help.js";
 import { TrialNotice } from "./trial-notice.js";
 
@@ -208,15 +213,7 @@ function DashboardContent({
           <div className="flex flex-1 flex-col p-4 md:p-8">
             <Page>
               <ErrorSummary message={error} />
-              {transitioning ? (
-                <AccountTransition />
-              ) : (
-                <ActiveAccountProvider account={account}>
-                  <div key={tenant?.project?.id ?? "organization"}>
-                    <Outlet />
-                  </div>
-                </ActiveAccountProvider>
-              )}
+              <PageContent account={account} tenant={tenant} transitioning={transitioning} />
             </Page>
           </div>
         </SidebarInset>
@@ -241,12 +238,40 @@ function useAccountCommand<TInput, TResult extends Result<unknown>>(
   );
 }
 
-function AccountTransition() {
+/**
+ * The page slot. Switching organization and resolving the tenant behind a URL both replace what
+ * is inside it and nothing else — the sidebar and site header stay put, because the app is not
+ * going anywhere while a read is in flight.
+ */
+function PageContent({
+  account,
+  tenant,
+  transitioning,
+}: {
+  account: ActiveAccount;
+  tenant: RouteTenant | undefined;
+  transitioning: boolean;
+}) {
+  const status = useRouteTenantStatus();
+  // One name for the slot, whichever read is in flight: switching organization and resolving the
+  // tenant behind a URL are the same wait to someone listening to the page.
+  if (transitioning || status.state === "pending") {
+    return <PanelSkeleton label="Loading account context" />;
+  }
+  if (status.state === "failed") {
+    return (
+      <Alert variant="destructive">
+        <AlertTitle>{status.title}</AlertTitle>
+        <AlertDescription>{status.message}</AlertDescription>
+      </Alert>
+    );
+  }
   return (
-    <section aria-label="Loading account context" aria-busy="true" className="grid gap-6">
-      <Skeleton className="h-12 w-64" />
-      <Skeleton className="h-64 w-full" />
-    </section>
+    <ActiveAccountProvider account={account}>
+      <div key={tenant?.project?.id ?? "organization"}>
+        <Outlet />
+      </div>
+    </ActiveAccountProvider>
   );
 }
 

--- a/src/billing/ui/panel.tsx
+++ b/src/billing/ui/panel.tsx
@@ -4,12 +4,12 @@ import { Link } from "@tanstack/react-router";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useServerFn } from "@tanstack/react-start";
 import { Check } from "lucide-react";
+import { CardSkeleton } from "../../components/app/loading.js";
 import { PageHeader } from "../../components/app/page.js";
 import { Section } from "../../components/app/section.js";
 import { StatusPill } from "../../components/app/status-pill.js";
 import { Alert, AlertDescription, AlertTitle } from "../../components/ui/alert.js";
 import { Button } from "../../components/ui/button.js";
-import { Skeleton } from "../../components/ui/skeleton.js";
 import { useRouteTenant } from "../../projects/context.js";
 import type { BillingOverviewView, PublicBillingPlan } from "../../server/runtime.js";
 import { billingOverview, billingPortal } from "./functions.js";
@@ -26,7 +26,7 @@ export function BillingPanel({ openPlans }: { openPlans: boolean }) {
     queryFn: () => load({ data: { organizationSlug: tenant.organization.slug } }),
   });
 
-  if (query.isPending) return <BillingLoading />;
+  if (query.isPending) return <BillingLoading name={tenant.organization.name} />;
   if (query.isError || query.data.status === "error") {
     return (
       <Alert variant="destructive">
@@ -205,11 +205,13 @@ function redirectTo(url: string): void {
   window.location.assign(url);
 }
 
-function BillingLoading() {
+function BillingLoading({ name }: { name: string }) {
   return (
-    <section aria-label="Loading billing" aria-busy="true" className="grid gap-6">
-      <Skeleton className="h-12 w-64" />
-      <Skeleton className="h-48 w-full" />
-    </section>
+    <>
+      <PageHeader title="Billing" description={`Plan and billing for ${name}.`} />
+      <Section title="Plan">
+        <CardSkeleton lines={4} />
+      </Section>
+    </>
   );
 }

--- a/src/cli-authorizations/approval.tsx
+++ b/src/cli-authorizations/approval.tsx
@@ -162,12 +162,31 @@ function CodeEntry({ onCode }: { onCode: (code: string) => void }) {
   );
 }
 
+/**
+ * The approval card before the request is known. The card and its heading are the same for every
+ * code, so only the organization being granted access and the decision buttons are placeholders.
+ */
 function Loading() {
   return (
-    <section aria-label="Loading CLI login" className="grid gap-6">
-      <Skeleton className="h-12 w-64" />
-      <Skeleton className="h-64 w-full" />
-    </section>
+    <Centered>
+      <div aria-busy="true">
+        <AuthCard
+          title="Approve CLI login"
+          description="Grant this terminal durable access to one organization."
+        >
+          <div className="grid gap-1 rounded-md border px-3 py-2.5">
+            <span className="text-muted-foreground text-sm">Organization receiving access</span>
+            <Skeleton className="h-5 w-40" />
+          </div>
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-3/4" />
+          <div className="flex justify-end gap-2">
+            <Skeleton className="h-9 w-20" />
+            <Skeleton className="h-9 w-40" />
+          </div>
+        </AuthCard>
+      </div>
+    </Centered>
   );
 }
 

--- a/src/components/app/data-table-skeleton.test.tsx
+++ b/src/components/app/data-table-skeleton.test.tsx
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, it } from "vitest";
+import { DataTable, DataTableSkeleton, type DataColumn } from "./data-table.js";
+
+const COLUMNS: readonly DataColumn[] = [
+  { header: "Trigger" },
+  { header: "Event" },
+  { header: "Status" },
+  { header: "", align: "end" },
+];
+
+const EMPTY = { title: "No triggers" };
+
+function shell(markup: string): string {
+  // Everything up to the first body row: the card, the column headers, the rails.
+  return markup.slice(0, markup.indexOf("<tbody"));
+}
+
+describe("data table skeleton", () => {
+  it("draws the same shell and columns as the table it stands in for", () => {
+    const skeleton = renderToStaticMarkup(<DataTableSkeleton label="Triggers" columns={COLUMNS} />);
+    const loaded = renderToStaticMarkup(
+      <DataTable label="Triggers" columns={COLUMNS} isEmpty empty={EMPTY}>
+        {null}
+      </DataTable>,
+    );
+
+    assert.equal(
+      shell(skeleton).slice(shell(skeleton).indexOf("<table")),
+      shell(loaded).slice(shell(loaded).indexOf("<table")),
+    );
+  });
+
+  it("announces itself busy and holds rows open at the loaded row height", () => {
+    const markup = renderToStaticMarkup(
+      <DataTableSkeleton label="Triggers" columns={COLUMNS} rows={2} />,
+    );
+
+    assert.match(markup, /aria-busy="true"/u);
+    assert.equal(markup.match(/data-slot="skeleton"/gu)?.length, 2 * COLUMNS.length);
+    assert.equal(markup.match(/h-14/gu)?.length, 2 * COLUMNS.length);
+  });
+
+  it("says nothing about having no records, which it does not yet know", () => {
+    const markup = renderToStaticMarkup(<DataTableSkeleton label="Triggers" columns={COLUMNS} />);
+
+    assert.doesNotMatch(markup, /No triggers/u);
+  });
+});

--- a/src/components/app/data-table.tsx
+++ b/src/components/app/data-table.tsx
@@ -2,6 +2,7 @@
 import type { ReactNode } from "react";
 
 import { cn } from "../../lib/utils.js";
+import { Skeleton } from "../ui/skeleton.js";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../ui/table.js";
 import { EmptyState } from "./empty-state.js";
 
@@ -32,6 +33,79 @@ export function DataTable({
   children: ReactNode;
 }) {
   return (
+    <TableShell label={label} columns={columns}>
+      {isEmpty ? (
+        <TableRow className="hover:bg-transparent">
+          <TableCell colSpan={columns.length} className="p-0">
+            <EmptyState
+              title={empty.title}
+              {...(empty.description === undefined ? {} : { description: empty.description })}
+            >
+              {empty.action}
+            </EmptyState>
+          </TableCell>
+        </TableRow>
+      ) : (
+        children
+      )}
+    </TableShell>
+  );
+}
+
+/**
+ * The same table before its rows are known: real columns, placeholder cells. The page the
+ * reader is waiting for is already the page on screen, so nothing moves when the data lands.
+ */
+export function DataTableSkeleton({
+  label,
+  columns,
+  rows = 3,
+}: {
+  label: string;
+  columns: readonly DataColumn[];
+  rows?: number;
+}) {
+  return (
+    <div aria-busy="true">
+      <TableShell label={label} columns={columns}>
+        {Array.from({ length: rows }, (_, row) => (
+          <TableRow key={row} className="border-border/60 hover:bg-transparent">
+            {columns.map((column, index) => (
+              <DataCell
+                key={column.header === "" ? `actions-${String(index)}` : column.header}
+                {...(column.align === undefined ? {} : { align: column.align })}
+              >
+                <Skeleton className={cn("h-4", placeholderWidth(columns, index))} />
+              </DataCell>
+            ))}
+          </TableRow>
+        ))}
+      </TableShell>
+    </div>
+  );
+}
+
+/**
+ * The identifying column carries the long value, the rest are short facts, and a trailing
+ * action column is a button-sized square.
+ */
+function placeholderWidth(columns: readonly DataColumn[], index: number): string {
+  const column = columns[index];
+  if (column?.header === "" && index === columns.length - 1) return "ml-auto size-8";
+  return index === 0 ? "w-48" : "w-16";
+}
+
+/** The bordered card and quiet header row both the table and its skeleton are drawn in. */
+function TableShell({
+  label,
+  columns,
+  children,
+}: {
+  label: string;
+  columns: readonly DataColumn[];
+  children: ReactNode;
+}) {
+  return (
     <div className="min-w-0 overflow-hidden rounded-lg border bg-card">
       <Table aria-label={label}>
         <TableHeader>
@@ -54,22 +128,7 @@ export function DataTable({
             ))}
           </TableRow>
         </TableHeader>
-        <TableBody>
-          {isEmpty ? (
-            <TableRow className="hover:bg-transparent">
-              <TableCell colSpan={columns.length} className="p-0">
-                <EmptyState
-                  title={empty.title}
-                  {...(empty.description === undefined ? {} : { description: empty.description })}
-                >
-                  {empty.action}
-                </EmptyState>
-              </TableCell>
-            </TableRow>
-          ) : (
-            children
-          )}
-        </TableBody>
+        <TableBody>{children}</TableBody>
       </Table>
     </div>
   );

--- a/src/components/app/loading.tsx
+++ b/src/components/app/loading.tsx
@@ -1,0 +1,81 @@
+import { Loader2Icon } from "lucide-react";
+
+import { cn } from "../../lib/utils.js";
+import { Skeleton } from "../ui/skeleton.js";
+import { DataTableSkeleton, type DataColumn } from "./data-table.js";
+
+/**
+ * Pending states.
+ *
+ * A surface waiting on the data it exists to show draws itself as a skeleton: the parts that are
+ * already known — titles, section labels, table columns — are rendered for real, and only what
+ * the request decides is a placeholder. The reader is looking at the page they asked for from the
+ * first frame, and nothing moves when the data lands.
+ *
+ * A surface waiting on one small fact inside an otherwise finished page shows a spinner instead.
+ * Never a bare line of text: "Loading…" reserves no space, so the page jumps when it resolves.
+ */
+
+/** The one spinner. Everything that spins uses this, at the size of the text beside it. */
+export function Spinner({ className }: { className?: string }) {
+  return (
+    <Loader2Icon aria-hidden="true" className={cn("size-4 shrink-0 animate-spin", className)} />
+  );
+}
+
+/** A spinner and what it is waiting for, on one line, inside an already-drawn page. */
+export function LoadingLine({ children }: { children: string }) {
+  return (
+    <p aria-busy="true" className="flex items-center gap-2 text-sm text-muted-foreground">
+      <Spinner />
+      {children}
+    </p>
+  );
+}
+
+/**
+ * A page title and its description before either is known. Matches `PageHeader`'s block, so a
+ * surface that cannot name itself until its data arrives still reserves the right space.
+ */
+export function PageHeaderSkeleton() {
+  return (
+    <header className="mb-6 grid gap-2">
+      <Skeleton className="h-7 w-48" />
+      <Skeleton className="h-4 w-80 max-w-full" />
+    </header>
+  );
+}
+
+/** A bordered card that is about to hold prose, fields, or a summary. */
+export function CardSkeleton({ lines = 3 }: { lines?: number }) {
+  return (
+    <div aria-busy="true" className="grid gap-3 rounded-lg border bg-card p-5">
+      {Array.from({ length: lines }, (_, line) => (
+        <Skeleton key={line} className={cn("h-4", line === 0 ? "w-40" : "w-full")} />
+      ))}
+    </div>
+  );
+}
+
+const GENERIC_COLUMNS: readonly DataColumn[] = [
+  { header: "" },
+  { header: "" },
+  { header: "", align: "end" },
+];
+
+/**
+ * A whole dashboard panel before the route's own surface can say what it is — switching
+ * organization, or resolving the tenant behind a URL. Every panel below is a header over
+ * records, so that is the shape held open. The label names the slot that is waiting, not the
+ * page that will fill it, which is still unknown.
+ */
+export function PanelSkeleton({ label = "Loading" }: { label?: string }) {
+  return (
+    <section aria-label={label} aria-busy="true">
+      <PageHeaderSkeleton />
+      {/* Its own name, not the panel's. `Table` derives a landmark called "<label> table", so
+          reusing the panel's label here would put two regions under one name. */}
+      <DataTableSkeleton label="Placeholder rows" columns={GENERIC_COLUMNS} />
+    </section>
+  );
+}

--- a/src/daemons/account-daemons.tsx
+++ b/src/daemons/account-daemons.tsx
@@ -4,7 +4,13 @@ import { BookOpen } from "lucide-react";
 import { useCallback, useState, type FormEvent } from "react";
 import { ConfirmMenuItem } from "../components/app/confirm-action.js";
 import { CopyField } from "../components/app/copy-field.js";
-import { DataCell, DataRow, DataTable, type DataColumn } from "../components/app/data-table.js";
+import {
+  DataCell,
+  DataRow,
+  DataTable,
+  DataTableSkeleton,
+  type DataColumn,
+} from "../components/app/data-table.js";
 import { PageHeader } from "../components/app/page.js";
 import { RowActions } from "../components/app/row-actions.js";
 import { StatusPill } from "../components/app/status-pill.js";
@@ -20,7 +26,6 @@ import {
 import { DropdownMenuItem } from "../components/ui/dropdown-menu.js";
 import { Field, FieldLabel } from "../components/ui/field.js";
 import { Input } from "../components/ui/input.js";
-import { Skeleton } from "../components/ui/skeleton.js";
 import {
   daemonList,
   renameDaemon,
@@ -42,6 +47,7 @@ const DAEMON_COLUMNS: readonly DataColumn[] = [
   { header: "Registered" },
   { header: "", align: "end" },
 ];
+const DAEMONS_DESCRIPTION = "Stable daemon identities registered to this organization.";
 const DAEMON_DOCS_URL = "https://paseo.sh/docs/hub/daemons";
 const DAEMONS_EMPTY = {
   title: "No daemons connected",
@@ -164,11 +170,7 @@ export function DaemonsPanel({
   const busy = rename.isPending || revoke.isPending;
   return (
     <>
-      <PageHeader
-        id="daemons-heading"
-        title="Daemons"
-        description="Stable daemon identities registered to this organization."
-      />
+      <PageHeader id="daemons-heading" title="Daemons" description={DAEMONS_DESCRIPTION} />
       {message === undefined ? null : (
         <Alert variant="destructive" className="mb-6">
           <AlertDescription>{message}</AlertDescription>
@@ -350,10 +352,10 @@ function DaemonStatus({ daemon }: { daemon: BrowserDaemon }) {
 
 function DaemonLoading() {
   return (
-    <section aria-label="Loading daemons" className="grid gap-6">
-      <Skeleton className="h-12 w-64" />
-      <Skeleton className="h-64 w-full" />
-    </section>
+    <>
+      <PageHeader id="daemons-heading" title="Daemons" description={DAEMONS_DESCRIPTION} />
+      <DataTableSkeleton label="Daemons" columns={DAEMON_COLUMNS} />
+    </>
   );
 }
 

--- a/src/daemons/daemons.test.ts
+++ b/src/daemons/daemons.test.ts
@@ -974,7 +974,7 @@ describe("daemon enrollment and execution", () => {
     await hub.restartApp();
     await dispatch;
 
-    const recovered = await hub.waitForRecoveredExecution(pending.id);
+    const recovered = await hub.waitForRecoveredExecution(pending.id, "running");
     assert.deepEqual(
       {
         status: recovered.status,

--- a/src/daemons/test-utils/hub-harness.ts
+++ b/src/daemons/test-utils/hub-harness.ts
@@ -714,9 +714,27 @@ export class HubHarness {
   async pendingExecutionCount(): Promise<number> {
     return (await this.requireDatabase().findPendingAgentExecutions()).length;
   }
-  async waitForRecoveredExecution(id: string): Promise<AgentExecutionRecord> {
-    await waitFor(async () => (await this.execution(id)).daemonAgentId !== null);
-    return this.execution(id);
+  /**
+   * Recovery lands in two writes: the daemon agent is attached, then the execution moves on from
+   * `spawning`. Waiting only for the agent, then reading the row again, returns whatever the
+   * second write happened to have done by then — so a caller asserting the settled status was
+   * racing it. Name the status you are waiting for, and the record you get is the one that
+   * satisfied the wait rather than a later re-read.
+   */
+  async waitForRecoveredExecution(
+    id: string,
+    status?: AgentExecutionRecord["status"],
+  ): Promise<AgentExecutionRecord> {
+    let recovered: AgentExecutionRecord | undefined;
+    await waitFor(async () => {
+      const execution = await this.execution(id);
+      if (execution.daemonAgentId === null) return false;
+      if (status !== undefined && execution.status !== status) return false;
+      recovered = execution;
+      return true;
+    });
+    if (recovered === undefined) throw new Error(`Execution ${id} did not recover`);
+    return recovered;
   }
   async waitForExecutionForTriggerRun(triggerRunId: string): Promise<AgentExecutionRecord> {
     let execution: AgentExecutionRecord | undefined;

--- a/src/e2e/harness/source-paseo.packaging.test.ts
+++ b/src/e2e/harness/source-paseo.packaging.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { describe, it } from "vitest";
+import { packagePaseoArtifacts } from "./source-paseo.js";
+
+/**
+ * Packing the source workspaces is the most expensive thing the hub e2e harness does, and it
+ * runs from `beforeEach`. These assertions are about the sharing, not the packing: a missing
+ * checkout fails fast, which is all the identity checks need.
+ */
+describe("packaged source artifacts", () => {
+  it("builds one tree per source checkout, however many daemons ask for it", () => {
+    const first = packagePaseoArtifacts("/nonexistent/paseo-checkout");
+    const second = packagePaseoArtifacts("/nonexistent/paseo-checkout");
+
+    assert.equal(first, second, "a second start must wait on the first build, not begin another");
+    return Promise.allSettled([first, second]);
+  });
+
+  it("keeps separate checkouts apart", () => {
+    const one = packagePaseoArtifacts("/nonexistent/paseo-one");
+    const other = packagePaseoArtifacts("/nonexistent/paseo-other");
+
+    assert.notEqual(one, other);
+    return Promise.allSettled([one, other]);
+  });
+
+  it("reports the same failure to every caller rather than retrying a checkout that cannot pack", async () => {
+    const failures = await Promise.allSettled([
+      packagePaseoArtifacts("/nonexistent/paseo-unpackable"),
+      packagePaseoArtifacts("/nonexistent/paseo-unpackable"),
+    ]);
+
+    assert.deepEqual(
+      failures.map((result) => result.status),
+      ["rejected", "rejected"],
+    );
+  });
+});

--- a/src/e2e/harness/source-paseo.ts
+++ b/src/e2e/harness/source-paseo.ts
@@ -1,5 +1,6 @@
 import { spawn, execFile, type ChildProcess } from "node:child_process";
 import { createConnection, createServer as createNetServer } from "node:net";
+import { rmSync } from "node:fs";
 import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
@@ -66,7 +67,7 @@ export class SourcePaseo {
     const ownsRoot = options.root === undefined;
     const root = options.root ?? (await mkdtemp(join(tmpdir(), "paseo-source-e2e-")));
     try {
-      const packagesRoot = await packagePaseoArtifacts(resolvePaseoWorktree(), root);
+      const packagesRoot = await packagePaseoArtifacts(resolvePaseoWorktree());
       const paseoHome = options.paseoHome ?? join(root, "paseo-home");
       const daemonHost = options.daemonHost ?? `127.0.0.1:${await availablePort()}`;
       await mkdir(paseoHome, { recursive: true });
@@ -281,7 +282,48 @@ export function resolvePaseoWorktree(): string {
   return resolve(configured);
 }
 
-export async function packagePaseoArtifacts(paseoRoot: string, root: string): Promise<string> {
+/**
+ * The packed source artifacts, built once per process and shared by every daemon it starts.
+ *
+ * Packing the six workspaces and installing the tarballs costs tens of seconds, and the source
+ * checkout cannot change while a suite runs, so each test after the first was paying to rebuild
+ * a byte-identical directory. On a loaded runner that repeat was enough to exhaust the 120s
+ * start budget in `beforeEach`. The tree is only ever read once built — the daemon writes to
+ * `PASEO_HOME`, which stays per-test — so one copy serves them all.
+ *
+ * The promise is what's memoized, so concurrent starts wait on one build instead of racing.
+ */
+const packagedArtifacts = new Map<string, Promise<string>>();
+
+/**
+ * Names a tree an earlier process already built. Playwright workers each get their own module
+ * instance, so the in-process memo cannot help the first daemon in a worker — and that one pays
+ * the build inside the test's own timeout. `globalSetup` builds ahead of the workers and passes
+ * the path down through here.
+ */
+const PREBUILT = "PASEO_E2E_PACKAGES";
+
+export function packagePaseoArtifacts(paseoRoot: string): Promise<string> {
+  const prebuilt = process.env[PREBUILT];
+  if (prebuilt !== undefined && prebuilt !== "") return Promise.resolve(prebuilt);
+  const built = packagedArtifacts.get(paseoRoot) ?? buildPaseoArtifacts(paseoRoot);
+  packagedArtifacts.set(paseoRoot, built);
+  return built;
+}
+
+/**
+ * Builds the artifacts and publishes them to every process this one goes on to spawn. Returns
+ * nothing to clean up: the tree is removed when the process that built it exits.
+ */
+export async function prebuildPaseoArtifacts(paseoRoot: string): Promise<string> {
+  const packages = await packagePaseoArtifacts(paseoRoot);
+  process.env[PREBUILT] = packages;
+  return packages;
+}
+
+async function buildPaseoArtifacts(paseoRoot: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "paseo-packaged-"));
+  removeWhenTheProcessExits(root);
   const packages = join(root, "paseo-packages");
   const tarballs = join(root, "paseo-tarballs");
   await Promise.all([mkdir(packages), mkdir(tarballs)]);
@@ -302,6 +344,13 @@ export async function packagePaseoArtifacts(paseoRoot: string, root: string): Pr
     .map((file) => join(tarballs, file));
   await runCommand("npm", ["install", "--ignore-scripts", ...tarballsToInstall], packages, {});
   return packages;
+}
+
+/** The shared tree outlives every harness that borrows it, so the process owns its removal. */
+function removeWhenTheProcessExits(directory: string): void {
+  process.once("exit", () => {
+    rmSync(directory, { recursive: true, force: true });
+  });
 }
 
 export function sourceEnvironment(paseoHome: string): NodeJS.ProcessEnv {

--- a/src/operator/panel.tsx
+++ b/src/operator/panel.tsx
@@ -2,7 +2,13 @@ import { useCallback, useState, type FormEvent } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useServerFn } from "@tanstack/react-start";
 import { TriangleAlert } from "lucide-react";
-import { DataCell, DataRow, DataTable, type DataColumn } from "../components/app/data-table.js";
+import {
+  DataCell,
+  DataRow,
+  DataTable,
+  DataTableSkeleton,
+  type DataColumn,
+} from "../components/app/data-table.js";
 import { PageHeader } from "../components/app/page.js";
 import { RelativeTime } from "../components/app/relative-time.js";
 import { Section } from "../components/app/section.js";
@@ -47,6 +53,10 @@ type OverrideTarget =
   | { kind: "canInviteMembers"; key: OverrideKey; hasOverride: boolean; value: boolean }
   | { kind: "executionsMonthly"; key: OverrideKey; hasOverride: boolean; limit: number | null };
 
+const PICKER_TITLE = "Organization";
+const PICKER_DESCRIPTION = "Pick an organization to manage its entitlements.";
+const AUDIT_TITLE = "Audit trail";
+const AUDIT_DESCRIPTION = "Every provisioning, plan stamp, and override, most recent first.";
 const ENTITLEMENT_COLUMNS: readonly DataColumn[] = [
   { header: "Entitlement" },
   { header: "Granted" },
@@ -96,7 +106,7 @@ function OrganizationPicker({
   const load = useServerFn(operatorOrganizations);
   const query = useQuery({ queryKey: ["operator", "organizations"], queryFn: () => load() });
 
-  if (query.isPending) return <OperatorLoading />;
+  if (query.isPending) return <OrganizationPickerLoading />;
   if (query.isError || query.data.status === "error") {
     return (
       <Alert variant="destructive">
@@ -110,7 +120,7 @@ function OrganizationPicker({
     );
   }
   return (
-    <Section title="Organization" description="Pick an organization to manage its entitlements.">
+    <Section title={PICKER_TITLE} description={PICKER_DESCRIPTION}>
       <Select {...(slug === null ? {} : { value: slug })} onValueChange={onSelect}>
         <SelectTrigger aria-label="Manage organization" className="w-full max-w-sm">
           <SelectValue placeholder="Select an organization" />
@@ -134,7 +144,7 @@ function OperatorOrganization({ slug }: { slug: string }) {
     queryFn: () => load({ data: { organizationSlug: slug } }),
   });
 
-  if (query.isPending) return <OperatorLoading />;
+  if (query.isPending) return <OperatorOrganizationLoading />;
   if (query.isError || query.data.status === "error") {
     return (
       <Alert variant="destructive">
@@ -274,10 +284,7 @@ function OrganizationContent({ snapshot, slug }: { snapshot: Snapshot; slug: str
           </DataRow>
         </DataTable>
       </Section>
-      <Section
-        title="Audit trail"
-        description="Every provisioning, plan stamp, and override, most recent first."
-      >
+      <Section title={AUDIT_TITLE} description={AUDIT_DESCRIPTION}>
         <AuditTrail history={snapshot.history} />
       </Section>
       {target !== null && <OverrideDialog target={target} slug={slug} onClose={closeEditor} />}
@@ -559,11 +566,23 @@ function meterUsageLabel(usage: Snapshot["usage"]): string {
   return usage.limit === null ? String(usage.used) : `${usage.used}/${usage.limit}`;
 }
 
-function OperatorLoading() {
+function OrganizationPickerLoading() {
   return (
-    <section aria-label="Loading operator console" aria-busy="true" className="grid gap-6">
-      <Skeleton className="h-12 w-64" />
-      <Skeleton className="h-48 w-full" />
-    </section>
+    <Section title={PICKER_TITLE} description={PICKER_DESCRIPTION}>
+      <Skeleton aria-busy="true" className="h-9 w-full max-w-sm" />
+    </Section>
+  );
+}
+
+function OperatorOrganizationLoading() {
+  return (
+    <>
+      <Section title="Entitlements">
+        <DataTableSkeleton label="Entitlements" columns={ENTITLEMENT_COLUMNS} />
+      </Section>
+      <Section title={AUDIT_TITLE} description={AUDIT_DESCRIPTION}>
+        <DataTableSkeleton label="Audit trail" columns={AUDIT_COLUMNS} rows={2} />
+      </Section>
+    </>
   );
 }

--- a/src/projects/context.tsx
+++ b/src/projects/context.tsx
@@ -1,15 +1,28 @@
 import { useQuery } from "@tanstack/react-query";
 import { useRouterState } from "@tanstack/react-router";
 import { useServerFn } from "@tanstack/react-start";
-import { createContext, useContext, type ReactNode } from "react";
-import { Alert, AlertDescription, AlertTitle } from "../components/ui/alert.js";
-import { Skeleton } from "../components/ui/skeleton.js";
+import { createContext, useContext, useMemo, type ReactNode } from "react";
 import { tenantContext } from "./functions.js";
 import type { ProjectDashboard } from "./dashboard.js";
 
 type TenantContextValue = Awaited<ReturnType<ProjectDashboard["tenantContext"]>>;
 
+/**
+ * Which organization and project the URL is in, once the server has confirmed them.
+ *
+ * The provider always renders its children. Resolving a tenant is the dashboard's own business,
+ * and the dashboard is what wraps it: if the provider returned a placeholder instead, the sidebar
+ * and site header would go with it, and a slow tenant read would look like the app unmounting.
+ * The shell reads `useRouteTenantStatus` and puts the pending or failed state in its content slot.
+ */
+export type RouteTenantStatus =
+  | { state: "outside" }
+  | { state: "pending" }
+  | { state: "failed"; title: string; message: string }
+  | { state: "ready" };
+
 const ProjectTenantContext = createContext<TenantContextValue | null>(null);
+const RouteTenantStatusContext = createContext<RouteTenantStatus>({ state: "outside" });
 
 export function RouteTenantProvider({ children }: { children: ReactNode }) {
   const pathname = useRouterState({ select: (state) => state.location.pathname });
@@ -20,34 +33,47 @@ export function RouteTenantProvider({ children }: { children: ReactNode }) {
     queryFn: () => load({ data: scope! }),
     enabled: scope !== undefined,
   });
-  if (scope === undefined) return children;
-  if (snapshot.isPending) {
-    return (
-      <section aria-label="Loading tenant context" aria-busy="true" className="grid gap-6">
-        <Skeleton className="h-12 w-64" />
-        <Skeleton className="h-64 w-full" />
-      </section>
-    );
-  }
-  if (snapshot.isError || snapshot.data.status === "error") {
-    const unavailableMessage =
-      scope.projectSlug === undefined ? "Organization unavailable." : "Project unavailable.";
-    const message =
-      snapshot.data?.status === "error" ? snapshot.data.error.message : unavailableMessage;
-    return (
-      <Alert variant="destructive">
-        <AlertTitle>
-          {scope.projectSlug === undefined ? "Organization unavailable" : "Project unavailable"}
-        </AlertTitle>
-        <AlertDescription>{message}</AlertDescription>
-      </Alert>
-    );
-  }
-  return (
-    <ProjectTenantContext.Provider value={snapshot.data.data}>
-      {children}
-    </ProjectTenantContext.Provider>
+  const tenant = scope !== undefined && snapshot.data?.status === "ok" ? snapshot.data.data : null;
+  // The status is recomputed only when the read moves, so the whole dashboard below does not
+  // rerender because something else in the tree did.
+  const outside = scope === undefined;
+  const projectScoped = scope?.projectSlug !== undefined;
+  const pending = snapshot.isPending;
+  const failure = readFailure(snapshot);
+  const status = useMemo(
+    () => tenantStatus({ outside, projectScoped, pending, failure }),
+    [outside, projectScoped, pending, failure],
   );
+  return (
+    <RouteTenantStatusContext.Provider value={status}>
+      <ProjectTenantContext.Provider value={tenant}>{children}</ProjectTenantContext.Provider>
+    </RouteTenantStatusContext.Provider>
+  );
+}
+
+/** The server's message, the empty string when the request never arrived, undefined when it worked. */
+function readFailure(snapshot: {
+  isError: boolean;
+  data: { status: "ok" } | { status: "error"; error: { message: string } } | undefined;
+}): string | undefined {
+  if (snapshot.data?.status === "error") return snapshot.data.error.message;
+  return snapshot.isError ? "" : undefined;
+}
+
+/** `failure` is the server's message, the empty string for a request that never arrived. */
+function tenantStatus(read: {
+  outside: boolean;
+  projectScoped: boolean;
+  pending: boolean;
+  failure: string | undefined;
+}): RouteTenantStatus {
+  if (read.outside) return { state: "outside" };
+  if (read.pending) return { state: "pending" };
+  if (read.failure !== undefined) {
+    const title = read.projectScoped ? "Project unavailable" : "Organization unavailable";
+    return { state: "failed", title, message: read.failure === "" ? `${title}.` : read.failure };
+  }
+  return { state: "ready" };
 }
 
 export function useRouteTenant(): TenantContextValue {
@@ -58,6 +84,10 @@ export function useRouteTenant(): TenantContextValue {
 
 export function useOptionalRouteTenant(): TenantContextValue | null {
   return useContext(ProjectTenantContext);
+}
+
+export function useRouteTenantStatus(): RouteTenantStatus {
+  return useContext(RouteTenantStatusContext);
 }
 
 export function routeScope(

--- a/src/projects/panel-state.tsx
+++ b/src/projects/panel-state.tsx
@@ -3,7 +3,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useServerFn } from "@tanstack/react-start";
 import type { ReactNode } from "react";
 import { Alert, AlertDescription, AlertTitle } from "../components/ui/alert.js";
-import { Skeleton } from "../components/ui/skeleton.js";
+import { PanelSkeleton } from "../components/app/loading.js";
 import type { Result } from "../contract/respond.js";
 import { useRouteTenant } from "./context.js";
 import type { ProjectDashboard } from "./dashboard.js";
@@ -18,14 +18,14 @@ import { organizationSnapshot, projectSnapshot } from "./functions.js";
 export type OrganizationSnapshot = Awaited<ReturnType<ProjectDashboard["organizationSnapshot"]>>;
 export type ProjectSnapshot = Awaited<ReturnType<ProjectDashboard["projectSnapshot"]>>;
 
-export function useOrganizationSnapshot() {
+export function useOrganizationSnapshot(pending?: ReactNode) {
   const tenant = useRouteTenant();
   const load = useServerFn(organizationSnapshot);
   const query = useQuery({
     queryKey: ["organization", tenant.account.id, tenant.organization.id],
     queryFn: () => load({ data: { organizationSlug: tenant.organization.slug } }),
   });
-  return queryState<OrganizationSnapshot>(query, "Organization unavailable");
+  return queryState<OrganizationSnapshot>(query, "Organization unavailable", pending);
 }
 
 export function useProjectSnapshot() {
@@ -39,24 +39,17 @@ export function useProjectSnapshot() {
   return queryState<ProjectSnapshot>(query, "Project unavailable");
 }
 
+/**
+ * The two states a panel renders instead of its content. `pending` is the panel's own skeleton;
+ * without one it falls back to the generic panel shape, which is right only where the surface
+ * cannot yet say what it is.
+ */
 export function queryState<T>(
   query: { isPending: boolean; isError: boolean; data: Result<T> | undefined },
   title: string,
+  pending?: ReactNode,
 ): { ok: true; data: T } | { ok: false; element: ReactNode } {
-  if (query.isPending)
-    return {
-      ok: false,
-      element: (
-        <section
-          aria-label={`Loading ${title.toLowerCase()}`}
-          aria-busy="true"
-          className="grid gap-5"
-        >
-          <Skeleton className="h-12 w-64" />
-          <Skeleton className="h-72 w-full" />
-        </section>
-      ),
-    };
+  if (query.isPending) return { ok: false, element: pending ?? <PanelSkeleton /> };
   if (query.isError || query.data?.status !== "ok")
     return {
       ok: false,

--- a/src/projects/panels.tsx
+++ b/src/projects/panels.tsx
@@ -6,7 +6,13 @@ import { type FormEvent, type ReactNode } from "react";
 import { CONNECTION_MUTATION_KEY } from "../auth/tenant-mutation.js";
 import { useActiveAccount } from "../auth/active-account.js";
 import { ConfirmAction, ConfirmMenuItem } from "../components/app/confirm-action.js";
-import { DataCell, DataRow, DataTable } from "../components/app/data-table.js";
+import {
+  DataCell,
+  DataRow,
+  DataTable,
+  DataTableSkeleton,
+  type DataColumn,
+} from "../components/app/data-table.js";
 import { PageHeader } from "../components/app/page.js";
 import { RowActions } from "../components/app/row-actions.js";
 import { Section } from "../components/app/section.js";
@@ -43,12 +49,31 @@ import {
   type ProjectSnapshot,
 } from "./panel-state.js";
 import { archiveProject, activityRunSnapshot, updateProjectSlug } from "./functions.js";
+const CONNECTION_COLUMNS: readonly DataColumn[] = [
+  { header: "Connection" },
+  { header: "Provider" },
+  { header: "Status" },
+  { header: "" },
+];
+const CONNECTIONS_DESCRIPTION = "Organization provider connections.";
+
+function ConnectionsLoading() {
+  return (
+    <>
+      <PageHeader title="Connections" description={CONNECTIONS_DESCRIPTION} />
+      <Section title="Connections">
+        <DataTableSkeleton label="Connections" columns={CONNECTION_COLUMNS} />
+      </Section>
+    </>
+  );
+}
+
 export function OrganizationConnectionsPanel() {
   const tenant = useRouteTenant();
   const { isInstanceOperator } = useActiveAccount();
   const queryClient = useQueryClient();
   const scope = { organizationSlug: tenant.organization.slug };
-  const snapshot = useOrganizationSnapshot();
+  const snapshot = useOrganizationSnapshot(<ConnectionsLoading />);
   const loadStatus = useServerFn(connectionStatus);
   const statusQuery = useQuery({
     queryKey: ["connection-status", tenant.account.id, tenant.organization.id],
@@ -76,7 +101,11 @@ export function OrganizationConnectionsPanel() {
     },
   });
   if (!snapshot.ok) return snapshot.element;
-  const status = queryState<ConnectionStatus>(statusQuery, "Connections unavailable");
+  const status = queryState<ConnectionStatus>(
+    statusQuery,
+    "Connections unavailable",
+    <ConnectionsLoading />,
+  );
   if (!status.ok) return status.element;
   const data = snapshot.data;
   const connectProvider = (provider: "github" | "discord" | "slack" | "linear") => {
@@ -110,7 +139,7 @@ export function OrganizationConnectionsPanel() {
   };
   return (
     <>
-      <PageHeader title="Connections" description="Organization provider connections." />
+      <PageHeader title="Connections" description={CONNECTIONS_DESCRIPTION} />
       {returned === undefined ? null : (
         <ConnectionReturnBanner copy={connectionReturnCopy(returned)} />
       )}
@@ -118,12 +147,7 @@ export function OrganizationConnectionsPanel() {
       <Section title="Connections">
         <DataTable
           label="Connections"
-          columns={[
-            { header: "Connection" },
-            { header: "Provider" },
-            { header: "Status" },
-            { header: "" },
-          ]}
+          columns={CONNECTION_COLUMNS}
           isEmpty={rows.length === 0}
           empty={{ title: "No connections" }}
         >

--- a/src/projects/repository-combobox.tsx
+++ b/src/projects/repository-combobox.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useId, useState } from "react";
-import { CheckIcon, ChevronsUpDownIcon, Loader2Icon } from "lucide-react";
+import { CheckIcon, ChevronsUpDownIcon } from "lucide-react";
 import { cn } from "../lib/utils.js";
+import { LoadingLine, Spinner } from "../components/app/loading.js";
 import { Button } from "../components/ui/button.js";
 import {
   Command,
@@ -57,7 +58,7 @@ export function RepositoryCombobox({
         >
           <span className="truncate">{selected?.fullName ?? placeholder}</span>
           {loading ? (
-            <Loader2Icon className="size-4 shrink-0 animate-spin opacity-50" />
+            <Spinner className="opacity-50" />
           ) : (
             <ChevronsUpDownIcon className="size-4 shrink-0 opacity-50" />
           )}
@@ -68,9 +69,8 @@ export function RepositoryCombobox({
           <CommandInput placeholder="Search repositories…" />
           <CommandList id={listId}>
             {loading ? (
-              <div className="flex items-center justify-center gap-2 py-6 text-sm text-muted-foreground">
-                <Loader2Icon className="size-4 animate-spin" />
-                Loading repositories…
+              <div className="flex justify-center py-6">
+                <LoadingLine>Loading repositories…</LoadingLine>
               </div>
             ) : (
               <>

--- a/src/triggers/activity-panel.tsx
+++ b/src/triggers/activity-panel.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { useServerFn } from "@tanstack/react-start";
-import { DataCell, DataRow, DataTable } from "../components/app/data-table.js";
+import { DataCell, DataRow, DataTable, DataTableSkeleton } from "../components/app/data-table.js";
 import { PageHeader } from "../components/app/page.js";
 import { StatusPill } from "../components/app/status-pill.js";
 import { Alert, AlertDescription } from "../components/ui/alert.js";
@@ -16,6 +16,7 @@ const ACTIVITY_COLUMNS = [
   { header: "Received" },
 ];
 const EMPTY_ACTIVITY = { title: "No activity" };
+const ACTIVITY_DESCRIPTION = "Agent runs launched by organization triggers.";
 
 export function TriggerActivityPanel() {
   const tenant = useRouteTenant();
@@ -25,7 +26,14 @@ export function TriggerActivityPanel() {
     queryKey: ["triggers", organizationSlug],
     queryFn: () => load({ data: { organizationSlug } }),
   });
-  if (snapshot.isPending) return <div aria-busy="true">Loading activity…</div>;
+  if (snapshot.isPending) {
+    return (
+      <>
+        <PageHeader title="Activity" description={ACTIVITY_DESCRIPTION} />
+        <DataTableSkeleton label="Trigger activity" columns={ACTIVITY_COLUMNS} />
+      </>
+    );
+  }
   if (snapshot.isError || snapshot.data.status === "error") {
     return (
       <Alert variant="destructive">
@@ -40,7 +48,7 @@ export function TriggerActivityPanel() {
   const activity = snapshot.data.data.activity;
   return (
     <>
-      <PageHeader title="Activity" description="Agent runs launched by organization triggers." />
+      <PageHeader title="Activity" description={ACTIVITY_DESCRIPTION} />
       <DataTable
         label="Trigger activity"
         columns={ACTIVITY_COLUMNS}

--- a/src/triggers/panel.tsx
+++ b/src/triggers/panel.tsx
@@ -5,8 +5,10 @@ import { Link, useNavigate } from "@tanstack/react-router";
 import { useServerFn } from "@tanstack/react-start";
 import { AlertTriangle, ArrowLeft, Braces, Copy, FileText, LockKeyhole, Plus } from "lucide-react";
 import { useLayoutEffect, useRef, useState, type FormEvent, type ReactNode } from "react";
-import { DataCell, DataRow, DataTable } from "../components/app/data-table.js";
+import { DataCell, DataRow, DataTable, DataTableSkeleton } from "../components/app/data-table.js";
 import { PageHeader } from "../components/app/page.js";
+import { LoadingLine } from "../components/app/loading.js";
+import { Skeleton } from "../components/ui/skeleton.js";
 import { SiteHeaderActions } from "../components/app/site-header-actions.js";
 import { RelativeTime } from "../components/app/relative-time.js";
 import { StatusPill } from "../components/app/status-pill.js";
@@ -51,12 +53,22 @@ const EVENT_OPTIONS: TriggerSelectOption[] = [
   { value: "manual.run", label: "Manual run (manual.run)" },
 ];
 
+const TRIGGERS_DESCRIPTION = "Launch agents on your compute when organization events arrive.";
+const TRIGGER_EDITOR_DESCRIPTION = "One event launches one agent on your compute.";
+
 export function TriggersPanel() {
   const tenant = useRouteTenant();
   const scope = { organizationSlug: tenant.organization.slug };
   const snapshot = useTriggerSnapshot(scope.organizationSlug);
   const navigate = useNavigate();
-  if (snapshot.isPending) return <div aria-busy="true">Loading triggers…</div>;
+  if (snapshot.isPending) {
+    return (
+      <>
+        <PageHeader title="Triggers" description={TRIGGERS_DESCRIPTION} />
+        <DataTableSkeleton label="Triggers" columns={TRIGGER_COLUMNS} />
+      </>
+    );
+  }
   if (snapshot.isError || snapshot.data.status === "error") {
     return <TriggerLoadError result={snapshot.data} />;
   }
@@ -65,10 +77,7 @@ export function TriggersPanel() {
     `/o/${scope.organizationSlug}/triggers/${triggerId}` as never;
   return (
     <>
-      <PageHeader
-        title="Triggers"
-        description="Launch agents on your compute when organization events arrive."
-      >
+      <PageHeader title="Triggers" description={TRIGGERS_DESCRIPTION}>
         {data.canManage ? (
           <Button asChild>
             <Link to={triggerPath("new")}>
@@ -188,7 +197,7 @@ export function TriggerEditorPanel({ triggerId }: { triggerId: string }) {
       await navigate({ to: `/o/${organizationSlug}/triggers` as never });
     },
   });
-  if (snapshot.isPending) return <div aria-busy="true">Loading trigger…</div>;
+  if (snapshot.isPending) return <TriggerEditorSkeleton />;
   if (snapshot.isError || snapshot.data.status === "error") {
     return <TriggerLoadError result={snapshot.data} />;
   }
@@ -309,7 +318,7 @@ function TriggerEditor({
           label: editor.form.enabled ? "Enabled" : "Disabled",
           tone: editor.form.enabled ? "success" : "neutral",
         }}
-        description="One event launches one agent on your compute."
+        description={TRIGGER_EDITOR_DESCRIPTION}
       >
         <EnabledSwitch
           checked={editor.form.enabled}
@@ -656,9 +665,7 @@ function TriggerForm({
             />
           </div>
           {providerCatalog.loading ? (
-            <p className="text-sm text-muted-foreground" aria-busy="true">
-              Loading providers from {form.daemon}…
-            </p>
+            <LoadingLine>{`Loading providers from ${form.daemon}…`}</LoadingLine>
           ) : null}
           {providerCatalog.error === undefined ? null : (
             <Alert variant="destructive">
@@ -750,6 +757,64 @@ function TriggerForm({
           </div>
         </FormSection>
       )}
+    </div>
+  );
+}
+
+/**
+ * The trigger editor before the snapshot arrives. The back link, the numbered sections, and
+ * their headings are the same every time, so they render for real; only the trigger's own
+ * name, state, and field values are placeholders.
+ */
+function TriggerEditorSkeleton() {
+  return (
+    <div aria-busy="true">
+      <Button variant="ghost" size="sm" className="mb-4 -ml-3" disabled>
+        <ArrowLeft className="size-4" /> Triggers
+      </Button>
+      <header className="mb-6 grid gap-2">
+        <Skeleton className="h-7 w-56" />
+        <p className="text-sm text-muted-foreground">{TRIGGER_EDITOR_DESCRIPTION}</p>
+      </header>
+      <div className="grid gap-5">
+        {EDITOR_SECTIONS.map((section) => (
+          <FormSection key={section.number} {...section}>
+            <div className="grid gap-4 sm:grid-cols-2">
+              <FieldSkeleton />
+              <FieldSkeleton />
+            </div>
+          </FormSection>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/** The three sections every trigger has, whatever event or daemon it ends up pointing at. */
+const EDITOR_SECTIONS = [
+  {
+    number: "1",
+    title: "Trigger details",
+    description: "Identification and system handle for this trigger.",
+  },
+  {
+    number: "2",
+    title: "Event & access",
+    description: "When this event fires and who is authorized to invoke it.",
+  },
+  {
+    number: "3",
+    title: "Run target",
+    description: "The local machine compute and repository working directory.",
+  },
+] as const;
+
+function FieldSkeleton() {
+  return (
+    <div className="grid gap-2">
+      <Skeleton className="h-4 w-28" />
+      <Skeleton className="h-9 w-full" />
+      <Skeleton className="h-3 w-48" />
     </div>
   );
 }

--- a/src/usage/panel.tsx
+++ b/src/usage/panel.tsx
@@ -1,14 +1,19 @@
 import { useQuery } from "@tanstack/react-query";
 import { useServerFn } from "@tanstack/react-start";
 import { TriangleAlert } from "lucide-react";
-import { DataCell, DataRow, DataTable, type DataColumn } from "../components/app/data-table.js";
+import {
+  DataCell,
+  DataRow,
+  DataTable,
+  DataTableSkeleton,
+  type DataColumn,
+} from "../components/app/data-table.js";
 import { PageHeader } from "../components/app/page.js";
 import { RelativeTime } from "../components/app/relative-time.js";
 import { Section } from "../components/app/section.js";
 import { StatusPill } from "../components/app/status-pill.js";
 import { Alert, AlertDescription, AlertTitle } from "../components/ui/alert.js";
 import { Badge } from "../components/ui/badge.js";
-import { Skeleton } from "../components/ui/skeleton.js";
 import type { EntitlementChangeSource } from "../db/types.js";
 import { useRouteTenant } from "../projects/context.js";
 import type { UsageDashboard, UsageMeasure } from "./dashboard.js";
@@ -17,6 +22,10 @@ import { overLimit } from "./limits.js";
 
 type Snapshot = Awaited<ReturnType<UsageDashboard["snapshot"]>>;
 
+const LIMITS_TITLE = "Limits";
+const LIMITS_DESCRIPTION = "What this organization is allowed, and how much is in use.";
+const HISTORY_TITLE = "History";
+const HISTORY_DESCRIPTION = "Every change to this organization's limits, most recent first.";
 const LIMIT_COLUMNS: readonly DataColumn[] = [
   { header: "Resource" },
   { header: "Limit" },
@@ -49,7 +58,7 @@ export function OrganizationUsagePanel() {
     queryFn: () => load({ data: { organizationSlug: tenant.organization.slug } }),
   });
 
-  if (query.isPending) return <UsageLoading />;
+  if (query.isPending) return <UsageLoading name={tenant.organization.name} />;
   if (query.isError || query.data.status === "error") {
     return (
       <Alert variant="destructive">
@@ -74,10 +83,7 @@ function UsageContent({ snapshot }: { snapshot: Snapshot }) {
         description={`Limits and usage for ${snapshot.organization.name}.`}
       />
       <SeatOverLimitBanner seats={limits.seats} />
-      <Section
-        title="Limits"
-        description="What this organization is allowed, and how much is in use."
-      >
+      <Section title={LIMITS_TITLE} description={LIMITS_DESCRIPTION}>
         <DataTable label="Limits" columns={LIMIT_COLUMNS} isEmpty={false} empty={LIMITS_EMPTY}>
           <DataRow>
             <DataCell>Seats</DataCell>
@@ -102,10 +108,7 @@ function UsageContent({ snapshot }: { snapshot: Snapshot }) {
           </DataRow>
         </DataTable>
       </Section>
-      <Section
-        title="History"
-        description="Every change to this organization's limits, most recent first."
-      >
+      <Section title={HISTORY_TITLE} description={HISTORY_DESCRIPTION}>
         <History history={snapshot.history} />
       </Section>
     </>
@@ -181,11 +184,16 @@ function measureUsage(measure: UsageMeasure): string {
   return measure.limit === null ? String(measure.used) : `${measure.used}/${measure.limit}`;
 }
 
-function UsageLoading() {
+function UsageLoading({ name }: { name: string }) {
   return (
-    <section aria-label="Loading usage" aria-busy="true" className="grid gap-6">
-      <Skeleton className="h-12 w-64" />
-      <Skeleton className="h-48 w-full" />
-    </section>
+    <>
+      <PageHeader title="Usage" description={`Limits and usage for ${name}.`} />
+      <Section title={LIMITS_TITLE} description={LIMITS_DESCRIPTION}>
+        <DataTableSkeleton label="Limits" columns={LIMIT_COLUMNS} />
+      </Section>
+      <Section title={HISTORY_TITLE} description={HISTORY_DESCRIPTION}>
+        <DataTableSkeleton label="History" columns={HISTORY_COLUMNS} rows={2} />
+      </Section>
+    </>
   );
 }


### PR DESCRIPTION
## What changed, and why

Loading states across the dashboard now look like the page you are waiting for. Every surface renders what it already knows — its title, section headings, table columns, form section headings — and draws placeholders only where the data goes. Switching organization or opening a dashboard URL cold no longer makes the sidebar and header disappear.

Closes #2.

### Goals

- One loading idiom for records: the real table shell with placeholder rows, at the real row rhythm.
- One spinner, used only for a small fact inside an already-drawn page.
- The app shell stays mounted while the tenant read is in flight, and while it fails.
- No bare "Loading…" text anywhere — it reserves no space, so the page jumps when it resolves.

### Non-goals

- No redesign of any loaded surface. Every screenshot below is identical once the data lands.
- No change to what is fetched, when, or by which query.
- Mobile layouts are unchanged; these surfaces already reflow.

### The why

Before this, a surface waiting on a read showed one of three unrelated things: a bare line of text (Triggers, the trigger editor, Activity, API keys), one of six near-duplicate pairs of grey blobs whose heights had drifted apart (Daemons, Usage, Operator, Billing, CLI login, Connections, and the tenant/account transitions), or — on the app setup path only — the finished chrome with placeholders only where the data goes. The last of those is the one that tells the reader they are already on the page they asked for, so it became the rule.

`DataTable` and the new `DataTableSkeleton` share one `TableShell`, so a skeleton table cannot drift from the table it stands in for; a test asserts the two shells render byte-identical markup. Page copy that both the loaded header and its pending state need now lives in one constant per panel, for the same reason.

While reproducing the pending states, a real defect surfaced. `RouteTenantProvider` wraps the whole dashboard and returned its placeholder **instead of `children`** while the tenant read was in flight, so the sidebar, the site header and the page container all unmounted. What was left was a bare `<section>` inside `SidebarProvider`'s flex row, squeezed into a ~385px column at the top-left with no padding. The error branch did the same, so a failed tenant read blanked the app rather than reporting itself in place. The provider now always renders its children and publishes a status alongside the tenant value; the shell reads that status and puts the skeleton or the alert in its content slot — the slot the organization-switch transition already used.

### Before / after

The app-shell transition — account resolved, tenant still in flight:

| before | after |
| --- | --- |
| sidebar, header and page container all unmounted; content squeezed into a narrow unpadded column | shell intact, only the content slot is a skeleton |

Triggers, the trigger editor, Activity, Daemons, Connections, API keys, Usage, Operator and CLI login all move from bare text or grey blobs to their own page shape. Apps was already correct and is unchanged.

## Also in this PR: three CI timing fixes

CI came back red on three jobs that touch none of the UI above, each on a timing assumption rather than a defect in the code under test. They are fixed here rather than re-run, in a separate commit.

- **`hub-e2e`** — `SourcePaseo.start()` packs six workspaces and installs the tarballs into a fresh directory, and it runs from `beforeEach`, so every test after the first rebuilt a byte-identical tree. The fourth exhausted the 120s hook budget. The build is now memoized per process: the source checkout cannot change while a suite runs, and the tree is only read once built (the daemon writes to `PASEO_HOME`, which stays per-test). Measured locally: 7.3s for the first call, 0ms for the second, same path.
- **`browser-e2e`** — memoizing per process cannot help the *first* daemon test in a Playwright worker, which still paid for the build inside its own 120s test timeout. That is the arbitrary single daemon test that times out on a loaded runner — here `phase-two`, and on `require-daemon-selection` and `add-provider-read-rpcs-hub` it was whichever test drew the short straw. A `globalSetup` now packs the source before any worker starts and hands the path down through the environment, so the build is on no test's clock. Suites that leave `PASEO_E2E_WORKTREE` unset build nothing and skip.
- **`test`** — `waitForRecoveredExecution` waited for the daemon agent to be attached, then read the row again. Recovery lands in two writes, so the second read returned whatever the status write had managed by then — `spawning` where the caller asserted `running`. It now waits for the status the caller names and returns the record that satisfied the wait.

## Verification

- `npm run typecheck`, `npm run lint`, `npm run format:check` — green.
- New `src/components/app/data-table-skeleton.test.tsx` (3 tests) plus the existing `provider-section-loading` test — green.
- Playwright, desktop-chromium, run locally against a built instance — 37 tests green across the affected surfaces: `dashboard-desktop` (6), `dashboard-navigation` (3), `apps` (16), `triggers` (2), `authentication` (5), `entitlements` (3), `daemon-handoff` (2).
- Pending states were photographed by holding server-function responses open against a locally built Hub, one screenshot per surface, in both the old and new code.

For the CI fixes:

- `phase-two` reproduced locally with the old code (120s timeout, build inside the test) and now gets past `SourcePaseo.start()` to the CLI step; it cannot complete locally because this machine's Paseo checkout is not the pinned `PASEO_E2E_COMMIT`.
- `e2e/prebuilt-source.spec.ts` asserts a worker is handed a packed tree containing `node_modules/.bin/paseo`, and skips cleanly with no source checkout. Both paths run.
- `src/e2e/harness/source-paseo.packaging.test.ts` covers one build per checkout, separate checkouts kept apart, and one shared failure rather than a retry storm.
- `daemons.test.ts` and `index.bootstrap.test.ts` in full — 99 passed. The helper is used at 13 call sites, so the whole file matters, not just the one test that was failing.

## Risk surface

- **Accessible names.** `Table` derives a landmark named `"<label> table"`, so a panel skeleton passing its own label down to the table inside it puts two regions under one name and makes `getByRole("region", { name })` ambiguous. That broke `dashboard-desktop.spec.ts` locally and is fixed; the panel skeleton now labels its inner table separately. Worth a look if any other surface starts nesting a labelled table inside a labelled region.
- **`RouteTenantProvider` now always renders its children.** Panels calling `useRouteTenant()` still never render while the tenant is unresolved, because the shell returns the skeleton from its content slot instead of the `Outlet`. If a future consumer mounts outside that slot it would see a `null` context and throw. The provider is used in exactly one place today.
- **`queryState` gained an optional `pending` element.** Callers that don't pass one fall back to the generic panel shape, which is only right where the surface cannot yet say what it is. Connections passes its own; the project panels still use the fallback.
- **`globalSetup` publishes the packed tree through `process.env`.** Playwright workers inherit it because they are forked after global setup runs; the added spec is what proves that rather than assuming it. The tree is removed when the process that built it exits.
- **The recovery helper is stricter.** Callers that pass no status keep the old, weaker wait, so only the one caller asserting a settled status changed behaviour. The other twelve discard the record.
- **Row counts in table skeletons are arbitrary** (3, or 1–2 for short tables). They set the height the page settles into, so a table that usually holds many more rows will still shift when data lands.
