### PR TITLE
Make every alert say what happened, and every empty surface stop drawing furniture

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -128,9 +128,10 @@ missing app component.
 | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
 | `Page`, `PageHeader`, `PageHeaderSkeleton`                              | Lay out a screen: the column, the one `h1`, its description, status, and actions.   |
 | `Section`                                                               | Group content under a quiet heading with an optional trailing action.               |
-| `Card`, `CardSkeleton`                                                  | Put content in a bordered surface. Title and description optional.                  |
+| `Card`, `CardSkeleton`                                                  | Put content in a bordered surface. Icon, title, description, and action optional.   |
 | `Steps`                                                                 | Number a run of cards in order and join them with a rail.                           |
-| `DataTable`, `DataRow`, `DataCell`, `DataTableSkeleton`                 | List records.                                                                       |
+| `DataTable`, `DataRow`, `DataCell`, `DataTableSkeleton`                 | List records at page level, in columns.                                             |
+| `RecordList`, `RecordRow`                                               | List a card's own few records, with no header row to repeat the card's subject.     |
 | `TwoLine`                                                               | Show a primary fact over a muted secondary one, in a cell or a row.                 |
 | `SummaryPanel`                                                          | Show labelled facts as a description list.                                          |
 | `StatTile`, `StatGrid`                                                  | Show a figure with a label.                                                         |
@@ -161,6 +162,12 @@ Rules for the roster:
 
 - A component owns its spacing to its neighbours. Callers never add `mb-*` or `mt-*` to a shared
   component; if the rhythm is wrong, fix it in the component.
+- Every alert is one anatomy, owned by `Alert`: a tone glyph, a title, the message under it, and
+  at most one control at the far edge, centred against the whole message. A caller passes those
+  four things and never assembles them, because three callers assembling them is how two of them
+  ended up with different spacing between a title and the line under it.
+- A list with nothing in it is the empty state alone on the background. `DataTable` renders it
+  instead of the table: column headers over a hollow body promise records that are not coming.
 - An alert standing in a page stack takes `standalone`. `PageHeader` and `Section` each own their
   bottom margin and nothing owns the distance after an alert, so a banner between them has to own
   it itself. Inside a form, a dialog, or a section, leave it off — the container's gap already

--- a/e2e/helpers/hub.ts
+++ b/e2e/helpers/hub.ts
@@ -4536,7 +4536,7 @@ class HubUser {
     await expect(
       this.page.getByRole("heading", { name: "Connections", exact: true, level: 1 }),
     ).toBeVisible();
-    await expect(this.page.getByText("No connections", { exact: true })).toBeVisible();
+    await this.expectNoConnections();
     await expect(this.page.getByText(/does not deploy a/u)).toHaveCount(0);
     const widths = await this.page.getByRole("main").evaluate((main) => ({
       document: document.documentElement.scrollWidth,
@@ -4678,15 +4678,26 @@ class HubUser {
     await this.expectUntrustedConnectionReturnUnavailable(forged.toString());
   }
 
+  /**
+   * A round trip that connected nothing is reported as a failed request, headed by the provider
+   * the operator was trying to connect. Both halves are asserted: a banner with only the title
+   * has stopped saying what to do next.
+   */
+  private async expectConnectionFailure(message: string): Promise<void> {
+    const alert = this.page.getByRole("alert");
+    await expect(alert).toContainText(/ wasn't connected/u);
+    await expect(alert).toContainText(message);
+  }
+
   async expectGitHubConnectionConflict(): Promise<void> {
     await this.openOrganizationSection("Connections");
     const connectionsUrl = this.page.url();
     await this.page.getByRole("button", { name: "Connect GitHub" }).click();
     await expect(this.page).toHaveURL(connectionsUrl);
-    await expect(this.page.getByRole("status")).toHaveText(
+    await this.expectConnectionFailure(
       "That account is already connected to another organization. Nothing was connected. Disconnect it there, or pick a different one.",
     );
-    await expect(this.page.getByText("No connections", { exact: true })).toBeVisible();
+    await this.expectNoConnections();
     await this.expectNoProviderIdentity("acme-inc");
   }
 
@@ -4694,10 +4705,10 @@ class HubUser {
     const connectionsUrl = this.page.url();
     await this.page.getByRole("button", { name: "Connect Discord" }).click();
     await expect(this.page).toHaveURL(connectionsUrl);
-    await expect(this.page.getByRole("status")).toHaveText(
+    await this.expectConnectionFailure(
       "That account is already connected to another organization. Nothing was connected. Disconnect it there, or pick a different one.",
     );
-    await expect(this.page.getByText("No connections", { exact: true })).toBeVisible();
+    await this.expectNoConnections();
     await this.expectNoProviderIdentity("Acme Guild");
   }
 
@@ -4733,7 +4744,7 @@ class HubUser {
     await this.page.goto(url);
     await expect(this.page).toHaveURL(/\/o\/[^/]+\/connections$/u);
     await expect(this.page.getByRole("heading", { name: "Connections", level: 1 })).toBeVisible();
-    await expect(this.page.getByRole("status")).toHaveText(
+    await this.expectConnectionFailure(
       "That connection link had already been used or had expired, so it was refused. Nothing was connected. Start the connection again from this page.",
     );
   }
@@ -4763,7 +4774,7 @@ class HubUser {
       .click();
     await expect(this.page).toHaveURL(/\/o\/[^/]+\/connections$/u);
     await expect(this.page.getByRole("heading", { name: "Connections", level: 1 })).toBeVisible();
-    await expect(this.page.getByRole("status")).toHaveText(
+    await this.expectConnectionFailure(
       "GitHub sent you back to a Hub address this browser isn't signed in to, so nothing was connected. Sign in there, or ask your Hub operator to check the GitHub app's callback and setup URLs, then start the connection again.",
     );
   }
@@ -4803,12 +4814,10 @@ class HubUser {
     const connectionsUrl = this.page.url();
     const github = this.connectionRow("GitHub");
     const discord = this.connectionRow("Discord");
-    await expect(github.getByRole("cell").first()).toContainText(expected.github);
-    await expect(github.getByRole("cell").first()).toContainText(
-      `installation ${expected.installationId}`,
-    );
-    await expect(discord.getByRole("cell").first()).toContainText(expected.discord);
-    await expect(discord.getByRole("cell").first()).toContainText(`guild ${expected.guildId}`);
+    await expect(github).toContainText(expected.github);
+    await expect(github).toContainText(`installation ${expected.installationId}`);
+    await expect(discord).toContainText(expected.discord);
+    await expect(discord).toContainText(`guild ${expected.guildId}`);
     await expect(this.page).toHaveURL(connectionsUrl);
     await expect(this.page.getByText(/ephemeral|state|code=/u)).toHaveCount(0);
     await expectAccessible(this.page);
@@ -4934,10 +4943,19 @@ class HubUser {
     await expect(this.page.getByRole("button", { name: /Connect|Revoke/u })).toHaveCount(0);
   }
 
+  /**
+   * An instance with no provider credentials, seen by someone who cannot supply them. The page
+   * says so once and offers nothing: four provider blocks with no action are four ways to say
+   * the same thing to a reader who can do nothing about any of them.
+   */
   async expectNotConfiguredConnections(): Promise<void> {
     await this.openOrganizationSection("Connections");
-    await expect(this.page.getByText("Not configured", { exact: true })).toHaveCount(4);
-    await expect(this.page.getByRole("button", { name: /Connect|Revoke/u })).toHaveCount(0);
+    await expect(this.page.getByText("No connections", { exact: true })).toBeVisible();
+    await expect(this.page.getByText(/no provider apps set up yet/u)).toBeVisible();
+    await expect(this.page.getByRole("button", { name: /Connect|Revoke|Set up the/u })).toHaveCount(
+      0,
+    );
+    await expect(this.page.getByText("Not configured", { exact: true })).toHaveCount(0);
     await expectAccessible(this.page);
   }
 
@@ -4945,7 +4963,7 @@ class HubUser {
     await this.openOrganizationSection("Connections");
     await this.requestGitHubApproval();
     await this.requestGitHubApproval();
-    await expect(this.page.getByText("No connections", { exact: true })).toBeVisible();
+    await this.expectNoConnections();
   }
 
   private async requestGitHubApproval(): Promise<void> {
@@ -4956,7 +4974,7 @@ class HubUser {
     await this.page.getByRole("button", { name: "Connect GitHub" }).click();
     await returned;
     await expect(this.page).toHaveURL(connectionsUrl);
-    await expect(this.page.getByRole("status")).toHaveText(
+    await this.expectConnectionFailure(
       "A GitHub organization owner has to approve this installation. Nothing was connected. Ask an owner to approve the request, then install again.",
     );
   }
@@ -5183,11 +5201,14 @@ class HubUser {
     await this.page.reload();
   }
 
+  /** Every connection a provider card lists. Each provider owns its own list on the page. */
   private connectionRow(provider: string): Locator {
-    return this.page
-      .getByRole("table", { name: "Connections" })
-      .getByRole("row")
-      .filter({ has: this.page.getByRole("cell", { name: provider, exact: true }) });
+    return this.page.getByRole("list", { name: `${provider} connections` }).getByRole("listitem");
+  }
+
+  /** No provider lists any connection, whatever the reason there is nothing to list. */
+  private async expectNoConnections(): Promise<void> {
+    await expect(this.page.getByRole("list", { name: /^\w+ connections$/u })).toHaveCount(0);
   }
 
   private async chooseOption(select: Locator, option: string): Promise<void> {

--- a/e2e/helpers/projects/connections.ts
+++ b/e2e/helpers/projects/connections.ts
@@ -6,6 +6,8 @@ export class ProjectConnections {
   async connectGitHub() {
     await this.page.getByRole("button", { name: "Connect GitHub" }).click();
     await expect(this.page.getByRole("heading", { name: "Connections", level: 1 })).toBeVisible();
-    await expect(this.page.getByRole("cell", { name: /acme-inc.*installation/u })).toBeVisible();
+    await expect(
+      this.page.getByRole("list", { name: "GitHub connections" }).getByRole("listitem"),
+    ).toContainText(/acme-inc.*installation/u);
   }
 }

--- a/src/auth/account-states.tsx
+++ b/src/auth/account-states.tsx
@@ -6,7 +6,7 @@ import {
   ProductMark,
 } from "../components/app/auth-layout.js";
 import { AuthActions } from "../components/app/auth-form.js";
-import { Alert, AlertDescription } from "../components/ui/alert.js";
+import { Alert } from "../components/ui/alert.js";
 import { Button } from "../components/ui/button.js";
 
 /**
@@ -26,7 +26,7 @@ export function ErrorSummary({ message }: { message: string | undefined }) {
   }, [message]);
   return message === undefined ? null : (
     <Alert ref={alert} tabIndex={-1} variant="destructive">
-      <AlertDescription>{message}</AlertDescription>
+      {message}
     </Alert>
   );
 }
@@ -57,9 +57,7 @@ export function FailedEntry({ message }: { message: string }) {
   return (
     <AuthLayout>
       <AuthCard titleId="account-failed-heading" title="Sign in to Paseo Hub">
-        <Alert variant="destructive">
-          <AlertDescription>{message}</AlertDescription>
-        </Alert>
+        <Alert variant="destructive">{message}</Alert>
       </AuthCard>
     </AuthLayout>
   );
@@ -73,11 +71,7 @@ export function UnavailableInvitation({ message }: { message: string | undefined
         title="Invitation unavailable"
         description="This link is invalid, expired, already used, or belongs to another account."
       >
-        {message === undefined ? null : (
-          <Alert variant="destructive">
-            <AlertDescription>{message}</AlertDescription>
-          </Alert>
-        )}
+        {message === undefined ? null : <Alert variant="destructive">{message}</Alert>}
         <AuthActions>
           <Button asChild size="lg">
             <a href="/">Continue to Paseo Hub</a>

--- a/src/components/app/card.tsx
+++ b/src/components/app/card.tsx
@@ -10,12 +10,15 @@ import { Skeleton } from "../ui/skeleton.js";
  * optional: a card with neither is just the box.
  */
 export function Card({
+  icon,
   title,
   description,
   action,
   children,
   className,
 }: {
+  /** A glyph identifying what the card is about, beside its title. */
+  icon?: ReactNode;
   title?: string;
   description?: string;
   /** A single trailing link or button belonging to the card, not to its body. */
@@ -29,12 +32,19 @@ export function Card({
   return (
     <section className={cn("grid min-w-0 gap-4 rounded-xl border bg-card p-6", className)}>
       {titled ? (
-        <div className="flex min-w-0 items-start justify-between gap-4">
-          <div className="grid min-w-0 gap-1">
-            {title === undefined ? null : <h2 className="text-sm text-foreground">{title}</h2>}
-            {description === undefined ? null : (
-              <p className="text-sm text-muted-foreground">{description}</p>
+        <div className="flex min-w-0 items-center justify-between gap-4">
+          <div className="flex min-w-0 items-center gap-2.5">
+            {icon === undefined ? null : (
+              <span aria-hidden="true" className="flex shrink-0 items-center [&>svg]:size-4">
+                {icon}
+              </span>
             )}
+            <div className="grid min-w-0 gap-1">
+              {title === undefined ? null : <h2 className="text-sm text-foreground">{title}</h2>}
+              {description === undefined ? null : (
+                <p className="text-sm text-muted-foreground">{description}</p>
+              )}
+            </div>
           </div>
           {action === undefined ? null : <div className="shrink-0">{action}</div>}
         </div>

--- a/src/components/app/data-table-skeleton.test.tsx
+++ b/src/components/app/data-table-skeleton.test.tsx
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, it } from "vitest";
-import { DataTable, DataTableSkeleton, type DataColumn } from "./data-table.js";
+import { DataCell, DataRow, DataTable, DataTableSkeleton, type DataColumn } from "./data-table.js";
 
 const COLUMNS: readonly DataColumn[] = [
   { header: "Trigger" },
@@ -21,8 +21,12 @@ describe("data table skeleton", () => {
   it("draws the same shell and columns as the table it stands in for", () => {
     const skeleton = renderToStaticMarkup(<DataTableSkeleton label="Triggers" columns={COLUMNS} />);
     const loaded = renderToStaticMarkup(
-      <DataTable label="Triggers" columns={COLUMNS} isEmpty empty={EMPTY}>
-        {null}
+      <DataTable label="Triggers" columns={COLUMNS} isEmpty={false} empty={EMPTY}>
+        <DataRow>
+          {COLUMNS.map((column) => (
+            <DataCell key={column.header}>{column.header}</DataCell>
+          ))}
+        </DataRow>
       </DataTable>,
     );
 
@@ -46,5 +50,17 @@ describe("data table skeleton", () => {
     const markup = renderToStaticMarkup(<DataTableSkeleton label="Triggers" columns={COLUMNS} />);
 
     assert.doesNotMatch(markup, /No triggers/u);
+  });
+
+  it("drops the table entirely when there is nothing to list", () => {
+    const markup = renderToStaticMarkup(
+      <DataTable label="Triggers" columns={COLUMNS} isEmpty empty={EMPTY}>
+        {null}
+      </DataTable>,
+    );
+
+    assert.match(markup, /No triggers/u);
+    assert.doesNotMatch(markup, /<table/u);
+    assert.doesNotMatch(markup, /Trigger</u);
   });
 });

--- a/src/components/app/data-table.tsx
+++ b/src/components/app/data-table.tsx
@@ -15,9 +15,11 @@ export interface DataColumn {
 }
 
 /**
- * The one table shell: bordered card, quiet header row, one body-row height, and a built-in
- * empty row spanning the full width. Every list of records on the dashboard goes through here,
- * so members and daemons cannot drift apart.
+ * The one table shell: bordered card, quiet header row, one body-row height, and — when there is
+ * nothing to list — the empty state instead of the table. Column headers over no rows are a
+ * promise the screen cannot keep, so an empty list drops the card and says what is missing where
+ * the records would have been. Every list of records on the dashboard goes through here, so
+ * members and daemons cannot drift apart.
  */
 export function DataTable({
   label,
@@ -28,27 +30,23 @@ export function DataTable({
 }: {
   label: string;
   columns: readonly DataColumn[];
-  empty: { title: string; description?: string; align?: "center" | "start"; action?: ReactNode };
+  empty: { title: string; description?: string; action?: ReactNode };
   isEmpty: boolean;
   children: ReactNode;
 }) {
+  if (isEmpty) {
+    return (
+      <EmptyState
+        title={empty.title}
+        {...(empty.description === undefined ? {} : { description: empty.description })}
+      >
+        {empty.action}
+      </EmptyState>
+    );
+  }
   return (
     <TableShell label={label} columns={columns}>
-      {isEmpty ? (
-        <TableRow>
-          <TableCell colSpan={columns.length} className="p-0">
-            <EmptyState
-              title={empty.title}
-              {...(empty.description === undefined ? {} : { description: empty.description })}
-              {...(empty.align === undefined ? {} : { align: empty.align })}
-            >
-              {empty.action}
-            </EmptyState>
-          </TableCell>
-        </TableRow>
-      ) : (
-        children
-      )}
+      {children}
     </TableShell>
   );
 }

--- a/src/components/app/empty-state.tsx
+++ b/src/components/app/empty-state.tsx
@@ -1,38 +1,32 @@
 import type { ReactNode } from "react";
 
-import { cn } from "../../lib/utils.js";
-
 /**
  * The one empty state: a short noun phrase, a line of context, and — when there is exactly one
- * thing to do next — the way to do it.
- *
- * `align` is about the next step, not about taste. A button or a link reads centred; a command
- * to copy is a value, and a value that is centred is a value nobody can scan. Choose `start`
- * when the child has a left edge worth keeping.
+ * thing to do next — the way to do it. Always centred, and always on the page's own background:
+ * a bordered box drawn around "there is nothing here" is a frame around nothing.
  */
 export function EmptyState({
   title,
   description,
-  align = "center",
   children,
 }: {
   title: string;
   description?: string;
-  align?: "center" | "start";
   /** The single next step: a command to copy, a link to the docs, a button. */
   children?: ReactNode;
 }) {
-  const centred = align === "center";
   return (
-    <div className={cn("grid gap-2 px-6 py-12", centred && "justify-items-center text-center")}>
+    <div className="grid justify-items-center gap-2 px-6 py-12">
       <p className="text-sm">{title}</p>
       {description === undefined ? null : (
-        <p className="max-w-md text-sm text-balance text-muted-foreground">{description}</p>
+        <p className="max-w-md text-center text-sm text-balance text-muted-foreground">
+          {description}
+        </p>
       )}
+      {/* The next step keeps its own alignment: a command is a value, and a centred value is a
+          value nobody can scan. */}
       {children === undefined ? null : (
-        <div className={cn("mt-4 grid w-full max-w-md gap-3", centred && "justify-items-center")}>
-          {children}
-        </div>
+        <div className="mt-4 grid w-full max-w-sm gap-3">{children}</div>
       )}
     </div>
   );

--- a/src/components/app/failure-alert.tsx
+++ b/src/components/app/failure-alert.tsx
@@ -2,7 +2,7 @@ import { CircleCheck, Info, TriangleAlert } from "lucide-react";
 import { useEffect, useRef, type ReactNode } from "react";
 
 import type { Result } from "../../contract/respond.js";
-import { Alert, AlertDescription, AlertTitle } from "../ui/alert.js";
+import { Alert } from "../ui/alert.js";
 import { Button } from "../ui/button.js";
 
 /**
@@ -13,6 +13,12 @@ import { Button } from "../ui/button.js";
  * looks like.
  */
 const PAGE_STACK_GAP = "mb-6";
+
+// One element per glyph, created once: an alert's icon never changes, and a fresh element on
+// every render is a new prop identity for no reason.
+const WARNING_GLYPH = <TriangleAlert />;
+const SUCCESS_GLYPH = <CircleCheck />;
+const NEUTRAL_GLYPH = <Info />;
 
 function standaloneClass(standalone: boolean): string | undefined {
   return standalone ? PAGE_STACK_GAP : undefined;
@@ -83,20 +89,18 @@ export function FailureAlert({
     <Alert
       ref={alert}
       variant="destructive"
+      icon={WARNING_GLYPH}
+      title={title}
       className={standaloneClass(standalone)}
       {...(focusOnArrival ? { tabIndex: -1 } : {})}
     >
-      <TriangleAlert aria-hidden="true" />
-      <AlertTitle>{title}</AlertTitle>
-      <AlertDescription>
-        <p>{message}</p>
-        {details}
-        {onRetry === undefined ? null : (
-          <Button type="button" size="sm" variant="outline" onClick={onRetry}>
-            Try again
-          </Button>
-        )}
-      </AlertDescription>
+      <p>{message}</p>
+      {details}
+      {onRetry === undefined ? null : (
+        <Button type="button" size="sm" variant="outline" onClick={onRetry}>
+          Try again
+        </Button>
+      )}
     </Alert>
   );
 }
@@ -119,39 +123,46 @@ export function NoticeAlert({
   standalone?: boolean;
   children: ReactNode;
 }) {
-  const Icon = tone === "success" ? CircleCheck : Info;
   return (
     <Alert
       role="status"
       variant={tone === "success" ? "success" : "default"}
+      icon={tone === "success" ? SUCCESS_GLYPH : NEUTRAL_GLYPH}
       className={standaloneClass(standalone)}
+      {...(title === undefined ? {} : { title })}
     >
-      <Icon aria-hidden="true" />
-      {title === undefined ? null : <AlertTitle>{title}</AlertTitle>}
-      <AlertDescription>{children}</AlertDescription>
+      {children}
     </Alert>
   );
 }
 
 /**
- * Something the reader should know before they act, that does not stop them acting. Warnings
- * are the same shape as failures so the two read as one system; only the colour differs.
+ * Something the reader should know before they act, that does not stop them acting. Every alert
+ * on the dashboard is the same shape — glyph, title, message, optional trailing control — and
+ * only the colour and the glyph say which kind it is.
  */
 export function WarningAlert({
   title,
+  action,
   standalone = false,
   children,
 }: {
   title?: string;
+  /** The way out of the warning, at the far edge: a link to the page that resolves it. */
+  action?: ReactNode;
   /** Set when the alert stands in a page stack rather than inside a form, dialog, or section. */
   standalone?: boolean;
   children: ReactNode;
 }) {
   return (
-    <Alert variant="warning" className={standaloneClass(standalone)}>
-      <TriangleAlert aria-hidden="true" />
-      {title === undefined ? null : <AlertTitle>{title}</AlertTitle>}
-      <AlertDescription>{children}</AlertDescription>
+    <Alert
+      variant="warning"
+      icon={WARNING_GLYPH}
+      className={standaloneClass(standalone)}
+      {...(title === undefined ? {} : { title })}
+      {...(action === undefined ? {} : { action })}
+    >
+      {children}
     </Alert>
   );
 }

--- a/src/components/app/record-list.tsx
+++ b/src/components/app/record-list.tsx
@@ -1,0 +1,44 @@
+import type { ReactNode } from "react";
+
+/**
+ * A short list of records inside a card, for the times a table would be wrong: the records are
+ * already grouped by the card's own subject, so a header row would only repeat it.
+ *
+ * A table is still the answer for a page-level list of many records with real columns. Reach for
+ * this when a card owns a handful of rows and the only columns are "what it is" and "what state
+ * it is in" — four provider cards each listing their own connections, not one connections table.
+ */
+export function RecordList({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <ul aria-label={label} className="grid divide-y divide-border">
+      {children}
+    </ul>
+  );
+}
+
+/**
+ * One record: what it is on the left, its state and its actions on the right. The row owns the
+ * distance to its neighbours so no card decides that for itself.
+ */
+export function RecordRow({
+  children,
+  status,
+  actions,
+}: {
+  /** The identity of the record, normally a `TwoLine`. */
+  children: ReactNode;
+  /** Its state, always a `StatusPill`. */
+  status?: ReactNode;
+  /** Its actions, always behind a `RowActions` kebab. */
+  actions?: ReactNode;
+}) {
+  return (
+    <li className="flex min-w-0 items-center justify-between gap-3 py-3 first:pt-0 last:pb-0">
+      <div className="min-w-0">{children}</div>
+      <div className="flex shrink-0 items-center gap-2">
+        {status}
+        {actions}
+      </div>
+    </li>
+  );
+}

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -3,58 +3,87 @@ import { cva, type VariantProps } from "class-variance-authority";
 
 import { cn } from "../../lib/utils.js";
 
-const alertVariants = cva(
-  "relative grid w-full grid-cols-[0_1fr] items-start gap-y-0.5 rounded-lg border px-4 py-3 text-sm has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] has-[>svg]:gap-x-3 [&>*:not(svg)]:col-start-2 [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current",
-  {
-    variants: {
-      variant: {
-        default: "bg-card text-card-foreground",
-        destructive:
-          "bg-card text-destructive *:data-[slot=alert-description]:text-destructive/90 [&>svg]:text-current",
-        success:
-          "bg-card text-success *:data-[slot=alert-description]:text-success/90 [&>svg]:text-current",
-        warning:
-          "border-warning/40 bg-warning-surface text-warning *:data-[slot=alert-description]:text-warning/90 [&>svg]:text-current",
-      },
-    },
-    defaultVariants: {
-      variant: "default",
+const alertVariants = cva("flex w-full items-start gap-3 rounded-lg border px-4 py-3 text-sm", {
+  variants: {
+    variant: {
+      default:
+        "bg-card text-card-foreground [&_[data-slot=alert-description]]:text-muted-foreground",
+      destructive: "bg-card text-destructive [&_[data-slot=alert-description]]:text-destructive/90",
+      success: "bg-card text-success [&_[data-slot=alert-description]]:text-success/90",
+      warning:
+        "border-warning/40 bg-warning-surface text-warning [&_[data-slot=alert-description]]:text-warning/90",
     },
   },
-);
+  defaultVariants: {
+    variant: "default",
+  },
+});
 
+/**
+ * One anatomy for every alert: a glyph, a title over its message, and — when there is one thing
+ * to do about it — a control at the far edge, centred against the whole message. The alert owns
+ * that assembly rather than each caller repeating it, because three callers repeating it is how
+ * two of them ended up with different spacing between a title and the line under it.
+ *
+ * The rows are laid out with flex, not grid: an action spanning grid rows resolves against the
+ * *explicit* grid, so it silently landed in the title's row and stretched it to button height.
+ */
 function Alert({
   className,
   variant,
+  icon,
+  title,
+  action,
+  children,
   ...props
-}: React.ComponentProps<"div"> & VariantProps<typeof alertVariants>) {
+}: React.ComponentProps<"div"> &
+  VariantProps<typeof alertVariants> & {
+    /** The tone's glyph. Sized and coloured here; callers pass the bare icon. */
+    icon?: React.ReactNode;
+    title?: React.ReactNode;
+    /** The single control belonging to the alert, e.g. a link to the page that resolves it. */
+    action?: React.ReactNode;
+  }) {
   return (
     <div
       data-slot="alert"
       role="alert"
       className={cn(alertVariants({ variant }), className)}
       {...props}
-    />
+    >
+      {icon === undefined ? null : (
+        <span
+          aria-hidden="true"
+          className="shrink-0 translate-y-0.5 [&>svg]:size-4 [&>svg]:text-current"
+        >
+          {icon}
+        </span>
+      )}
+      <div className="grid min-w-0 flex-1 gap-0.5">
+        {title === undefined ? null : <AlertTitle>{title}</AlertTitle>}
+        {children === undefined ? null : <AlertDescription>{children}</AlertDescription>}
+      </div>
+      {action === undefined ? null : (
+        <div data-slot="alert-action" className="shrink-0 self-center pl-3">
+          {action}
+        </div>
+      )}
+    </div>
   );
 }
 
 function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
-  return (
-    <div data-slot="alert-title" className={cn("col-start-2 min-h-4", className)} {...props} />
-  );
+  return <div data-slot="alert-title" className={cn("min-w-0", className)} {...props} />;
 }
 
 function AlertDescription({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="alert-description"
-      className={cn(
-        "col-start-2 grid justify-items-start gap-1 text-sm text-muted-foreground [&_p]:leading-relaxed",
-        className,
-      )}
+      className={cn("grid min-w-0 justify-items-start gap-2 text-current", className)}
       {...props}
     />
   );
 }
 
-export { Alert, AlertTitle, AlertDescription };
+export { Alert };

--- a/src/connections/result-contract.ts
+++ b/src/connections/result-contract.ts
@@ -47,10 +47,9 @@ export interface ConnectionReturn {
   reference?: string;
 }
 
-export interface ConnectionReturnCopy {
-  tone: "success" | "error";
-  message: string;
-}
+export type ConnectionReturnCopy =
+  | { tone: "success"; message: string }
+  | { tone: "error"; title: string; message: string };
 
 /**
  * Where a callback lands when the attempt that started it cannot be read, so neither the
@@ -129,6 +128,14 @@ export function connectionReturnCopy(value: ConnectionReturn): ConnectionReturnC
   return { ...copy, message: withReference(copy.message, value.reference) };
 }
 
+/**
+ * A return that connected nothing is a failed request, and it is headed the way every other
+ * failure on the dashboard is: the thing that did not happen, then why, then what to do next.
+ */
+function failed(name: string, message: string): ConnectionReturnCopy {
+  return { tone: "error", title: `${name} wasn't connected`, message };
+}
+
 const RETURN_COPY: Readonly<Record<ConnectionResult, (name: string) => ConnectionReturnCopy>> = {
   github_connected: connected,
   discord_connected: connected,
@@ -142,38 +149,38 @@ const RETURN_COPY: Readonly<Record<ConnectionResult, (name: string) => Connectio
   slack_cancelled: (name) => cancelled("Installation", name),
   discord_cancelled: (name) => cancelled("Authorization", name),
   linear_cancelled: (name) => cancelled("Authorization", name),
-  github_approval_required: () => ({
-    tone: "error",
-    message:
+  github_approval_required: (name) =>
+    failed(
+      name,
       "A GitHub organization owner has to approve this installation. Nothing was connected. Ask an owner to approve the request, then install again.",
-  }),
-  slack_bot_failed: () => ({
-    tone: "error",
-    message:
+    ),
+  slack_bot_failed: (name) =>
+    failed(
+      name,
       "Slack installed the app without every permission Hub needs. Nothing was saved. Reapply the manifest under Features → OAuth & Permissions, then install again.",
-  }),
-  provider_not_configured: () => ({
-    tone: "error",
-    message: "There are no saved credentials to connect yet. Verify and save the app first.",
-  }),
-  connection_invalid: () => ({
-    tone: "error",
-    message:
+    ),
+  provider_not_configured: (name) =>
+    failed(name, "There are no saved credentials to connect yet. Verify and save the app first."),
+  connection_invalid: (name) =>
+    failed(
+      name,
       "That connection link had already been used or had expired, so it was refused. Nothing was connected. Start the connection again from this page.",
-  }),
-  connection_conflict: () => ({
-    tone: "error",
-    message:
+    ),
+  connection_conflict: (name) =>
+    failed(
+      name,
       "That account is already connected to another organization. Nothing was connected. Disconnect it there, or pick a different one.",
-  }),
-  connection_unauthenticated: (name) => ({
-    tone: "error",
-    message: `${name} sent you back to a Hub address this browser isn't signed in to, so nothing was connected. Sign in there, or ask your Hub operator to check the ${name} app's callback and setup URLs, then start the connection again.`,
-  }),
-  connection_unavailable: (name) => ({
-    tone: "error",
-    message: `Hub couldn't finish the ${name} connection. Nothing was connected. Start the connection again from this page.`,
-  }),
+    ),
+  connection_unauthenticated: (name) =>
+    failed(
+      name,
+      `${name} sent you back to a Hub address this browser isn't signed in to, so nothing was connected. Sign in there, or ask your Hub operator to check the ${name} app's callback and setup URLs, then start the connection again.`,
+    ),
+  connection_unavailable: (name) =>
+    failed(
+      name,
+      `Hub couldn't finish the ${name} connection. Nothing was connected. Start the connection again from this page.`,
+    ),
 };
 
 function connected(name: string): ConnectionReturnCopy {

--- a/src/daemons/account-daemons.tsx
+++ b/src/daemons/account-daemons.tsx
@@ -48,8 +48,6 @@ const DAEMONS_EMPTY = {
   title: "No daemons connected",
   description:
     "Hub runs your workflows on machines you own. Log in from the machine where your code lives and the CLI offers to connect it.",
-  // A command is a value, and a centred value is a value nobody can scan.
-  align: "start",
   action: <ConnectDaemonHint />,
 } as const;
 

--- a/src/projects/panels.tsx
+++ b/src/projects/panels.tsx
@@ -5,21 +5,17 @@ import { useServerFn } from "@tanstack/react-start";
 import { type FormEvent, type ReactNode } from "react";
 import { CONNECTION_MUTATION_KEY } from "../auth/tenant-mutation.js";
 import { useActiveAccount } from "../auth/active-account.js";
-import { Card } from "../components/app/card.js";
+import { Card, CardSkeleton } from "../components/app/card.js";
 import { ConfirmAction, ConfirmMenuItem } from "../components/app/confirm-action.js";
 import { CodeBlock } from "../components/app/copy-field.js";
-import {
-  DataCell,
-  DataRow,
-  DataTable,
-  DataTableSkeleton,
-  type DataColumn,
-} from "../components/app/data-table.js";
+import { DataCell, DataRow, DataTable } from "../components/app/data-table.js";
 import { FormActions } from "../components/app/form-actions.js";
 import { FormField } from "../components/app/form-field.js";
-import { NoticeAlert } from "../components/app/failure-alert.js";
+import { FailureAlert, NoticeAlert } from "../components/app/failure-alert.js";
+import { EmptyState } from "../components/app/empty-state.js";
 import { PageHeader } from "../components/app/page.js";
 import { RelativeTime, formatAbsolute } from "../components/app/relative-time.js";
+import { RecordList, RecordRow } from "../components/app/record-list.js";
 import { RowActions } from "../components/app/row-actions.js";
 import { Section } from "../components/app/section.js";
 import { StatusPill, statusLabel } from "../components/app/status-pill.js";
@@ -53,20 +49,18 @@ import {
   type ProjectSnapshot,
 } from "./panel-state.js";
 import { archiveProject, activityRunSnapshot, updateProjectSlug } from "./functions.js";
-const CONNECTION_COLUMNS: readonly DataColumn[] = [
-  { header: "Connection" },
-  { header: "Provider" },
-  { header: "Status" },
-  { header: "" },
-];
 const CONNECTIONS_DESCRIPTION = "Organization provider connections.";
+const CONNECTION_PROVIDERS = ["github", "discord", "slack", "linear"] as const;
+type ConnectionProviderName = (typeof CONNECTION_PROVIDERS)[number];
 
 function ConnectionsLoading() {
   return (
     <>
       <PageHeader title="Connections" description={CONNECTIONS_DESCRIPTION} />
-      <Section title="Connections">
-        <DataTableSkeleton label="Connections" columns={CONNECTION_COLUMNS} />
+      <Section>
+        {CONNECTION_PROVIDERS.map((provider) => (
+          <CardSkeleton key={provider} lines={2} />
+        ))}
       </Section>
     </>
   );
@@ -112,7 +106,7 @@ export function OrganizationConnectionsPanel() {
   );
   if (!status.ok) return status.element;
   const data = snapshot.data;
-  const connectProvider = (provider: "github" | "discord" | "slack" | "linear") => {
+  const connectProvider = (provider: ConnectionProviderName) => {
     connect.mutate(
       { data: { ...scope, provider } },
       {
@@ -124,7 +118,7 @@ export function OrganizationConnectionsPanel() {
   };
   const rows = connectionRows(data);
   const busy = connect.isPending || disconnect.isPending;
-  const connectionActionLabel = (provider: "github" | "discord" | "slack" | "linear") => {
+  const connectionActionLabel = (provider: ConnectionProviderName) => {
     if (
       (provider === "slack" || provider === "linear") &&
       status.data[provider].status === "requiresReauthorization"
@@ -141,6 +135,41 @@ export function OrganizationConnectionsPanel() {
     }
     return "Connect";
   };
+  const providerAction = (provider: ConnectionProviderName): ReactNode => {
+    if (!data.capabilities.manageResources) return undefined;
+    // An app nobody has given Hub credentials for cannot be connected from here, and only an
+    // instance operator can change that. Everyone else is told nothing about instance
+    // credentials: a state they cannot act on is not news, and a card with only a name on it is
+    // the page talking about work they cannot do.
+    if (status.data[provider].status === "notConfigured") {
+      if (!isInstanceOperator) return undefined;
+      return (
+        <Button variant="outline" size="sm" asChild>
+          <Link to={"/apps" as never}>Set up the {providerLabel(provider)} app</Link>
+        </Button>
+      );
+    }
+    return (
+      <Button disabled={busy} variant="outline" size="sm" onClick={() => connectProvider(provider)}>
+        {connectionActionLabel(provider)} {providerLabel(provider)}
+      </Button>
+    );
+  };
+  // A provider block that can neither be acted on nor list anything says only its own name.
+  // That is every provider for someone who cannot connect one, and four of them is the whole
+  // page talking about work the reader cannot do.
+  const shown = CONNECTION_PROVIDERS.map((provider) => ({
+    provider,
+    connections: rows.filter((connection) => connection.provider === provider),
+    action: providerAction(provider),
+  })).filter((block) => block.action !== undefined || block.connections.length > 0);
+  // Whose problem the empty page is: an instance with no provider apps is the operator's, an
+  // organization that has connected nothing is its owners'.
+  const nothingToConnect = CONNECTION_PROVIDERS.every(
+    (provider) => status.data[provider].status === "notConfigured",
+  )
+    ? "This Hub has no provider apps set up yet. Ask whoever runs it to add one."
+    : "An organization owner connects the providers this organization can use.";
   return (
     <>
       <PageHeader title="Connections" description={CONNECTIONS_DESCRIPTION} />
@@ -148,25 +177,68 @@ export function OrganizationConnectionsPanel() {
         <ConnectionReturnBanner copy={connectionReturnCopy(returned)} />
       )}
       <CommandError mutations={[connect, disconnect]} />
-      <Section title="Connections">
-        <DataTable
-          label="Connections"
-          columns={CONNECTION_COLUMNS}
-          isEmpty={rows.length === 0}
-          empty={{ title: "No connections" }}
-        >
-          {rows.map((connection) => (
-            <DataRow key={`${connection.provider}-${connection.id}`}>
-              <DataCell>
-                <TwoLine primary={connection.name} secondary={connection.externalId} mono />
-              </DataCell>
-              <DataCell>
-                <span className="inline-flex items-center gap-2">
-                  <ProviderGlyph provider={connection.provider} />
-                  {providerLabel(connection.provider)}
-                </span>
-              </DataCell>
-              <DataCell>
+      <Section>
+        {shown.length === 0 ? (
+          <EmptyState title="No connections" description={nothingToConnect} />
+        ) : (
+          shown.map(({ provider, connections, action }) => (
+            <ProviderConnections
+              key={provider}
+              provider={provider}
+              connections={connections}
+              canManage={data.capabilities.manageResources}
+              busy={busy}
+              action={action}
+              onRevoke={(connectionId) =>
+                disconnect.mutate({ data: { ...scope, provider, connectionId } })
+              }
+            />
+          ))
+        )}
+      </Section>
+      <Section
+        title="Known unrouted events"
+        description="Events received for this organization that were not routed to a workflow."
+      >
+        <ActivityTable activity={data.unroutedEvents} label="Unrouted events" showReason />
+      </Section>
+    </>
+  );
+}
+
+/**
+ * One integration, top to bottom: what it is, the one way to connect it, and the accounts it is
+ * already connected to. A provider with nothing connected is the same card without a list, so
+ * the page reads as the same four blocks whatever state the organization is in.
+ */
+function ProviderConnections({
+  provider,
+  connections,
+  canManage,
+  busy,
+  action,
+  onRevoke,
+}: {
+  provider: ConnectionProviderName;
+  connections: readonly ConnectionRecord[];
+  canManage: boolean;
+  busy: boolean;
+  action: ReactNode;
+  onRevoke: (connectionId: string) => void;
+}) {
+  const label = providerLabel(provider);
+  return (
+    <Card
+      icon={<ProviderGlyph provider={provider} />}
+      title={label}
+      {...(action === undefined ? {} : { action })}
+    >
+      {connections.length === 0 ? null : (
+        <RecordList label={`${label} connections`}>
+          {connections.map((connection) => (
+            <RecordRow
+              key={connection.id}
+              status={
                 <StatusPill
                   tone={
                     connection.status === "suspended" ||
@@ -177,9 +249,9 @@ export function OrganizationConnectionsPanel() {
                 >
                   {connectionStatusLabel(connection.status)}
                 </StatusPill>
-              </DataCell>
-              <DataCell align="end">
-                {data.capabilities.manageResources ? (
+              }
+              actions={
+                canManage ? (
                   <RowActions label={`Actions for ${connection.name}`}>
                     <ConfirmMenuItem
                       busy={busy}
@@ -189,56 +261,18 @@ export function OrganizationConnectionsPanel() {
                       description="Projects using this credential will stop receiving new events."
                       confirmLabel="Revoke connection"
                       cancelLabel="Cancel"
-                      onConfirm={() =>
-                        disconnect.mutate({
-                          data: {
-                            ...scope,
-                            provider: connection.provider,
-                            connectionId: connection.id,
-                          },
-                        })
-                      }
+                      onConfirm={() => onRevoke(connection.id)}
                     />
                   </RowActions>
-                ) : null}
-              </DataCell>
-            </DataRow>
+                ) : undefined
+              }
+            >
+              <TwoLine primary={connection.name} secondary={connection.externalId} mono />
+            </RecordRow>
           ))}
-        </DataTable>
-        {data.capabilities.manageResources ? (
-          <div className="grid gap-2 sm:grid-cols-4">
-            {(["github", "discord", "slack", "linear"] as const).map((provider) => (
-              <div
-                key={provider}
-                className="flex items-center justify-between gap-2 rounded-md border p-3"
-              >
-                <span className="inline-flex items-center gap-2 text-sm">
-                  <ProviderGlyph provider={provider} />
-                  {providerLabel(provider)}
-                </span>
-                {status.data[provider].status === "notConfigured" ? (
-                  <UnconfiguredProvider provider={provider} operator={isInstanceOperator} />
-                ) : (
-                  <Button
-                    disabled={busy}
-                    variant="outline"
-                    onClick={() => connectProvider(provider)}
-                  >
-                    {connectionActionLabel(provider)} {providerLabel(provider)}
-                  </Button>
-                )}
-              </div>
-            ))}
-          </div>
-        ) : null}
-      </Section>
-      <Section
-        title="Known unrouted events"
-        description="Events received for this organization that were not routed to a workflow."
-      >
-        <ActivityTable activity={data.unroutedEvents} label="Unrouted events" showReason />
-      </Section>
-    </>
+        </RecordList>
+      )}
+    </Card>
   );
 }
 
@@ -609,17 +643,30 @@ function ActivityTable({
 }
 
 /**
- * What the provider sent the operator back with. A return is an announcement about the round trip
- * they just took, not a failure of the page they landed on, so both tones read as one live region
- * and the banner owns the distance to the table below it.
+ * What the provider sent the operator back with. A round trip that connected nothing is a failed
+ * request — the operator pressed Connect and came back to a page that looks unchanged — so it is
+ * reported as one rather than as news. Success is still an announcement. Either way the banner
+ * owns the distance to the table below it.
  */
 function ConnectionReturnBanner({ copy }: { copy: ConnectionReturnCopy }) {
+  if (copy.tone === "error") {
+    return (
+      <FailureAlert
+        standalone
+        title={copy.title}
+        error={copy.message}
+        fallback="Hub couldn't finish the connection. Start it again from this page."
+      />
+    );
+  }
   return (
-    <NoticeAlert standalone tone={copy.tone === "success" ? "success" : "neutral"}>
+    <NoticeAlert standalone tone="success">
       {copy.message}
     </NoticeAlert>
   );
 }
+
+type ConnectionRecord = ReturnType<typeof connectionRows>[number];
 
 function connectionRows(data: OrganizationSnapshot) {
   return [
@@ -657,26 +704,7 @@ function connectionRows(data: OrganizationSnapshot) {
     })),
   ];
 }
-/**
- * An operator can do something about an app that is not set up, so they get the way to do it.
- * A member cannot, and learns nothing about instance credentials either way.
- */
-function UnconfiguredProvider({
-  provider,
-  operator,
-}: {
-  provider: "github" | "discord" | "slack" | "linear";
-  operator: boolean;
-}) {
-  if (!operator) return <StatusPill tone="neutral">Not configured</StatusPill>;
-  return (
-    <Button variant="link" asChild>
-      <Link to={"/apps" as never}>Set up the {providerLabel(provider)} app</Link>
-    </Button>
-  );
-}
-
-function providerLabel(provider: "github" | "discord" | "slack" | "linear") {
+function providerLabel(provider: ConnectionProviderName) {
   if (provider === "github") return "GitHub";
   if (provider === "discord") return "Discord";
   return provider === "slack" ? "Slack" : "Linear";

--- a/src/provider-applications/provider-section.tsx
+++ b/src/provider-applications/provider-section.tsx
@@ -51,10 +51,7 @@ export interface SectionReturn {
   message: string;
 }
 
-interface Outcome {
-  tone: "success" | "error";
-  message: string;
-}
+type Outcome = SectionReturn;
 
 type SaveResponse = Result<ProviderApplicationSaveResult>;
 type ConnectResponse = Result<{ url: string }>;

--- a/src/triggers/panel.tsx
+++ b/src/triggers/panel.tsx
@@ -111,11 +111,15 @@ export function TriggersPanel() {
       </PageHeader>
       <div className="grid gap-6">
         {data.daemons.length === 0 ? (
-          <WarningAlert title="Add a daemon first">
+          <WarningAlert
+            title="Add a daemon first"
+            action={
+              <Button asChild variant="outline" size="sm">
+                <Link to={`/o/${scope.organizationSlug}/daemons` as never}>Go to Daemons</Link>
+              </Button>
+            }
+          >
             <p>Triggers need a daemon to run.</p>
-            <Button asChild variant="outline" size="sm">
-              <Link to={`/o/${scope.organizationSlug}/daemons` as never}>Go to Daemons</Link>
-            </Button>
           </WarningAlert>
         ) : null}
         <DataTable


### PR DESCRIPTION
The Connections page is now one block per integration — the provider, its one action, and the accounts it is already connected to — and a provider return that connected nothing is reported as the failed request it is instead of a neutral notice that is easy to miss. Lists with no records show the empty state on the page background rather than a table with a hollow body.

## Goals

- A connection attempt that changed nothing reads as a failure, headed by the thing that did not happen.
- One alert anatomy across the dashboard: glyph, title, message, at most one control at the far edge.
- No empty tables. A list with nothing in it is the empty state, centred, on the background.
- Connections is stacked per integration, with the connect action in each integration's header.
- Nobody is shown a state they cannot act on: no "Not configured" pill, and no provider card that has no action and nothing to list.

## Non-goals

- Changing what "Set up the … app" does, or where it goes. It still routes an instance operator to `/apps`; its wording remains an open question.
- Touching the app-setup surface (`/apps`) or its per-provider sections.
- Any change to connection semantics, statuses, or the provider protocol.

## The why

Three things were wrong at the same time and they share one cause: the screens were assembling shared shapes themselves.

- `NoticeAlert` was carrying an error tone, so "That account is already connected to another organization" was drawn in the same quiet grey box a success uses.
- The warning alert's trailing button used `row-span-full`, which resolves against the **explicit** grid — with no explicit rows it collapsed to row 1 and stretched the title row to button height, which is why the title and its subtitle sat 30px apart while the failure alert's sat 22px apart. `Alert` now owns the whole anatomy and lays it out with flex, so three callers cannot drift again.
- Connections drew a page-wide table of every provider's connections plus a separate four-across tile strip of connect buttons, so the same integration appeared in two places and neither said what state it was in.

`Card` gained an `icon`, and `RecordList`/`RecordRow` joined the roster for a card's own few records — a header row would only repeat the card's subject. `docs/design.md` records all of it.

## Verification

- Typecheck, lint, format, and the component/typography/contract unit tests are green.
- Driven in a real browser against a fresh instance: failed connection return, triggers warning, daemons empty state, connections empty and populated (fabricated rows, reverted), the operator and non-operator views, the bare auth error alert, and all three surfaces at phone width with no horizontal overflow.
- Playwright was not run locally; CI covers it.

## Risk surface

- **E2E helpers were rewritten**, not just the screens: `connectionRow` now targets each provider's list instead of a table row, the "No connections" assertions became "no provider lists anything", and `expectNotConfiguredConnections` asserts the empty state instead of four pills. This is the most likely place for CI to disagree.
- `Alert` no longer exports `AlertTitle`/`AlertDescription`; every caller goes through `FailureAlert`, `NoticeAlert`, `WarningAlert`, or passes children to `Alert`.
- `DataTable` renders the empty state instead of the table for **every** list, not only daemons.
- Error copy for connection returns gained a title (`"GitHub wasn't connected"`); the messages themselves are unchanged.
- Touches `docs/design.md` and `src/triggers/panel.tsx`, which [#115](https://github.com/getpaseo/hub/pull/115) also touches — expect a conflict in whichever lands second.