### PR TITLE
Make adding a connection provider a compile-time contract

### DIFF
--- a/src/configuration/store.ts
+++ b/src/configuration/store.ts
@@ -1,4 +1,5 @@
 import { dump } from "js-yaml";
+import { assertNever } from "../exhaustive.js";
 import { z } from "zod";
 import {
   compiledConfigurationHash,
@@ -691,14 +692,21 @@ async function compileTriggers(
   return { triggers: compiled, routes, issues };
 }
 
+/**
+ * Keyed by every connection provider, so widening `ConnectionProvider` fails to compile here
+ * rather than silently classifying a new provider's events as belonging to no provider at all.
+ */
+const PROVIDERS_BY_EVENT_PREFIX: ReadonlyMap<string, ConnectionProvider> = new Map(
+  Object.entries({
+    github: "github",
+    slack: "slack",
+    discord: "discord",
+    linear: "linear",
+  } satisfies Record<ConnectionProvider, ConnectionProvider>),
+);
+
 function providerForEvent(eventName: string): ConnectionProvider | undefined {
-  const provider = eventName.slice(0, eventName.indexOf("."));
-  return provider === "github" ||
-    provider === "slack" ||
-    provider === "discord" ||
-    provider === "linear"
-    ? provider
-    : undefined;
+  return PROVIDERS_BY_EVENT_PREFIX.get(eventName.slice(0, eventName.indexOf(".")));
 }
 
 function readAuthoredResource(
@@ -706,11 +714,9 @@ function readAuthoredResource(
   filters: CompiledTrigger["filters"] | undefined,
 ): string | undefined {
   if (filters === undefined) return undefined;
-  let value: string | undefined;
-  if (provider === "github") value = filters.repo;
-  else if (provider === "slack") value = filters.workspace;
-  else if (provider === "discord") value = filters.guild;
-  else value = filters.project;
+  // Reads the same provider→filter-key mapping the authoring errors quote, rather than keeping a
+  // second copy of it that can drift.
+  const value = filters[resourceField(provider)];
   return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 
@@ -732,36 +738,42 @@ async function resolveResource(
   resource: string,
   allowedConnectionIds: ReadonlySet<string>,
 ): Promise<{ connectionId: string; resourceId: string } | undefined> {
-  if (provider === "github") {
-    const repositories = (await database.listGitHubRepositories(organizationId)).filter(
-      (repository) =>
-        repository.fullName === resource && allowedConnectionIds.has(repository.connectionId),
-    );
-    if (repositories.length !== 1) return undefined;
-    const repository = repositories[0]!;
-    return { connectionId: repository.connectionId, resourceId: String(repository.repositoryId) };
+  switch (provider) {
+    case "github": {
+      const repositories = (await database.listGitHubRepositories(organizationId)).filter(
+        (repository) =>
+          repository.fullName === resource && allowedConnectionIds.has(repository.connectionId),
+      );
+      if (repositories.length !== 1) return undefined;
+      const repository = repositories[0]!;
+      return { connectionId: repository.connectionId, resourceId: String(repository.repositoryId) };
+    }
+    case "slack": {
+      const connection = (await database.organizationConnectionUsage(organizationId)).slack.find(
+        ({ id, slug }) => slug === resource && allowedConnectionIds.has(id),
+      );
+      return connection === undefined
+        ? undefined
+        : { connectionId: connection.id, resourceId: connection.teamId };
+    }
+    case "discord": {
+      const connection = (await database.organizationConnectionUsage(organizationId)).discord.find(
+        ({ id, slug }) => slug === resource && allowedConnectionIds.has(id),
+      );
+      return connection === undefined
+        ? undefined
+        : { connectionId: connection.id, resourceId: connection.guildId };
+    }
+    case "linear": {
+      const connections = (
+        await database.organizationConnectionUsage(organizationId)
+      ).linear.filter(({ id }) => allowedConnectionIds.has(id));
+      if (connections.length !== 1) return undefined;
+      return { connectionId: connections[0]!.id, resourceId: resource };
+    }
+    default:
+      return assertNever(provider, "resolveResource");
   }
-  if (provider === "slack") {
-    const connection = (await database.organizationConnectionUsage(organizationId)).slack.find(
-      ({ id, slug }) => slug === resource && allowedConnectionIds.has(id),
-    );
-    return connection === undefined
-      ? undefined
-      : { connectionId: connection.id, resourceId: connection.teamId };
-  }
-  if (provider === "linear") {
-    const connections = (await database.organizationConnectionUsage(organizationId)).linear.filter(
-      ({ id }) => allowedConnectionIds.has(id),
-    );
-    if (connections.length !== 1) return undefined;
-    return { connectionId: connections[0]!.id, resourceId: resource };
-  }
-  const connection = (await database.organizationConnectionUsage(organizationId)).discord.find(
-    ({ id, slug }) => slug === resource && allowedConnectionIds.has(id),
-  );
-  return connection === undefined
-    ? undefined
-    : { connectionId: connection.id, resourceId: connection.guildId };
 }
 
 function triggerFilterPath(trigger: CompiledTrigger, field: string): readonly (string | number)[] {
@@ -769,15 +781,33 @@ function triggerFilterPath(trigger: CompiledTrigger, field: string): readonly (s
 }
 
 function resourceField(provider: ConnectionProvider): "repo" | "workspace" | "guild" | "project" {
-  if (provider === "github") return "repo";
-  if (provider === "slack") return "workspace";
-  return provider === "discord" ? "guild" : "project";
+  switch (provider) {
+    case "github":
+      return "repo";
+    case "slack":
+      return "workspace";
+    case "discord":
+      return "guild";
+    case "linear":
+      return "project";
+    default:
+      return assertNever(provider, "resourceField");
+  }
 }
 
 function providerLabel(provider: ConnectionProvider): string {
-  if (provider === "github") return "GitHub";
-  if (provider === "slack") return "Slack";
-  return provider === "discord" ? "Discord" : "Linear";
+  switch (provider) {
+    case "github":
+      return "GitHub";
+    case "slack":
+      return "Slack";
+    case "discord":
+      return "Discord";
+    case "linear":
+      return "Linear";
+    default:
+      return assertNever(provider, "providerLabel");
+  }
 }
 
 function resourceLabel(provider: ConnectionProvider): string {

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -1,4 +1,9 @@
-import type { AgentExecutionStatus, MachineSource, MachineStatus } from "./schema.js";
+import type {
+  AgentExecutionStatus,
+  CONNECTION_PROVIDERS,
+  MachineSource,
+  MachineStatus,
+} from "./schema.js";
 import type { JsonValue } from "../config/compiler.js";
 import type { LaunchMachineIntent } from "../dispatcher/launch-machine-intent.js";
 import type { InvocationRejection } from "../triggers/invocation.js";
@@ -354,7 +359,13 @@ export interface PendingProjectTriggerMigration {
   revision: ProjectConfigurationRevisionRecord;
 }
 
-export type ConnectionProvider = "github" | "discord" | "slack" | "linear";
+/**
+ * Derived from the schema constant rather than spelled out again, so a provider added to
+ * CONNECTION_PROVIDERS reaches every exhaustive switch and `satisfies Record<...>` map that
+ * keys off this type. Two independent spellings would let the array grow while the dispatch
+ * sites kept compiling.
+ */
+export type ConnectionProvider = (typeof CONNECTION_PROVIDERS)[number];
 
 export type ConnectionAttemptPhase =
   | "github_setup"

--- a/src/exhaustive.ts
+++ b/src/exhaustive.ts
@@ -1,0 +1,13 @@
+/**
+ * Call this in the `default` branch of a switch over a value that should be exhaustive.
+ * TypeScript treats the parameter as `never` if all cases are handled, so adding a new value
+ * to the union turns this into a compile error at the switch site rather than a silent fallthrough.
+ *
+ * @param value The switch discriminant — TypeScript infers `never` if all cases are covered.
+ * @param context Optional label for the error message, e.g. `"connectionTable"`.
+ */
+export function assertNever(value: never, context?: string): never {
+  throw new Error(
+    `Unhandled value${context === undefined ? "" : ` in ${context}`}: ${String(value)}`,
+  );
+}

--- a/src/failures/index.ts
+++ b/src/failures/index.ts
@@ -3,6 +3,7 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import type { Logger } from "pino";
 import { respondError, type Err } from "../contract/respond.js";
 import { errorForLog, logger as defaultLogger, redact } from "../logger.js";
+import type { ConnectionProvider } from "../db/types.js";
 import { withReference } from "./reference.js";
 
 export { withReference } from "./reference.js";
@@ -24,7 +25,8 @@ export type FailureKind =
 export interface FailureContext {
   operation: string;
   component: string;
-  provider?: "github" | "slack" | "discord" | "linear" | "stripe";
+  /** A `ConnectionProvider` (e.g. `"slack"`) or a billing provider (`"stripe"`). */
+  provider?: ConnectionProvider | "stripe";
   requestId?: string;
   status?: number;
   organizationSlug?: string;

--- a/src/projects/activity-summary.ts
+++ b/src/projects/activity-summary.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { assertNever } from "../exhaustive.js";
 import { reportFailure } from "../failures/index.js";
 import {
   IssueCommentPayloadSchema,
@@ -13,9 +14,10 @@ import { NormalizedDiscordMessageEventSchema } from "../triggers/discord/events.
 import { NormalizedSlackMentionEventSchema } from "../triggers/slack/events.js";
 import { NormalizedLinearEventSchema } from "../triggers/linear/events.js";
 import { classifyGitHubEvent } from "../triggers/github/classification.js";
+import type { ConnectionProvider } from "../db/types.js";
 
 export interface TriggerSummary {
-  provider: "github" | "slack" | "discord" | "linear" | "manual";
+  provider: ConnectionProvider | "manual";
   headline: string;
   actor: string | null;
   externalUrl: string | null;
@@ -31,12 +33,40 @@ const ManualTriggerPayloadSchema = z
  * everywhere else treats a trigger as an opaque id.
  */
 export function summarizeTrigger(source: string, payload: unknown): TriggerSummary {
-  const [provider] = source.split(".");
-  if (provider === "github") return summarizeGitHub(payload);
-  if (provider === "slack") return summarizeSlack(payload);
-  if (provider === "discord") return summarizeDiscord(payload);
-  if (provider === "linear") return summarizeLinear(payload);
-  return summarizeManual(payload);
+  const provider = providerForSource(source);
+  // A manual run, and anything whose prefix names no provider, has no payload shape to read.
+  if (provider === undefined) return summarizeManual(payload);
+  switch (provider) {
+    case "github":
+      return summarizeGitHub(payload);
+    case "slack":
+      return summarizeSlack(payload);
+    case "discord":
+      return summarizeDiscord(payload);
+    case "linear":
+      return summarizeLinear(payload);
+    default:
+      return assertNever(provider, "summarizeTrigger");
+  }
+}
+
+/**
+ * Keyed by every connection provider, so a provider added to `ConnectionProvider` without a
+ * summarizer here fails to compile. Without it the event falls through to `summarizeManual` and
+ * a thing a person did on Slack or Discord is reported as a manual run.
+ */
+const PROVIDERS_BY_SOURCE_PREFIX: ReadonlyMap<string, ConnectionProvider> = new Map(
+  Object.entries({
+    github: "github",
+    slack: "slack",
+    discord: "discord",
+    linear: "linear",
+  } satisfies Record<ConnectionProvider, ConnectionProvider>),
+);
+
+function providerForSource(source: string): ConnectionProvider | undefined {
+  const [prefix] = source.split(".");
+  return prefix === undefined ? undefined : PROVIDERS_BY_SOURCE_PREFIX.get(prefix);
 }
 
 interface GitHubHeadline {

--- a/src/provider-applications/internal/inventory.test.ts
+++ b/src/provider-applications/internal/inventory.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { describe, it } from "vitest";
+import { CONNECTION_PROVIDERS } from "../../db/schema.js";
+import { connectionIdentityQuery, connectionTable } from "./inventory.js";
+
+/**
+ * Direct coverage for the two provider→table and provider→query mappings in inventory.ts.
+ *
+ * The failure mode they guard against: both functions previously fell through to a bare else
+ * that returned discord_connections for any unrecognised provider, so a new provider added to
+ * CONNECTION_PROVIDERS would silently touch Discord's rows instead of failing loudly.
+ *
+ * The `satisfies` compile-time guard ensures that if CONNECTION_PROVIDERS gains a new member,
+ * the expected table map below stops compiling until someone adds a matching entry.
+ */
+describe("inventory provider mappings", () => {
+  const EXPECTED_TABLES = {
+    github: "github_connections",
+    slack: "slack_connections",
+    discord: "discord_connections",
+    linear: "linear_connections",
+  } satisfies Record<(typeof CONNECTION_PROVIDERS)[number], string>;
+
+  it("connectionTable returns the correct table for every provider", () => {
+    for (const provider of CONNECTION_PROVIDERS) {
+      assert.equal(connectionTable(provider), EXPECTED_TABLES[provider]);
+    }
+  });
+
+  it("every provider maps to a distinct table", () => {
+    const tables = CONNECTION_PROVIDERS.map(connectionTable);
+    assert.equal(new Set(tables).size, tables.length);
+  });
+
+  it("connectionIdentityQuery reads from the provider's own table and no other provider's table", () => {
+    for (const provider of CONNECTION_PROVIDERS) {
+      const query = connectionIdentityQuery(provider);
+      const ownTable = EXPECTED_TABLES[provider];
+
+      assert.ok(query.includes(ownTable), `query for "${provider}" should mention ${ownTable}`);
+
+      for (const other of CONNECTION_PROVIDERS) {
+        if (other === provider) continue;
+        const otherTable = EXPECTED_TABLES[other];
+        assert.ok(
+          !query.includes(otherTable),
+          `query for "${provider}" should not mention ${otherTable}`,
+        );
+      }
+    }
+  });
+});

--- a/src/provider-applications/internal/inventory.ts
+++ b/src/provider-applications/internal/inventory.ts
@@ -1,6 +1,7 @@
 import type { DatabaseRuntime, QueryRow } from "../../db/runtime/index.js";
 import { linearConnectionRequiresReauthorization } from "../../providers/linear/client.js";
 import { hasRequiredSlackScopes } from "../../providers/slack/client.js";
+import { assertNever } from "../../exhaustive.js";
 import type { Provider, ProviderApplicationInventory } from "../index.js";
 
 interface ConnectionIdentityRow extends QueryRow {
@@ -75,36 +76,48 @@ export function createProviderApplicationInventory(
   };
 }
 
-function connectionTable(provider: Provider): string {
-  if (provider === "github") return "github_connections";
-  if (provider === "slack") return "slack_connections";
-  if (provider === "linear") return "linear_connections";
-  return "discord_connections";
+/** @package — exported for tests only; treat as internal to this directory. */
+export function connectionTable(provider: Provider): string {
+  switch (provider) {
+    case "github":
+      return "github_connections";
+    case "slack":
+      return "slack_connections";
+    case "discord":
+      return "discord_connections";
+    case "linear":
+      return "linear_connections";
+    default:
+      return assertNever(provider, "connectionTable");
+  }
 }
 
-function connectionIdentityQuery(provider: Provider): string {
-  if (provider === "github") {
-    return `select id::text as id, account_login as name,
-                   provider_application_id as application_id,
-                   status = 'suspended' as action_needed, null::jsonb as scopes
-            from github_connections order by connected_at`;
+/** @package — exported for tests only; treat as internal to this directory. */
+export function connectionIdentityQuery(provider: Provider): string {
+  switch (provider) {
+    case "github":
+      return `select id::text as id, account_login as name,
+                     provider_application_id as application_id,
+                     status = 'suspended' as action_needed, null::jsonb as scopes
+              from github_connections order by connected_at`;
+    case "slack":
+      return `select id::text as id, team_name as name,
+                     provider_application_id as application_id,
+                     false as action_needed, scopes
+              from slack_connections order by connected_at`;
+    case "discord":
+      return `select id::text as id, guild_name as name,
+                     provider_application_id as application_id,
+                     false as action_needed, null::jsonb as scopes
+              from discord_connections order by connected_at`;
+    case "linear":
+      return `select id::text as id, linear_organization_name as name,
+                     provider_application_id as application_id,
+                     false as action_needed, scopes, refresh_token, access_token_expires_at
+              from linear_connections order by connected_at`;
+    default:
+      return assertNever(provider, "connectionIdentityQuery");
   }
-  if (provider === "slack") {
-    return `select id::text as id, team_name as name,
-                   provider_application_id as application_id,
-                   false as action_needed, scopes
-            from slack_connections order by connected_at`;
-  }
-  if (provider === "linear") {
-    return `select id::text as id, linear_organization_name as name,
-                   provider_application_id as application_id,
-                   false as action_needed, scopes, refresh_token, access_token_expires_at
-            from linear_connections order by connected_at`;
-  }
-  return `select id::text as id, guild_name as name,
-                 provider_application_id as application_id,
-                 false as action_needed, null::jsonb as scopes
-          from discord_connections order by connected_at`;
 }
 
 function linearConnectionActionNeeded(row: ConnectionIdentityRow): boolean {

--- a/src/providers/provider-union.test.ts
+++ b/src/providers/provider-union.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { describe, it } from "vitest";
+import { CONNECTION_PROVIDERS } from "../db/schema.js";
+import type { ConnectionProvider } from "../db/types.js";
+import type { FailureContext } from "../failures/index.js";
+import type { logProviderEventIntake } from "../triggers/audit.js";
+import { summarizeTrigger, type TriggerSummary } from "../projects/activity-summary.js";
+
+/**
+ * The provider union is spelled out in several modules that cannot all import each other. These
+ * assignments are the guard: adding a provider to one spelling without the others stops this file
+ * from compiling. They have to be compile-time, because a provider missing from a switch or a
+ * lookup table never reaches runtime to be asserted on.
+ */
+describe("connection provider union", () => {
+  it("lists every provider exactly once in the schema constant", () => {
+    assert.equal(new Set(CONNECTION_PROVIDERS).size, CONNECTION_PROVIDERS.length);
+  });
+
+  it("agrees on the provider union across the schema, audit, failures, and activity surfaces", () => {
+    // Each assignment must compile. If a surface's provider type widens (e.g. audit gains a
+    // new literal) but ConnectionProvider doesn't, backToSchema fails. If ConnectionProvider
+    // gains a new member but a surface forgets to widen, the forward assignment fails.
+
+    const fromSchema: ConnectionProvider = CONNECTION_PROVIDERS[0];
+    const backToSchema: (typeof CONNECTION_PROVIDERS)[number] = fromSchema;
+
+    // audit.ts: provider must be exactly ConnectionProvider (no wider, no narrower)
+    const auditProvider: Parameters<typeof logProviderEventIntake>[0]["provider"] = fromSchema;
+    const backFromAudit: ConnectionProvider = auditProvider;
+
+    // failures/index.ts: provider accepts ConnectionProvider (may also accept "stripe")
+    const failureProvider: FailureContext["provider"] = fromSchema;
+
+    // activity-summary.ts: provider accepts ConnectionProvider (may also accept "manual")
+    const summaryProvider: TriggerSummary["provider"] = fromSchema;
+
+    assert.ok(CONNECTION_PROVIDERS.includes(backToSchema));
+    assert.equal(backFromAudit, fromSchema);
+    assert.equal(failureProvider, fromSchema);
+    assert.equal(summaryProvider, fromSchema);
+  });
+
+  it("summarizes an event from every provider as that provider, never as a manual run", () => {
+    // The compile-time half above only proves the *type* admits every provider. This is the
+    // runtime half: summarizeTrigger dispatches on the source prefix, and a provider without a
+    // branch there does not fail — it quietly reports a person's message as a manual run.
+    for (const provider of CONNECTION_PROVIDERS) {
+      const summary = summarizeTrigger(`${provider}.mention`, {});
+      assert.equal(summary.provider, provider);
+    }
+
+    assert.equal(summarizeTrigger("manual.run", {}).provider, "manual");
+    assert.equal(summarizeTrigger("", {}).provider, "manual");
+  });
+});

--- a/src/triggers/audit.ts
+++ b/src/triggers/audit.ts
@@ -1,11 +1,11 @@
 import type { Logger } from "pino";
-import type { ProviderEventAcceptance } from "../db/types.js";
+import type { ConnectionProvider, ProviderEventAcceptance } from "../db/types.js";
 import { logger } from "../logger.js";
 
 type EventAuditLogger = Pick<Logger, "info">;
 
 export function logProviderEventIntake(input: {
-  provider: "github" | "slack" | "discord" | "linear";
+  provider: ConnectionProvider;
   source: string;
   deliveryId: string;
   acceptance: ProviderEventAcceptance;

--- a/src/triggers/discord/provider.ts
+++ b/src/triggers/discord/provider.ts
@@ -16,6 +16,7 @@ import {
   readDiscordPromptBody,
 } from "./match.js";
 import { matchesInputFilters, parseInvocation } from "../invocation.js";
+import { reactionPhase, type ReactionPhase } from "../reactions.js";
 import { NormalizedDiscordMessageEventSchema } from "./events.js";
 import type { NormalizedDiscordContextMessage, NormalizedDiscordMessageEvent } from "./events.js";
 
@@ -85,8 +86,6 @@ export interface DiscordOutputContext {
   threadId: string | null;
   messageId: string;
 }
-
-type DiscordReactionPhase = "accepted" | "started";
 
 export function createDiscordTriggerProvider(options: {
   configurationStoreForProject: (projectId: string) => ProjectConfigurationStore;
@@ -210,12 +209,12 @@ export function createDiscordTriggerProvider(options: {
       };
     },
     async onDispatchAccepted(triggerContext, _outputContext, reactionState) {
-      if (discordReactionPhase(reactionState) !== undefined) return reactionState;
+      if (reactionPhase(reactionState) !== undefined) return reactionState;
       await reactSafely(options.bot, triggerContext.target, "eyes");
       return { phase: "accepted" };
     },
     async onAgentExecutionStarted(triggerContext, _outputContext, reactionState) {
-      if (discordReactionPhase(reactionState) === "started") return reactionState;
+      if (reactionPhase(reactionState) === "started") return reactionState;
       await deleteReactionSafely(options.bot, triggerContext.target, "eyes");
       await reactSafely(options.bot, triggerContext.target, "hourglass");
       return { phase: "started" };
@@ -284,9 +283,9 @@ async function deleteReactionForPhase(
   bot: DiscordBotClient,
   target: DiscordOutputContext,
   reactionState: TriggerProviderReactionState | undefined,
-  fallbackPhase?: DiscordReactionPhase,
+  fallbackPhase?: ReactionPhase,
 ): Promise<void> {
-  const phase = discordReactionPhase(reactionState) ?? fallbackPhase;
+  const phase = reactionPhase(reactionState) ?? fallbackPhase;
   if (phase === "accepted") {
     await deleteReactionSafely(bot, target, "eyes");
     return;
@@ -297,16 +296,6 @@ async function deleteReactionForPhase(
   }
   await deleteReactionSafely(bot, target, "eyes");
   await deleteReactionSafely(bot, target, "hourglass");
-}
-
-function discordReactionPhase(
-  reactionState: TriggerProviderReactionState | undefined,
-): DiscordReactionPhase | undefined {
-  if (typeof reactionState !== "object" || reactionState === null || Array.isArray(reactionState)) {
-    return undefined;
-  }
-  const phase = reactionState["phase"];
-  return phase === "accepted" || phase === "started" ? phase : undefined;
 }
 
 function buildDiscordMergeData(

--- a/src/triggers/github/webhook.ts
+++ b/src/triggers/github/webhook.ts
@@ -10,8 +10,13 @@ import { readBoundedRequestBody } from "../../http/request-body.js";
 import type { TriggerHandler, TriggerSource } from "../index.js";
 import type { ProviderEventDropReasonCode } from "../drop-reason.js";
 import { logProviderEventIntake } from "../audit.js";
+import {
+  createWebhookHandlerRegistry,
+  dispatchWebhookEvents,
+  MAX_WEBHOOK_BYTES,
+  parseWebhookJsonBody,
+} from "../webhook-shared.js";
 
-const MAX_WEBHOOK_BYTES = 1_048_576;
 const MAX_HEADER_LENGTH = 128;
 
 export interface WebhookSourceOptions {
@@ -63,7 +68,7 @@ export function createWebhookSource(
   secret: string | undefined,
   options: WebhookSourceOptions,
 ): WebhookEndpoint {
-  const handlers = new Set<TriggerHandler>();
+  const registry = createWebhookHandlerRegistry();
 
   async function handle(request: Request): Promise<Response> {
     if (secret === undefined) {
@@ -74,7 +79,7 @@ export function createWebhookSource(
     if (verified instanceof Response) return verified;
 
     try {
-      return await handleVerifiedWebhook(verified, options, handlers);
+      return await handleVerifiedWebhook(verified, options, registry.handlers);
     } catch (error) {
       reportFailure(
         error,
@@ -96,15 +101,7 @@ export function createWebhookSource(
     }
   }
 
-  return {
-    handle,
-    async start(nextHandler: TriggerHandler): Promise<void> {
-      handlers.add(nextHandler);
-    },
-    async stop(): Promise<void> {
-      handlers.clear();
-    },
-  };
+  return { handle, start: registry.start, stop: registry.stop };
 }
 
 async function handleVerifiedWebhook(
@@ -174,7 +171,7 @@ async function handleVerifiedWebhook(
 
   if (acceptance.status !== "accepted") return new Response("OK", { status: 200 });
 
-  return dispatchWebhook(handlers, acceptance.events);
+  return dispatchWebhookEvents(handlers, acceptance.events);
 }
 
 async function verifyWebhookRequest(
@@ -212,20 +209,15 @@ async function verifyWebhookRequest(
     return new Response("Bad Request", { status: 400 });
   }
 
-  let rawJson: unknown;
+  const parsed = parseWebhookJsonBody({
+    body: captured,
+    operation: "github.webhook.parse",
+    provider: "github",
+    scrubValues: [secret, signature],
+  });
+  if (parsed instanceof Response) return parsed;
 
-  try {
-    rawJson = JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(captured));
-  } catch (error) {
-    reportFailure(
-      error,
-      { operation: "github.webhook.parse", component: "triggers", provider: "github", status: 400 },
-      { status: 400, scrubValues: [secret, signature] },
-    );
-    return Response.json({ error: "request body must be valid JSON" }, { status: 400 });
-  }
-
-  const parsedBody = WebhookPayloadSchema.safeParse(rawJson);
+  const parsedBody = WebhookPayloadSchema.safeParse(parsed.payload);
 
   if (!parsedBody.success) {
     reportGitHubRejection("invalid_payload", 400, secret, signature);
@@ -289,17 +281,6 @@ async function handleLifecycle(
     },
     "provider lifecycle event applied",
   );
-  return new Response("OK", { status: 200 });
-}
-
-async function dispatchWebhook(
-  handlers: Set<TriggerHandler>,
-  triggers: readonly Parameters<TriggerHandler>[0][],
-): Promise<Response> {
-  await Promise.all(
-    triggers.flatMap((trigger) => Array.from(handlers, (handler) => handler(trigger))),
-  );
-
   return new Response("OK", { status: 200 });
 }
 

--- a/src/triggers/linear/webhook.ts
+++ b/src/triggers/linear/webhook.ts
@@ -5,10 +5,15 @@ import { logger } from "../../logger.js";
 import { logProviderEventIntake } from "../audit.js";
 import type { ProviderEventDropReasonCode } from "../drop-reason.js";
 import type { TriggerHandler, TriggerSource } from "../index.js";
+import {
+  createWebhookHandlerRegistry,
+  dispatchWebhookEvents,
+  MAX_WEBHOOK_BYTES,
+  parseWebhookJsonBody,
+} from "../webhook-shared.js";
 import { eventIssueId, eventProjectId, normalizeLinearEvent } from "./events.js";
 import type { LinearIssueDetails } from "../../providers/linear/client.js";
 
-const MAX_WEBHOOK_BYTES = 1_048_576;
 const MAX_TIMESTAMP_SKEW_MS = 60_000;
 
 export interface LinearWebhookSourceOptions {
@@ -46,19 +51,15 @@ interface VerifiedLinearRequest {
 export function createLinearWebhookSource(
   options: LinearWebhookSourceOptions,
 ): LinearWebhookEndpoint {
-  const handlers = new Set<TriggerHandler>();
+  const registry = createWebhookHandlerRegistry();
   return {
     async handle(request) {
       const verified = await verifyLinearRequest(request, options);
       if (verified instanceof Response) return verified;
-      return handoffLinearEvent(verified, handlers, options);
+      return handoffLinearEvent(verified, registry.handlers, options);
     },
-    async start(handler) {
-      handlers.add(handler);
-    },
-    async stop() {
-      handlers.clear();
-    },
+    start: registry.start,
+    stop: registry.stop,
   };
 }
 
@@ -82,13 +83,14 @@ async function verifyLinearRequest(
     logger.warn("rejecting Linear event because signature verification failed");
     return new Response("Unauthorized", { status: 401 });
   }
-  let payload: unknown;
-  try {
-    payload = JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(body));
-  } catch {
-    logger.warn("rejecting Linear event because payload is invalid JSON");
-    return Response.json({ error: "request body must be valid JSON" }, { status: 400 });
-  }
+  const parsed = parseWebhookJsonBody({
+    body,
+    operation: "linear.webhook.parse",
+    provider: "linear",
+    scrubValues: [options.signingSecret, signature],
+  });
+  if (parsed instanceof Response) return parsed;
+  const payload = parsed.payload;
   const receivedAt = new Date(options.now?.() ?? Date.now());
   if (!verifyLinearWebhookTimestamp(payload, receivedAt.getTime())) {
     logger.warn("rejecting Linear event because its signed webhook timestamp is stale or invalid");
@@ -173,11 +175,7 @@ async function acceptAndDispatchLinearEvent(
     resourceId: projectId,
     acceptance,
   });
-  const events = acceptance.status === "accepted" ? acceptance.events : [];
-  await Promise.all(
-    events.flatMap((acceptedEvent) => Array.from(handlers, (handler) => handler(acceptedEvent))),
-  );
-  return new Response("OK", { status: 200 });
+  return dispatchWebhookEvents(handlers, acceptance.status === "accepted" ? acceptance.events : []);
 }
 
 function linearEventSource(

--- a/src/triggers/reactions.ts
+++ b/src/triggers/reactions.ts
@@ -1,0 +1,23 @@
+import type { TriggerProviderReactionState } from "./index.js";
+
+/**
+ * The two phases every chat-provider reaction machine tracks. The state is stored as a plain
+ * object in `TriggerProviderReactionState` so it survives serialisation across execution steps.
+ */
+export type ReactionPhase = "accepted" | "started";
+
+/**
+ * Reads the current reaction phase from an opaque `TriggerProviderReactionState`. Returns
+ * `undefined` when the state is absent, not an object, or does not carry a recognised phase —
+ * callers treat that the same as "no reaction has been posted yet".
+ *
+ * This is the only place that interprets the phase field. Chat providers (currently Slack and
+ * Discord) share the same phase semantics; only their emoji primitives differ.
+ */
+export function reactionPhase(
+  state: TriggerProviderReactionState | undefined,
+): ReactionPhase | undefined {
+  if (typeof state !== "object" || state === null || Array.isArray(state)) return undefined;
+  const phase = (state as Record<string, unknown>)["phase"];
+  return phase === "accepted" || phase === "started" ? phase : undefined;
+}

--- a/src/triggers/slack/provider.ts
+++ b/src/triggers/slack/provider.ts
@@ -18,6 +18,7 @@ import {
   readSlackPromptBody,
 } from "./match.js";
 import { matchesInputFilters, parseInvocation } from "../invocation.js";
+import { reactionPhase, type ReactionPhase } from "../reactions.js";
 
 export interface SlackAttachmentLocator {
   id: string;
@@ -94,8 +95,6 @@ export interface SlackOutputContext {
   threadTs: string;
   messageTs: string;
 }
-
-type SlackReactionPhase = "accepted" | "started";
 
 export function createSlackTriggerProvider(options: {
   configurationStoreForProject: (projectId: string) => ProjectConfigurationStore;
@@ -239,11 +238,11 @@ export function createSlackTriggerProvider(options: {
       };
     },
     async onDispatchAccepted(_triggerContext, _outputContext, reactionState) {
-      if (slackReactionPhase(reactionState) !== undefined) return reactionState;
+      if (reactionPhase(reactionState) !== undefined) return reactionState;
       return { phase: "accepted" };
     },
     async onAgentExecutionStarted(context, _outputContext, reactionState) {
-      if (slackReactionPhase(reactionState) === "started") return reactionState;
+      if (reactionPhase(reactionState) === "started") return reactionState;
       await replaceReaction(options.client, context.target, "eyes", "hourglass_flowing_sand");
       return { phase: "started" };
     },
@@ -306,9 +305,9 @@ async function removeReactionForPhase(
   client: SlackBotClient,
   target: SlackOutputContext,
   reactionState: TriggerProviderReactionState | undefined,
-  fallbackPhase?: SlackReactionPhase,
+  fallbackPhase?: ReactionPhase,
 ): Promise<void> {
-  const phase = slackReactionPhase(reactionState) ?? fallbackPhase;
+  const phase = reactionPhase(reactionState) ?? fallbackPhase;
   if (phase === "accepted") {
     await removeReactionSafely(client, target, "eyes");
     return;
@@ -319,16 +318,6 @@ async function removeReactionForPhase(
   }
   await removeReactionSafely(client, target, "eyes");
   await removeReactionSafely(client, target, "hourglass_flowing_sand");
-}
-
-function slackReactionPhase(
-  reactionState: TriggerProviderReactionState | undefined,
-): SlackReactionPhase | undefined {
-  if (typeof reactionState !== "object" || reactionState === null || Array.isArray(reactionState)) {
-    return undefined;
-  }
-  const phase = reactionState["phase"];
-  return phase === "accepted" || phase === "started" ? phase : undefined;
 }
 
 function buildSlackMergeData(

--- a/src/triggers/slack/webhook.ts
+++ b/src/triggers/slack/webhook.ts
@@ -7,8 +7,12 @@ import type { TriggerHandler, TriggerSource } from "../index.js";
 import type { ProviderEventDropReasonCode } from "../drop-reason.js";
 import { intakeSlackEvent, SlackEventIntakeValidationError } from "./source/internal/intake.js";
 import { SlackUrlVerificationSchema } from "./events.js";
+import {
+  createWebhookHandlerRegistry,
+  MAX_WEBHOOK_BYTES,
+  parseWebhookJsonBody,
+} from "../webhook-shared.js";
 
-const MAX_WEBHOOK_BYTES = 1_048_576;
 const MAX_TIMESTAMP_SKEW_SECONDS = 5 * 60;
 const SlackEnvelopeTypeSchema = z.object({ type: z.string() }).passthrough();
 
@@ -37,20 +41,16 @@ interface VerifiedSlackRequest {
 }
 
 export function createSlackWebhookSource(options: SlackWebhookSourceOptions): SlackWebhookEndpoint {
-  const handlers = new Set<TriggerHandler>();
+  const registry = createWebhookHandlerRegistry();
 
   return {
     async handle(request) {
       const verified = await verifySlackRequest(request, options);
       if (verified instanceof Response) return verified;
-      return handleVerifiedSlackRequest(verified, handlers, options);
+      return handleVerifiedSlackRequest(verified, registry.handlers, options);
     },
-    async start(handler) {
-      handlers.add(handler);
-    },
-    async stop() {
-      handlers.clear();
-    },
+    start: registry.start,
+    stop: registry.stop,
   };
 }
 
@@ -72,19 +72,18 @@ async function verifySlackRequest(
     return new Response("Unauthorized", { status: 401 });
   }
 
-  let payload: unknown;
-  try {
-    payload = JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(body));
-  } catch (error) {
-    reportFailure(
-      error,
-      { operation: "slack.webhook.parse", component: "triggers", provider: "slack", status: 400 },
-      { status: 400, scrubValues: [options.signingSecret] },
-    );
-    return Response.json({ error: "request body must be valid JSON" }, { status: 400 });
-  }
+  const parsed = parseWebhookJsonBody({
+    body,
+    operation: "slack.webhook.parse",
+    provider: "slack",
+    scrubValues: [options.signingSecret],
+  });
+  if (parsed instanceof Response) return parsed;
 
-  return { payload, signatureHash: createHash("sha256").update(signature).digest("hex") };
+  return {
+    payload: parsed.payload,
+    signatureHash: createHash("sha256").update(signature).digest("hex"),
+  };
 }
 
 async function handleVerifiedSlackRequest(

--- a/src/triggers/webhook-shared.ts
+++ b/src/triggers/webhook-shared.ts
@@ -1,0 +1,79 @@
+import type { FailureContext } from "../failures/index.js";
+import { reportFailure } from "../failures/index.js";
+import type { DurableProviderEvent } from "../db/types.js";
+import type { TriggerHandler } from "./index.js";
+
+/**
+ * The largest webhook body any provider will read. Deliveries above this are refused with 413
+ * before the body is buffered, so a hostile or runaway sender cannot exhaust memory.
+ */
+export const MAX_WEBHOOK_BYTES = 1_048_576;
+
+/**
+ * Successful parse result. `unknown | Response` collapses to `unknown`, so the value is wrapped
+ * to keep the `instanceof Response` discrimination the call sites rely on.
+ */
+export interface ParsedWebhookBody {
+  payload: unknown;
+}
+
+/**
+ * Decodes strict UTF-8 and parses JSON, returning a 400 `Response` on either failure. Strict
+ * decoding matters: a lenient decoder would silently replace invalid bytes and hand downstream
+ * validation a payload that differs from what the provider actually sent.
+ */
+export function parseWebhookJsonBody(input: {
+  body: Uint8Array;
+  operation: string;
+  provider: FailureContext["provider"];
+  scrubValues: readonly string[];
+}): ParsedWebhookBody | Response {
+  try {
+    return { payload: JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(input.body)) };
+  } catch (error) {
+    reportFailure(
+      error,
+      {
+        operation: input.operation,
+        component: "triggers",
+        ...(input.provider === undefined ? {} : { provider: input.provider }),
+        status: 400,
+      },
+      { status: 400, scrubValues: [...input.scrubValues] },
+    );
+    return Response.json({ error: "request body must be valid JSON" }, { status: 400 });
+  }
+}
+
+export interface WebhookHandlerRegistry {
+  handlers: Set<TriggerHandler>;
+  start: (handler: TriggerHandler) => Promise<void>;
+  stop: () => Promise<void>;
+}
+
+/**
+ * The `TriggerSource` start/stop pair every webhook provider implements identically. The set is
+ * exposed because handlers must also be counted (an empty registry means the runtime has no
+ * configuration loaded yet, which providers report as a `configuration_unavailable` drop).
+ */
+export function createWebhookHandlerRegistry(): WebhookHandlerRegistry {
+  const handlers = new Set<TriggerHandler>();
+  return {
+    handlers,
+    start: async (handler: TriggerHandler): Promise<void> => {
+      handlers.add(handler);
+    },
+    stop: async (): Promise<void> => {
+      handlers.clear();
+    },
+  };
+}
+
+/** Fans one accepted delivery out to every registered handler and answers the provider with 200. */
+export async function dispatchWebhookEvents(
+  handlers: ReadonlySet<TriggerHandler>,
+  events: readonly DurableProviderEvent[],
+): Promise<Response> {
+  await Promise.all(events.flatMap((event) => Array.from(handlers, (handler) => handler(event))));
+  return new Response("OK", { status: 200 });
+}


### PR DESCRIPTION
This PR is the basis for my upcoming Mattermost and GitLab integration PRs.

# Make adding a connection provider a compile-time contract

Adding a connection provider now fails to compile until every dispatch site handles it, instead of silently falling through to whichever provider happened to be last in an if-chain. The GitHub, Slack, and Linear webhooks share one module for the idioms they each re-implemented, and Slack and Discord share one reader for reaction phase state. No runtime behavior changes for the four current providers.

## Goals

- Derive `ConnectionProvider` from `CONNECTION_PROVIDERS` so the provider set has one authoritative spelling.
- Turn every provider fallthrough into an exhaustive switch guarded by `assertNever`, or a `satisfies Record<ConnectionProvider, ...>` map.
- Move the body cap, strict-UTF-8 JSON parse, handler registry, and event fan-out that all three webhooks re-implemented into `src/triggers/webhook-shared.ts`.
- Replace the identical `slackReactionPhase` / `discordReactionPhase` functions with one `reactionPhase` reader.

## Non-goals

- Add, remove, or change the behavior of any provider.
- Reconcile the third copy of the provider list in `src/connections/result-contract.ts`, which feeds the connection-result surface rather than any dispatch site guarded here.
- Change any database schema, migration, or HTTP response contract.
- Introduce provider-neutral abstractions over provider-specific capabilities. The shared modules hold only the idioms that were already byte-identical; client types, emoji names, and signature schemes stay per-provider.

## Why

The provider set was spelled out independently in several modules that cannot all import each other, and most dispatch sites ended in a bare `else` rather than an exhaustive check. That combination fails silently and in the worst possible direction:

- `connectionTable()` and `connectionIdentityQuery()` returned `discord_connections` for any unrecognised provider. A provider added without touching that file would have had `claimLegacyConnections` rewrite Discord's ownership rows.
- In `src/configuration/store.ts` the fallthroughs had drifted apart: `resolveResource` ended in an unguarded Discord branch, while `readAuthoredResource`, `resourceField`, and `providerLabel` ended in Linear's. A new provider would have resolved against Discord's connections but read Linear's filter key and been labelled "Linear" in the UI.
- `summarizeTrigger` ended in `return summarizeManual(payload)`, so a provider without a branch there did not fail — it quietly reported a person's Slack or Discord message as a manual run.

`ConnectionProvider` was itself a second, hand-written copy of the union, so widening `CONNECTION_PROVIDERS` alone left every one of those guards compiling. Deriving it is what makes the contract in the title actually hold.

## Verification

- `npm run typecheck` (node, start, e2e): 0 errors
- `npm run lint`: 0 warnings and 0 errors on both configs
- `npm run format:check`
- `npm run db:check`: no schema changes
- `npm run test:scripts`
- `npm run build`
- `npm test`: 1186 passed, 15 skipped, 0 failed (166 files). The daemon recovery timing flake noted in #94 did not recur; this branch does not touch daemon lifecycle code.
- Contract check: temporarily adding a fifth provider (`"gitlab"`) to `CONNECTION_PROVIDERS` produces 20 compile errors across `store.ts` (x8), `inventory.test.ts` (x7), `activity-summary.ts` (x2), `db/pg.ts` (x2), and `db/connections.ts` (x1), then reverted. Before the derived type, the same edit produced 7 errors in one test file.

## Risk surface

- **Linear webhook, one behavior change.** Its invalid-JSON path moves from a bare `logger.warn` to `reportFailure`, so the rejection is reported with the signing secret and signature scrubbed. The response is unchanged: 400 with the same body. Signature verification, timestamp skew checking, issue hydration, and acceptance are untouched.
- **`ConnectionProvider` is now derived.** Any future widening of `CONNECTION_PROVIDERS` will break compilation at every guarded site. That is the intent, but it makes adding a provider a larger and noisier diff than before.
- No schema, migration, HTTP response, or provider credential changes. `db:check` reports no schema changes.

## Notes for review

The three refactors are independent and land as separate commits; none of them share a file. The provider-union commit is the one that changes dispatch behavior for a hypothetical future provider, and is worth reading on its own.
