### PR TITLE
Make the trigger editor read as the four decisions a trigger is

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -129,6 +129,7 @@ missing app component.
 | `Page`, `PageHeader`, `PageHeaderSkeleton`                              | Lay out a screen: the column, the one `h1`, its description, status, and actions.   |
 | `Section`                                                               | Group content under a quiet heading with an optional trailing action.               |
 | `Card`, `CardSkeleton`                                                  | Put content in a bordered surface. Title and description optional.                  |
+| `Steps`                                                                 | Number a run of cards in order and join them with a rail.                           |
 | `DataTable`, `DataRow`, `DataCell`, `DataTableSkeleton`                 | List records.                                                                       |
 | `TwoLine`                                                               | Show a primary fact over a muted secondary one, in a cell or a row.                 |
 | `SummaryPanel`                                                          | Show labelled facts as a description list.                                          |

--- a/e2e/helpers/triggers.ts
+++ b/e2e/helpers/triggers.ts
@@ -17,10 +17,12 @@ export class OrganizationTriggers {
     await this.page.getByRole("link", { name: "New trigger" }).click();
     await expect(this.page).toHaveURL(/\/triggers\/new$/u);
     await expect(this.page.getByRole("heading", { name: "New trigger", level: 1 })).toBeVisible();
-    await expect(this.page.getByRole("heading", { name: "Trigger details" })).toBeVisible();
-    await expect(this.page.getByRole("heading", { name: "Event & access" })).toBeVisible();
-    await expect(this.page.getByRole("heading", { name: "Run target" })).toBeVisible();
-    await expect(this.page.getByRole("heading", { name: "Agent & instructions" })).toBeHidden();
+    await expect(this.page.getByRole("heading", { name: "The event" })).toBeVisible();
+    await expect(this.page.getByRole("heading", { name: "Where it runs" })).toBeVisible();
+    // The last step keeps its place and says what it is waiting for, so the shape of the
+    // trigger is on screen before a daemon is chosen; only its controls are absent.
+    await expect(this.page.getByRole("heading", { name: "What runs there" })).toBeVisible();
+    await expect(this.page.getByRole("combobox", { name: "Agent" })).toBeHidden();
     await expect(this.page.getByLabel("Working directory")).toBeHidden();
     const topbar = this.page.locator("header.sticky");
     await expect(topbar.getByRole("radio", { name: "Form" })).toBeEnabled();
@@ -43,6 +45,9 @@ export class OrganizationTriggers {
   }) {
     await this.page.getByLabel("Trigger name").fill(input.name);
     await this.selectOption("When this happens", "slack.mention");
+    // An event that arrives on a connection is an event someone sends, so the step asking who
+    // may send it joins the run; a manual run has no audience and no step.
+    await expect(this.page.getByRole("heading", { name: "Who can invoke it" })).toBeVisible();
     await this.selectOption("Connection", input.connection);
     await this.page.getByRole("radio", { name: "Specific people" }).click();
     await this.page.getByLabel("User IDs").fill(input.users);
@@ -202,6 +207,29 @@ export class OrganizationTriggers {
     const row = this.page.getByRole("row").filter({ hasText: name });
     await expect(row.getByLabel("slack provider")).toBeVisible();
     await expect(row).toContainText("Never");
+  }
+
+  /**
+   * A disclosure with no brand mark starts its title on the same rail as its own description.
+   * The compact header is a grid, and the column a mark would have occupied is still a gap when
+   * there is no mark: the title used to sit 12px right of every other line in the card, on
+   * phones only, because from `sm` the header is a flex row where an absent mark takes no space.
+   */
+  async expectDisclosureRailsAtPhoneWidth() {
+    const viewport = this.page.viewportSize();
+    await this.page.setViewportSize({ width: 420, height: 900 });
+    for (const name of ["Advanced provider options", "GitHub access"]) {
+      const header = this.page.getByRole("button", { name, exact: false }).first();
+      await header.scrollIntoViewIfNeeded();
+      const rails = await header.evaluate((element: HTMLElement) =>
+        Array.from(element.querySelectorAll("span > span"), (line) =>
+          Math.round(line.getBoundingClientRect().left),
+        ),
+      );
+      expect(rails.length).toBeGreaterThan(1);
+      expect(new Set(rails).size).toBe(1);
+    }
+    if (viewport !== null) await this.page.setViewportSize(viewport);
   }
 
   async capture(path: string) {

--- a/e2e/triggers.spec.ts
+++ b/e2e/triggers.spec.ts
@@ -22,9 +22,11 @@ test("requires daemon setup before trigger configuration", async ({ hub, page })
   );
   await page.screenshot({ path: `${SHOTS}/00-no-daemon-callout.png`, fullPage: true });
   await triggers.startNew();
-  await expect(page.getByText("No daemons available", { exact: true })).toBeVisible();
+  await expect(
+    page.getByText("No daemon is connected to this organization yet", { exact: false }),
+  ).toBeVisible();
   await expect(page.getByRole("combobox", { name: "Run on daemon" })).toBeHidden();
-  await expect(page.getByRole("heading", { name: "Agent & instructions" })).toBeHidden();
+  await expect(page.getByText("Choose a daemon first", { exact: false })).toBeVisible();
   await page.screenshot({ path: `${SHOTS}/00-no-daemons.png`, fullPage: true });
   await page.getByRole("link", { name: "Go to Daemons" }).click();
   await expect(page).toHaveURL(/\/daemons$/u);
@@ -66,6 +68,7 @@ test("creates a trigger visually, preserves advanced YAML through the form, and 
     await triggers.expectAgentSearch();
     await triggers.expectComboboxes();
     await triggers.changePrompt("Handle the Slack request.");
+    await triggers.expectDisclosureRailsAtPhoneWidth();
     await page.evaluate(() => window.scrollTo({ top: 0 }));
     await triggers.capture(`${SHOTS}/02-configured-form.png`);
     await triggers.captureInstructions(`${SHOTS}/02b-agent-instructions.png`);

--- a/src/components/app/disclosure.tsx
+++ b/src/components/app/disclosure.tsx
@@ -36,6 +36,12 @@ export function Disclosure({
 }) {
   const headerId = `${id}-header`;
   const bodyId = `${id}-body`;
+  // The compact header is a grid so the title, the description, and the status stack under one
+  // another; a brand mark, when there is one, owns the column beside them. Without a mark there
+  // is no column to leave empty — an empty column is still a `gap-x-3` indent, which put the
+  // title 12px off the rail its own description sits on. From `sm` the header is a flex row and
+  // an absent mark takes no space at all, so only the compact grid has a column to drop.
+  const compact = media === undefined ? COMPACT_WITHOUT_MEDIA : COMPACT_WITH_MEDIA;
   return (
     <Collapsible
       open={open}
@@ -47,7 +53,8 @@ export function Disclosure({
         id={headerId}
         aria-controls={bodyId}
         className={cn(
-          "grid w-full grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-x-3 gap-y-1 rounded-xl px-4 py-3 text-left sm:flex sm:gap-3",
+          "grid w-full items-center gap-x-3 gap-y-1 rounded-xl px-4 py-3 text-left sm:flex sm:gap-3",
+          compact.columns,
           "hover:bg-accent",
         )}
       >
@@ -57,23 +64,33 @@ export function Disclosure({
           </span>
         )}
         <span className="contents sm:grid sm:min-w-0 sm:flex-1 sm:gap-0.5">
-          <span className="col-start-2 row-start-1 truncate text-sm sm:col-auto sm:row-auto">
+          <span
+            className={cn("row-start-1 truncate text-sm sm:col-auto sm:row-auto", compact.title)}
+          >
             {title}
           </span>
           {description === undefined ? null : (
-            <span className="col-span-3 row-start-2 text-sm text-muted-foreground sm:col-auto sm:row-auto">
+            <span
+              className={cn(
+                "row-start-2 text-sm text-muted-foreground sm:col-auto sm:row-auto",
+                compact.full,
+              )}
+            >
               {description}
             </span>
           )}
         </span>
         <span className="contents sm:flex sm:shrink-0 sm:items-center sm:gap-2">
-          <span className="col-span-3 row-start-3 justify-self-start sm:col-auto sm:row-auto">
+          <span
+            className={cn("row-start-3 justify-self-start sm:col-auto sm:row-auto", compact.full)}
+          >
             {status}
           </span>
           <ChevronDown
             aria-hidden="true"
             className={cn(
-              "col-start-3 row-start-1 size-4 text-muted-foreground transition-transform sm:col-auto sm:row-auto",
+              "row-start-1 size-4 text-muted-foreground transition-transform sm:col-auto sm:row-auto",
+              compact.chevron,
               open ? "rotate-180" : "",
             )}
           />
@@ -94,3 +111,18 @@ export function Disclosure({
     </Collapsible>
   );
 }
+
+/** Where the title, the stacked lines, and the chevron sit in the compact header's grid. */
+const COMPACT_WITH_MEDIA = {
+  columns: "grid-cols-[auto_minmax(0,1fr)_auto]",
+  title: "col-start-2",
+  full: "col-span-3",
+  chevron: "col-start-3",
+} as const;
+
+const COMPACT_WITHOUT_MEDIA = {
+  columns: "grid-cols-[minmax(0,1fr)_auto]",
+  title: "col-start-1",
+  full: "col-span-2",
+  chevron: "col-start-2",
+} as const;

--- a/src/components/app/steps.tsx
+++ b/src/components/app/steps.tsx
@@ -1,0 +1,35 @@
+import { Children, isValidElement, type ReactNode } from "react";
+
+/**
+ * A sequence of cards read in order, numbered in the gutter and joined by a rail.
+ *
+ * The number is decoration: the list is an `ol`, so the order is already carried for a reader
+ * who cannot see the rail, and the marker is hidden from them rather than announced twice. A
+ * child that renders nothing is not a step — `Children.toArray` drops it — so a decision that
+ * removes a step renumbers the ones after it instead of leaving a gap.
+ *
+ * Each child is a surface of its own; in practice a `Card`. Steps owns the distance between
+ * them, so a caller never spaces the run itself.
+ */
+export function Steps({ children }: { children: ReactNode }) {
+  const steps = Children.toArray(children).filter((step) => isValidElement(step));
+  return (
+    <ol className="grid gap-3">
+      {steps.map((step, index) => (
+        <li
+          key={isValidElement(step) ? (step.key ?? index) : index}
+          className="grid min-w-0 grid-cols-[1.5rem_minmax(0,1fr)] gap-4"
+        >
+          {/* The marker sits on the card's first line: `mt-6` is the card's own top padding. */}
+          <span aria-hidden="true" className="flex flex-col items-center">
+            <span className="mt-6 grid size-6 shrink-0 place-items-center rounded-full border bg-card text-xs text-muted-foreground">
+              {index + 1}
+            </span>
+            {index === steps.length - 1 ? null : <span className="mt-2 w-px flex-1 bg-border" />}
+          </span>
+          {step}
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/src/triggers/panel.tsx
+++ b/src/triggers/panel.tsx
@@ -18,7 +18,7 @@ import { FieldSkeleton, FormField } from "../components/app/form-field.js";
 import { LoadingLine, Spinner } from "../components/app/loading.js";
 import { PageHeader, PageHeaderSkeleton } from "../components/app/page.js";
 import { RelativeTime } from "../components/app/relative-time.js";
-import { Section } from "../components/app/section.js";
+import { Steps } from "../components/app/steps.js";
 import { SegmentedControl, type SegmentedOption } from "../components/app/segmented-control.js";
 import { StatusPill, statusLabel } from "../components/app/status-pill.js";
 import { TwoLine } from "../components/app/two-line.js";
@@ -598,17 +598,15 @@ function TriggerForm({
     onChange({ ...form, [key]: value });
   const text = (key: TriggerTextField) => (value: string) => update(key, value);
   const selectedDaemon = snapshot.daemons.find((daemon) => daemon.slug === form.daemon);
+  const noDaemons = snapshot.daemons.length === 0;
   const providerCatalog = useDaemonProviderCatalog(
     snapshot.organization.slug,
     selectedDaemon?.id,
     form.cwd,
   );
   return (
-    <div>
-      <Section
-        title="Trigger details"
-        description="Identification and system handle for this trigger."
-      >
+    <div className="grid gap-6">
+      <Card>
         <div className="grid gap-4 sm:grid-cols-2">
           <FormField
             id="trigger-name"
@@ -638,288 +636,297 @@ function TriggerForm({
           checked={form.enabled}
           onChange={(checked) => update("enabled", checked)}
         />
-      </Section>
+      </Card>
 
-      <Section
-        title="Event & access"
-        description="When this event fires and who is authorized to invoke it."
-      >
-        <div className="grid gap-4 sm:grid-cols-2">
-          <FormField
-            id="trigger-event"
-            label="When this happens"
-            description="Exactly one event launches this trigger."
-          >
-            {(control) => (
-              <Combobox
-                {...control}
-                value={form.event}
-                options={EVENT_OPTIONS}
-                placeholder="Select an event"
-                empty="No events found."
-                onChange={(option) => update("event", parseEditorEvent(option.value))}
-              />
-            )}
-          </FormField>
-          {form.event === "manual.run" ? null : (
-            <FormField
-              id="trigger-connection"
-              label="Connection"
-              description="The organization connection that receives the event."
-              required
-              {...fieldError(errors, "connection")}
-            >
+      {/*
+        The four decisions a trigger is made of, in the order the run makes them: what arrives,
+        who may send it, where it lands, what runs there. A step whose decision does not exist —
+        a manual run has no audience — is not rendered, and `Steps` renumbers the rest.
+      */}
+      <Steps>
+        <Card title={EDITOR_STEPS.event.title} description={EDITOR_STEPS.event.description}>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <FormField id="trigger-event" label="When this happens">
               {(control) => (
                 <Combobox
                   {...control}
-                  required
-                  value={form.connection}
-                  options={connectionOptions}
-                  placeholder="Select a connection"
-                  empty="No connections found."
-                  onChange={(option) => update("connection", option.value)}
+                  value={form.event}
+                  options={EVENT_OPTIONS}
+                  placeholder="Select an event"
+                  empty="No events found."
+                  onChange={(option) => update("event", parseEditorEvent(option.value))}
                 />
               )}
             </FormField>
-          )}
-        </div>
-        {form.event === "manual.run" ? null : (
-          <div className="grid gap-4 sm:grid-cols-2">
-            <FormField
-              id="trigger-audience"
-              label="Who can trigger it?"
-              description="Everyone the connection can see, or a named list."
-            >
-              {() => (
-                <SegmentedControl
-                  label="Who can trigger it?"
-                  value={everyone ? "everyone" : "specific"}
-                  options={AUDIENCE_OPTIONS}
-                  onChange={(value) => update("allowedUsers", value === "everyone" ? "*" : "")}
-                />
-              )}
-            </FormField>
-            {everyone ? null : (
+            {form.event === "manual.run" ? null : (
               <FormField
-                id="trigger-allowed-users"
-                label="User IDs"
-                description="Comma-separated provider user IDs."
-                kind="text"
-                name="allowedUsers"
-                value={form.allowedUsers}
-                onChange={text("allowedUsers")}
+                id="trigger-connection"
+                label="Connection"
+                description="The organization connection that receives the event."
                 required
-                {...fieldError(errors, "allowedUsers")}
-              />
-            )}
-          </div>
-        )}
-      </Section>
-
-      <Section
-        title="Run target"
-        description="The local machine compute and repository working directory."
-      >
-        {snapshot.daemons.length === 0 ? (
-          <Card
-            title="No daemons available"
-            description="A trigger runs on a daemon connected to this organization."
-            action={
-              <Button asChild variant="outline" size="sm">
-                <Link to={`/o/${snapshot.organization.slug}/daemons` as never}>Go to Daemons</Link>
-              </Button>
-            }
-          >
-            {null}
-          </Card>
-        ) : (
-          <FormField
-            id="trigger-daemon"
-            label="Run on daemon"
-            description="The daemon owns compute, credentials, and sandboxing."
-            required
-            {...fieldError(errors, "daemon")}
-          >
-            {(control) => (
-              <Combobox
-                {...control}
-                required
-                value={form.daemon}
-                options={daemonOptions}
-                placeholder="Select a daemon"
-                empty="No daemons found."
-                onChange={(option) =>
-                  onChange({
-                    ...form,
-                    daemon: option.value,
-                    agent: "",
-                    mode: "",
-                    thinkingOptionId: "",
-                    providerOptions: "",
-                  })
-                }
-              />
-            )}
-          </FormField>
-        )}
-        {selectedDaemon === undefined ? null : (
-          <div className="grid gap-4 sm:grid-cols-2">
-            <FormField
-              id="trigger-cwd"
-              label="Working directory"
-              description="Absolute path on the daemon."
-              kind="text"
-              name="cwd"
-              value={form.cwd}
-              onChange={text("cwd")}
-              required
-              {...fieldError(errors, "cwd")}
-            />
-            <FormField
-              id="trigger-max-runtime"
-              label="Maximum runtime"
-              description="Hard deadline for the agent, for example 2h."
-              kind="text"
-              name="maxRuntime"
-              value={form.maxRuntime}
-              onChange={text("maxRuntime")}
-              required
-              {...fieldError(errors, "maxRuntime")}
-            />
-            <FormField
-              id="trigger-idle-timeout"
-              label="Idle timeout"
-              description="Stop an unresponsive agent, for example 10m."
-              kind="text"
-              name="idleTimeout"
-              value={form.idleTimeout}
-              onChange={text("idleTimeout")}
-              required
-              {...fieldError(errors, "idleTimeout")}
-            />
-          </div>
-        )}
-      </Section>
-
-      {selectedDaemon === undefined ? null : (
-        <Section
-          title="Agent & instructions"
-          description="The AI coding agent model and task prompt instructions."
-        >
-          <div className="grid gap-4 sm:grid-cols-2">
-            <ProviderCatalogFields
-              form={form}
-              errors={errors}
-              entries={providerCatalog.entries}
-              loading={providerCatalog.loading}
-              onChange={onChange}
-            />
-          </div>
-          {providerCatalog.loading ? (
-            <LoadingLine>{`Loading providers from ${form.daemon}…`}</LoadingLine>
-          ) : null}
-          {providerCatalog.error === undefined ? null : (
-            <FailureAlert
-              title="Providers unavailable"
-              error={providerCatalog.error}
-              fallback="Hub couldn't load this daemon's providers."
-              onRetry={providerCatalog.refresh}
-            />
-          )}
-          <Disclosure
-            id="trigger-provider-options"
-            open={optionsExpanded}
-            onOpenChange={setOptionsExpanded}
-            title="Advanced provider options"
-            description="Fields the form does not model, passed through to the provider."
-          >
-            <FormField
-              id="trigger-provider-options-json"
-              label="Provider options (JSON)"
-              description="Passed to the provider on your daemon. YAML-only agent fields remain untouched."
-              kind="multiline"
-              name="providerOptions"
-              value={form.providerOptions}
-              onChange={text("providerOptions")}
-              placeholder={'{"sandbox_mode":"workspace-write"}'}
-              {...fieldError(errors, "providerOptions")}
-            />
-          </Disclosure>
-          <Disclosure
-            id="trigger-github"
-            open={githubExpanded}
-            onOpenChange={setGithubExpanded}
-            title="GitHub access"
-            description="Give the run a short-lived token scoped to the repositories you name."
-          >
-            <div className="grid gap-4 sm:grid-cols-2">
-              <FormField
-                id="trigger-github-connection"
-                label="GitHub connection"
-                description="Mints a short-lived, restricted GH_TOKEN for this run."
+                {...fieldError(errors, "connection")}
               >
                 {(control) => (
                   <Combobox
                     {...control}
-                    value={form.githubConnection}
-                    options={githubConnectionOptions}
-                    placeholder="Select a GitHub connection"
-                    empty="No GitHub connections found."
-                    onChange={(option) => update("githubConnection", option.value)}
+                    required
+                    value={form.connection}
+                    options={connectionOptions}
+                    placeholder="Select a connection"
+                    empty="No connections found."
+                    onChange={(option) => update("connection", option.value)}
                   />
                 )}
               </FormField>
-              {githubEnabled ? (
-                <>
-                  <FormField
-                    id="trigger-github-repositories"
-                    label="GitHub repositories"
-                    description="Comma-separated owner/repository names."
-                    kind="text"
-                    name="githubRepositories"
-                    value={form.githubRepositories}
-                    onChange={text("githubRepositories")}
-                    required
+            )}
+          </div>
+        </Card>
+
+        {form.event === "manual.run" ? null : (
+          <Card title={EDITOR_STEPS.access.title} description={EDITOR_STEPS.access.description}>
+            <div className="grid gap-4 sm:grid-cols-2">
+              <FormField id="trigger-audience" label="Audience">
+                {() => (
+                  <SegmentedControl
+                    label="Audience"
+                    value={everyone ? "everyone" : "specific"}
+                    options={AUDIENCE_OPTIONS}
+                    onChange={(value) => update("allowedUsers", value === "everyone" ? "*" : "")}
                   />
-                  <FormField
-                    id="trigger-github-duration"
-                    label="GitHub token lifetime"
-                    description="At most 1h."
-                    kind="text"
-                    name="githubDuration"
-                    value={form.githubDuration}
-                    onChange={text("githubDuration")}
-                    required
-                  />
-                  <FormField
-                    id="trigger-github-permissions"
-                    label="GitHub permissions (JSON)"
-                    description="Defaults to read-only repository contents when empty."
-                    kind="multiline"
-                    name="githubPermissions"
-                    value={form.githubPermissions}
-                    onChange={text("githubPermissions")}
-                    placeholder={'{"contents":"write","pull_requests":"write"}'}
-                    {...fieldError(errors, "githubPermissions")}
-                  />
-                </>
-              ) : null}
+                )}
+              </FormField>
+              {everyone ? null : (
+                <FormField
+                  id="trigger-allowed-users"
+                  label="User IDs"
+                  description="Comma-separated provider user IDs."
+                  kind="text"
+                  name="allowedUsers"
+                  value={form.allowedUsers}
+                  onChange={text("allowedUsers")}
+                  required
+                  {...fieldError(errors, "allowedUsers")}
+                />
+              )}
             </div>
-          </Disclosure>
-          <PromptEditor
-            value={form.prompt}
-            {...fieldError(errors, "prompt")}
-            onChange={(prompt) => update("prompt", prompt)}
-          />
-          <Card>
-            <p className="flex items-center gap-2 text-sm text-muted-foreground">
-              <LockKeyhole aria-hidden="true" className="size-4 shrink-0 text-link" />
-              Hub launches the agent on your daemon. Keys, provider configuration, and sandboxing
-              stay on your compute.
-            </p>
           </Card>
-        </Section>
-      )}
+        )}
+
+        <Card
+          title={EDITOR_STEPS.target.title}
+          description={noDaemons ? NO_DAEMON_DESCRIPTION : EDITOR_STEPS.target.description}
+          {...(noDaemons
+            ? {
+                action: (
+                  <Button asChild variant="outline" size="sm">
+                    <Link to={`/o/${snapshot.organization.slug}/daemons` as never}>
+                      Go to Daemons
+                    </Link>
+                  </Button>
+                ),
+              }
+            : {})}
+        >
+          {noDaemons ? null : (
+            <>
+              <FormField
+                id="trigger-daemon"
+                label="Run on daemon"
+                required
+                {...fieldError(errors, "daemon")}
+              >
+                {(control) => (
+                  <Combobox
+                    {...control}
+                    required
+                    value={form.daemon}
+                    options={daemonOptions}
+                    placeholder="Select a daemon"
+                    empty="No daemons found."
+                    onChange={(option) =>
+                      onChange({
+                        ...form,
+                        daemon: option.value,
+                        agent: "",
+                        mode: "",
+                        thinkingOptionId: "",
+                        providerOptions: "",
+                      })
+                    }
+                  />
+                )}
+              </FormField>
+              {selectedDaemon === undefined ? null : (
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <FormField
+                    id="trigger-cwd"
+                    label="Working directory"
+                    description="Absolute path on the daemon."
+                    kind="text"
+                    name="cwd"
+                    value={form.cwd}
+                    onChange={text("cwd")}
+                    required
+                    {...fieldError(errors, "cwd")}
+                  />
+                  <FormField
+                    id="trigger-max-runtime"
+                    label="Maximum runtime"
+                    description="Hard deadline for the agent, for example 2h."
+                    kind="text"
+                    name="maxRuntime"
+                    value={form.maxRuntime}
+                    onChange={text("maxRuntime")}
+                    required
+                    {...fieldError(errors, "maxRuntime")}
+                  />
+                  <FormField
+                    id="trigger-idle-timeout"
+                    label="Idle timeout"
+                    description="Stop an unresponsive agent, for example 10m."
+                    kind="text"
+                    name="idleTimeout"
+                    value={form.idleTimeout}
+                    onChange={text("idleTimeout")}
+                    required
+                    {...fieldError(errors, "idleTimeout")}
+                  />
+                </div>
+              )}
+            </>
+          )}
+        </Card>
+
+        {/*
+          The agent step keeps its place while it waits: its models are the selected daemon's own
+          answer, so before there is a daemon the step says what it is waiting for rather than
+          disappearing and taking the shape of the trigger with it.
+        */}
+        <Card
+          title={EDITOR_STEPS.agent.title}
+          description={
+            selectedDaemon === undefined ? NO_AGENT_DESCRIPTION : EDITOR_STEPS.agent.description
+          }
+        >
+          {selectedDaemon === undefined ? null : (
+            <>
+              <div className="grid gap-4 sm:grid-cols-2">
+                <ProviderCatalogFields
+                  form={form}
+                  errors={errors}
+                  entries={providerCatalog.entries}
+                  loading={providerCatalog.loading}
+                  onChange={onChange}
+                />
+              </div>
+              {providerCatalog.loading ? (
+                <LoadingLine>{`Loading providers from ${form.daemon}…`}</LoadingLine>
+              ) : null}
+              {providerCatalog.error === undefined ? null : (
+                <FailureAlert
+                  title="Providers unavailable"
+                  error={providerCatalog.error}
+                  fallback="Hub couldn't load this daemon's providers."
+                  onRetry={providerCatalog.refresh}
+                />
+              )}
+              <PromptEditor
+                value={form.prompt}
+                {...fieldError(errors, "prompt")}
+                onChange={(prompt) => update("prompt", prompt)}
+              />
+              <Disclosure
+                id="trigger-provider-options"
+                open={optionsExpanded}
+                onOpenChange={setOptionsExpanded}
+                title="Advanced provider options"
+                description="Fields the form does not model, passed through to the provider."
+              >
+                <FormField
+                  id="trigger-provider-options-json"
+                  label="Provider options (JSON)"
+                  description="Passed to the provider on your daemon. YAML-only agent fields remain untouched."
+                  kind="multiline"
+                  name="providerOptions"
+                  value={form.providerOptions}
+                  onChange={text("providerOptions")}
+                  placeholder={'{"sandbox_mode":"workspace-write"}'}
+                  {...fieldError(errors, "providerOptions")}
+                />
+              </Disclosure>
+              <Disclosure
+                id="trigger-github"
+                open={githubExpanded}
+                onOpenChange={setGithubExpanded}
+                title="GitHub access"
+                description="Give the run a short-lived token scoped to the repositories you name."
+              >
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <FormField
+                    id="trigger-github-connection"
+                    label="GitHub connection"
+                    description="Mints a short-lived, restricted GH_TOKEN for this run."
+                  >
+                    {(control) => (
+                      <Combobox
+                        {...control}
+                        value={form.githubConnection}
+                        options={githubConnectionOptions}
+                        placeholder="Select a GitHub connection"
+                        empty="No GitHub connections found."
+                        onChange={(option) => update("githubConnection", option.value)}
+                      />
+                    )}
+                  </FormField>
+                  {githubEnabled ? (
+                    <>
+                      <FormField
+                        id="trigger-github-repositories"
+                        label="GitHub repositories"
+                        description="Comma-separated owner/repository names."
+                        kind="text"
+                        name="githubRepositories"
+                        value={form.githubRepositories}
+                        onChange={text("githubRepositories")}
+                        required
+                      />
+                      <FormField
+                        id="trigger-github-duration"
+                        label="GitHub token lifetime"
+                        description="At most 1h."
+                        kind="text"
+                        name="githubDuration"
+                        value={form.githubDuration}
+                        onChange={text("githubDuration")}
+                        required
+                      />
+                      <FormField
+                        id="trigger-github-permissions"
+                        label="GitHub permissions (JSON)"
+                        description="Defaults to read-only repository contents when empty."
+                        kind="multiline"
+                        name="githubPermissions"
+                        value={form.githubPermissions}
+                        onChange={text("githubPermissions")}
+                        placeholder={'{"contents":"write","pull_requests":"write"}'}
+                        {...fieldError(errors, "githubPermissions")}
+                      />
+                    </>
+                  ) : null}
+                </div>
+              </Disclosure>
+            </>
+          )}
+        </Card>
+      </Steps>
+
+      <Card>
+        <p className="flex items-center gap-2 text-sm text-muted-foreground">
+          <LockKeyhole aria-hidden="true" className="size-4 shrink-0 text-link" />
+          Hub launches the agent on your daemon. Keys, provider configuration, and sandboxing stay
+          on your compute.
+        </p>
+      </Card>
     </div>
   );
 }
@@ -930,9 +937,9 @@ const AUDIENCE_OPTIONS: readonly SegmentedOption[] = [
 ];
 
 /**
- * The trigger editor before the snapshot arrives. The back link, the section headings, and the
- * page description are the same every time, so they render for real; only the trigger's own name
- * and field values are placeholders.
+ * The trigger editor before the snapshot arrives. The back link, the step titles, and the page
+ * description are the same every time, so they render for real; only the trigger's own name and
+ * field values are placeholders.
  */
 function TriggerEditorSkeleton() {
   return (
@@ -941,33 +948,57 @@ function TriggerEditorSkeleton() {
         <ArrowLeft aria-hidden="true" /> Triggers
       </Button>
       <PageHeaderSkeleton description={TRIGGER_EDITOR_DESCRIPTION} />
-      {EDITOR_SECTIONS.map((section) => (
-        <Section key={section.title} title={section.title} description={section.description}>
+      <div className="grid gap-6">
+        <Card>
           <div className="grid gap-4 sm:grid-cols-2">
             <FieldSkeleton />
             <FieldSkeleton />
           </div>
-        </Section>
-      ))}
+        </Card>
+        <Steps>
+          {Object.values(EDITOR_STEPS).map((step) => (
+            <Card key={step.title} title={step.title} description={step.description}>
+              <div className="grid gap-4 sm:grid-cols-2">
+                <FieldSkeleton />
+                <FieldSkeleton />
+              </div>
+            </Card>
+          ))}
+        </Steps>
+      </div>
     </div>
   );
 }
 
-/** The three sections every trigger has, whatever event or daemon it ends up pointing at. */
-const EDITOR_SECTIONS = [
-  {
-    title: "Trigger details",
-    description: "Identification and system handle for this trigger.",
+/**
+ * The four decisions a trigger is made of, named once. The form renders them as steps and the
+ * skeleton stands in for them, so a reader waiting for a snapshot already sees the shape of the
+ * trigger they are about to fill in.
+ */
+const EDITOR_STEPS = {
+  event: {
+    title: "The event",
+    description: "What arrives, and the connection it arrives on.",
   },
-  {
-    title: "Event & access",
-    description: "When this event fires and who is authorized to invoke it.",
+  access: {
+    title: "Who can invoke it",
+    description: "Everyone the connection can see, or a named list.",
   },
-  {
-    title: "Run target",
-    description: "The local machine compute and repository working directory.",
+  target: {
+    title: "Where it runs",
+    description: "The daemon owns compute, credentials, and sandboxing.",
   },
-] as const;
+  agent: {
+    title: "What runs there",
+    description: "The agent, its model, and the instructions it is given.",
+  },
+} as const;
+
+/** What the step says while the decision above it is still missing. */
+const NO_DAEMON_DESCRIPTION =
+  "No daemon is connected to this organization yet, and a trigger runs on a daemon.";
+const NO_AGENT_DESCRIPTION =
+  "Choose a daemon first. The agents you can run are the ones it reports.";
 
 function PromptEditor({
   value,


### PR DESCRIPTION
The trigger editor is no longer a page of fields under document-shaped headings. Creating or editing a trigger now walks four numbered steps — what arrives, who may send it, where it lands, what runs there — and a step that is waiting on an earlier one keeps its place and says what it needs instead of disappearing.

## Goals

- One form for both `/triggers/new` and `/triggers/:id`. No separate create flow.
- Each decision is a bordered card in a numbered run, so the shape of a trigger is visible before it is filled in.
- A step that cannot be completed yet says why: the agent step names the daemon it is waiting for, the run-target step carries the reason and the way to fix it when the organization has no daemon.
- The numbering is honest — a manual run has no audience, so that step is absent and the rest renumber.
- The run of cards is a shared component, not a shape hand-rolled in one screen.

## Non-goals

- No change to the trigger document, the YAML editor, the schema, or what a save produces. Every value round-trips exactly as before.
- No new fields and no removed fields. Only how they are grouped, and the copy that groups them.
- No redesign of the existing-trigger page beyond using the same form the create page uses.

## The why

The sections were named after parts of the document rather than after decisions, and nothing enclosed them, so the form read as one stack of controls. Worse, the sections that depend on a daemon were rendered conditionally: a new trigger on an organization with no daemon showed two headings and a callout, which is not the shape of the thing being created. A step that keeps its place and states its precondition costs one line of copy and answers the question the empty page used to raise.

`Steps` lives in `src/components/app` rather than in the trigger screen because the design contract says a screen composes shared components — the roster in `docs/design.md` gained a row for it. It numbers whatever cards it is given and owns the spacing between them; a child that renders nothing is not a step, which is what makes the manual-run case renumber for free.

## Related work

Refs #1 — this keeps the form as a projection of the YAML document; the document is still canonical and the YAML tab is untouched.

## Verification

- `e2e/triggers.spec.ts` updated to the new headings and passing (2/2), covering the no-daemon page, the full create journey, YAML round-trip, advanced-YAML preservation, and the legacy workflow lane.
- Regression test for the `Disclosure` fix below, written failing-first: reverted the component and watched `expectDisclosureRailsAtPhoneWidth` report two distinct left edges, restored it and watched it report one.
- `e2e/apps-mobile.spec.ts` passing (4/4) — that suite covers the disclosures that *do* carry a brand mark, which is the path the fix had to leave alone.
- The prompt textarea still autosizes: measured 190px at one line, 394px at 24 lines with no inner scroll, back to 190px.
- `npm run typecheck`, `npm run lint`, `npm run format:check`, and `src/typography-policy.test.ts` all clean.

## Risk surface

- **`src/components/app/disclosure.tsx` is shared.** Its compact header reserved a column for the brand mark even when there was no mark, and `gap-x-3` turned that into a 12px indent — the title sat off the rail its own description sits on, on phones only. The grid now drops the column when there is no mark. Two call sites pass a mark (`provider-section.tsx`) and three do not; the mark path is covered by `apps-mobile`, the markless path by the new trigger assertion. Worth a look at phone width on the Apps screen if you want belt and braces.
- **Copy changed on every step heading and several field descriptions.** Anything asserting the old strings — "Trigger details", "Event & access", "Run target", "Agent & instructions", "No daemons available", "Who can trigger it?" — needs updating. The only such places in the repo were the two e2e files in this diff.
- **The agent step now renders with no daemon selected**, where it previously did not render at all. Its controls are still absent; only the card and its explanation are new.