### PR TITLE
Expose supported events and label qualifiers in trigger forms

### DIFF
--- a/e2e/helpers/triggers.ts
+++ b/e2e/helpers/triggers.ts
@@ -1,3 +1,4 @@
+import { parseDocument } from "yaml";
 import { expect, type Page } from "@playwright/test";
 
 export class OrganizationTriggers {
@@ -29,6 +30,43 @@ export class OrganizationTriggers {
     await expect(topbar.getByRole("radio", { name: "YAML" })).toBeVisible();
     await expect(topbar.getByRole("button", { name: "Discard" })).toBeVisible();
     await expect(this.page.getByLabel("Trigger ID")).toHaveValue("Assigned when saved");
+  }
+
+  async exploreEventQualifiers() {
+    await this.page.getByRole("combobox", { name: "When this happens" }).click();
+    const search = this.page.getByPlaceholder("Select an event…");
+    await expect(search).toBeFocused();
+    await expect(search).toHaveCSS("outline-style", "none");
+    await this.page.screenshot({ path: "e2e/screenshots/triggers/event-picker.png" });
+    await search.fill("pull request created");
+    await expect(
+      this.page.getByRole("option", {
+        name: "GitHub pull request created github.pull_request_created",
+        exact: true,
+      }),
+    ).toBeVisible();
+    await this.page.keyboard.press("Escape");
+    await this.selectOption("When this happens", "github.pull_request_label_added");
+    await expect(this.page.getByRole("radio", { name: "Any label", exact: true })).toBeHidden();
+    await expect(this.page.getByLabel("Added label", { exact: true })).toHaveValue("");
+
+    await this.page.getByLabel("Added label", { exact: true }).fill("ready-for-review");
+    await this.page.getByLabel("Added label", { exact: true }).scrollIntoViewIfNeeded();
+    await this.page.screenshot({ path: "e2e/screenshots/triggers/added-label-qualifier.png" });
+    await this.selectOption("When this happens", "github.issue_label_added");
+    await expect(this.page.getByLabel("Added label", { exact: true })).toHaveValue(
+      "ready-for-review",
+    );
+    await this.page.screenshot({ path: "e2e/screenshots/triggers/issue-label-qualifier.png" });
+    await expect(this.page.getByLabel("Added label", { exact: true })).toHaveAttribute(
+      "required",
+      "",
+    );
+    await this.selectOption("When this happens", "slack.mention");
+    await expect(this.page.getByLabel("Added label", { exact: true })).toBeHidden();
+    await this.selectOption("When this happens", "github.pull_request_label_added");
+    await expect(this.page.getByLabel("Added label", { exact: true })).toHaveValue("");
+    await expect(this.page.getByRole("radio", { name: "Any label", exact: true })).toBeHidden();
   }
 
   async configureSlackMention(input: {
@@ -94,6 +132,56 @@ export class OrganizationTriggers {
     await this.selectOption("Execution mode", input.mode);
     await this.selectOption("Thinking", input.thinking);
     await this.page.getByLabel("Instructions", { exact: true }).fill(input.prompt);
+  }
+
+  async configureLabelAdded(input: { name: string; daemon: string; event: string }) {
+    await this.configureManual({
+      name: input.name,
+      daemon: input.daemon,
+      cwd: "/workspace/acme",
+      agent: "pi/gateway/vendor/model-v1",
+      mode: "full-access",
+      thinking: "high",
+      prompt: "Handle the labeled item.",
+    });
+    await this.selectOption("When this happens", input.event);
+    await this.page.getByRole("combobox", { name: "Connection", exact: true }).click();
+    await this.page.getByRole("option", { name: "acme-inc", exact: true }).click();
+  }
+
+  async changeAddedLabel(label: string) {
+    await this.page.getByLabel("Added label", { exact: true }).fill(label);
+  }
+
+  async expectLabelRequiredOnSubmit() {
+    const url = this.page.url();
+    await this.page
+      .locator("#trigger-editor-form")
+      .getByRole("button", { name: /Create trigger|Save changes/u })
+      .click();
+    await expect(
+      this.page.getByRole("alert").filter({ hasText: "This trigger is not ready to save" }),
+    ).toContainText("Added label is required.");
+    await expect(this.page.getByLabel("Added label", { exact: true })).toHaveAttribute(
+      "aria-invalid",
+      "true",
+    );
+    await expect(this.page).toHaveURL(url);
+  }
+
+  async expectPersistedLabel(event: string, label: string) {
+    await this.page.reload();
+    await expect(this.page.getByRole("combobox", { name: "When this happens" })).toHaveAttribute(
+      "data-value",
+      event,
+    );
+    await expect(this.page.getByLabel("Added label", { exact: true })).toHaveValue(label);
+    await this.switchToYaml();
+    expect(parseDocument(await this.yamlEditor().innerText()).toJS()).toMatchObject({
+      on: { [event]: { filters: { label } } },
+    });
+    await this.switchToForm();
+    await expect(this.page.getByLabel("Added label", { exact: true })).toHaveValue(label);
   }
 
   async switchToYaml() {

--- a/e2e/triggers.spec.ts
+++ b/e2e/triggers.spec.ts
@@ -22,6 +22,7 @@ test("requires daemon setup before trigger configuration", async ({ hub, page })
   );
   await page.screenshot({ path: `${SHOTS}/00-no-daemon-callout.png`, fullPage: true });
   await triggers.startNew();
+  await triggers.exploreEventQualifiers();
   await expect(
     page.getByText("No daemon is connected to this organization yet", { exact: false }),
   ).toBeVisible();
@@ -128,6 +129,50 @@ test("creates a trigger visually, preserves advanced YAML through the form, and 
     await triggers.capture(`${SHOTS}/07-legacy-workflow-warning.png`);
   });
 });
+
+for (const scenario of [
+  { event: "github.issue_label_added", name: "issue-label" },
+  { event: "github.pull_request_label_added", name: "pr-label" },
+]) {
+  test(`saves, reloads, and requires a label for ${scenario.event}`, async ({ hub, page }) => {
+    await hub.signUpAs("owner", owner);
+    await hub.createOrganization("owner", "Acme");
+    const daemon = await hub.connectProviderDaemon("owner", "Acme");
+    await hub.connectGitHub("owner");
+    const triggers = new OrganizationTriggers(page);
+
+    await test.step("reject an otherwise complete form with an empty or blank label", async () => {
+      await triggers.open();
+      await triggers.startNew();
+      await triggers.configureLabelAdded({ ...scenario, daemon });
+      await triggers.expectLabelRequiredOnSubmit();
+      await triggers.changeAddedLabel("   ");
+      await triggers.expectLabelRequiredOnSubmit();
+      await triggers.capture(`${SHOTS}/${scenario.name}-required.png`);
+    });
+
+    await test.step("save through the form and verify persisted YAML after reload", async () => {
+      await triggers.changeAddedLabel("ready-for-review");
+      await triggers.save(scenario.name);
+      await triggers.openTrigger(scenario.name);
+      await triggers.expectPersistedLabel(scenario.event, "ready-for-review");
+    });
+
+    await test.step("reject clearing a saved label without changing the saved trigger", async () => {
+      await triggers.changeAddedLabel("");
+      await triggers.expectLabelRequiredOnSubmit();
+      await triggers.expectPersistedLabel(scenario.event, "ready-for-review");
+    });
+
+    await test.step("edit the label and verify the new value survives another reload", async () => {
+      await triggers.changeAddedLabel("ready-to-ship");
+      await triggers.save(scenario.name);
+      await triggers.openTrigger(scenario.name);
+      await triggers.expectPersistedLabel(scenario.event, "ready-to-ship");
+      await triggers.capture(`${SHOTS}/${scenario.name}-persisted.png`);
+    });
+  });
+}
 
 function advancedTriggerYaml(daemon: string) {
   return `# survives form edits

--- a/src/components/app/combobox.tsx
+++ b/src/components/app/combobox.tsx
@@ -16,6 +16,7 @@ export interface ComboboxOption {
   keywords?: readonly string[];
   /** The quiet second line under the label. */
   detail?: string;
+  icon?: ReactNode;
   disabled?: boolean;
 }
 
@@ -103,13 +104,14 @@ export function Combobox<T extends ComboboxOption>({
         >
           <span
             className={cn(
-              "truncate",
+              "flex min-w-0 items-center gap-2",
               comboboxSelection(options, value) === undefined &&
                 value === "" &&
                 "text-extra-muted-foreground",
             )}
           >
-            {comboboxLabel(options, value, placeholder, loading)}
+            {comboboxSelection(options, value)?.icon}
+            <span className="truncate">{comboboxLabel(options, value, placeholder, loading)}</span>
           </span>
           {loading ? (
             <Spinner className="opacity-50" />
@@ -145,6 +147,7 @@ export function Combobox<T extends ComboboxOption>({
                       aria-hidden="true"
                       className={cn(option.value === value ? "opacity-100" : "opacity-0")}
                     />
+                    {option.icon}
                     {renderOption === undefined ? (
                       <span className="grid min-w-0 gap-0.5">
                         <span className="truncate">{option.label}</span>

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -27,7 +27,7 @@ function CommandInput({
       <CommandPrimitive.Input
         data-slot="command-input"
         className={cn(
-          "flex h-8 w-full rounded-md bg-transparent text-sm placeholder:text-extra-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+          "flex h-8 w-full outline-none bg-transparent text-sm placeholder:text-extra-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
           className,
         )}
         {...props}

--- a/src/styles.css
+++ b/src/styles.css
@@ -210,7 +210,7 @@
     font-weight: 400;
   }
 
-  /* Linear's focus ring. One pixel, two pixel offset, everywhere, no exceptions. */
+  /* Default focus ring. Composite controls may own focus styling in their primitives. */
   :focus-visible {
     outline: 1px solid var(--ring);
     outline-offset: 2px;

--- a/src/triggers/configuration/editor.test.ts
+++ b/src/triggers/configuration/editor.test.ts
@@ -1,7 +1,9 @@
+import { EDITOR_EVENTS } from "./events.js";
 import { describe, expect, test } from "vitest";
 import { parseDocument } from "yaml";
 import { TriggerDocumentSchema } from "./schema.js";
 import {
+  changeTriggerEvent,
   createTriggerYaml,
   mergeTriggerForm,
   patchTriggerYaml,
@@ -9,6 +11,11 @@ import {
   splitAgentId,
   triggerFormErrors,
 } from "./editor.js";
+
+import {
+  GITHUB_SEMANTIC_TRIGGER_EVENT_NAMES,
+  GITHUB_TRIGGER_SOURCE_NAMES,
+} from "../github/classification.js";
 
 const ADVANCED = `# keep this heading
 name: answer
@@ -148,6 +155,7 @@ describe("trigger form YAML bridge", () => {
       event: "manual.run",
       connection: "",
       allowedUsers: "*",
+      qualifiers: {},
       daemon: "office",
       cwd: "/workspace",
       agent: "codex/gpt-5.4",
@@ -183,6 +191,7 @@ describe("trigger form YAML bridge", () => {
       event: "manual.run",
       connection: "",
       allowedUsers: "*",
+      qualifiers: {},
       daemon: "office",
       cwd: "/workspace",
       agent: "opencode",
@@ -312,3 +321,108 @@ describe("what the form still needs", () => {
     });
   });
 });
+
+test.each([
+  "github.pull_request_created",
+  "github.issue_created",
+  "linear.issue_assigned",
+  "linear.comment_created",
+  "linear.issue_entered_scope",
+])("edits supported event %s", (event) => {
+  expect(projectTriggerForm(ADVANCED.replace("slack.mention", event)).status).toBe("editable");
+});
+
+test("round trips the added label separately from existing item labels", () => {
+  const yaml = ADVANCED.replace("slack.mention", "github.pull_request_label_added").replace(
+    "channels: [engineering]",
+    "label: ready\n      labels: [bug]",
+  );
+  const projection = projectTriggerForm(yaml);
+  expect(projection.status).toBe("editable");
+  if (projection.status !== "editable") throw new Error("not editable");
+  expect(projection.value.qualifiers.label).toBe("ready");
+  const patched = patchTriggerYaml(yaml, { ...projection.value, qualifiers: { label: "review" } });
+  expect(
+    TriggerDocumentSchema.parse(parseDocument(patched).toJS()).on["github.pull_request_label_added"]
+      ?.filters,
+  ).toEqual({
+    from_users: ["*"],
+    label: "review",
+    labels: ["bug"],
+  });
+  expect(() => patchTriggerYaml(patched, { ...projection.value, qualifiers: {} })).toThrow(
+    "Added label is required.",
+  );
+});
+
+test("offers every supported GitHub semantic event and webhook source", () => {
+  for (const event of [...GITHUB_SEMANTIC_TRIGGER_EVENT_NAMES, ...GITHUB_TRIGGER_SOURCE_NAMES]) {
+    expect(EDITOR_EVENTS).toContain(event);
+  }
+});
+
+test("creates a qualified event and removes the qualifier when changing event kind", () => {
+  const initial = projectTriggerForm(ADVANCED);
+  if (initial.status !== "editable") throw new Error(initial.reason);
+  const yaml = createTriggerYaml({
+    ...initial.value,
+    event: "github.issue_label_added",
+    qualifiers: { label: "ready" },
+  });
+  const projection = projectTriggerForm(yaml);
+  if (projection.status !== "editable") throw new Error(projection.reason);
+  expect(projection.value.qualifiers.label).toBe("ready");
+  const changed = patchTriggerYaml(yaml, {
+    ...projection.value,
+    event: "github.pull_request_created",
+  });
+  expect(
+    TriggerDocumentSchema.parse(parseDocument(changed).toJS()).on["github.pull_request_created"]
+      ?.filters,
+  ).toEqual({ from_users: ["*"] });
+});
+
+test("event changes carry compatible qualifiers and reset provider-bound values", () => {
+  const projection = projectTriggerForm(
+    ADVANCED.replace("slack.mention", "github.issue_label_added").replace(
+      "channels: [engineering]",
+      "label: ready",
+    ),
+  );
+  if (projection.status !== "editable") throw new Error(projection.reason);
+  const initial = { ...projection.value, qualifiers: { label: "ready" } };
+  const pr = changeTriggerEvent(initial, "github.pull_request_label_added");
+  expect(pr.qualifiers).toEqual({ label: "ready" });
+  expect(pr.connection).toBe(initial.connection);
+  const created = changeTriggerEvent(pr, "github.issue_created");
+  expect(created.qualifiers).toEqual({});
+  const slack = changeTriggerEvent(pr, "slack.mention");
+  expect(slack.qualifiers).toEqual({});
+  expect(slack.connection).toBe("");
+});
+
+test.each(["github.issue_label_added", "github.pull_request_label_added"])(
+  "requires an added label for %s",
+  (event) => {
+    const projection = projectTriggerForm(
+      ADVANCED.replace("slack.mention", event).replace("channels: [engineering]", "label: ready"),
+    );
+    if (projection.status !== "editable") throw new Error(projection.reason);
+    expect(triggerFormErrors({ ...projection.value, qualifiers: { label: "  " } })).toEqual({
+      "qualifiers.label": "Added label is required.",
+    });
+    expect(triggerFormErrors({ ...projection.value, qualifiers: {} })).toEqual({
+      "qualifiers.label": "Added label is required.",
+    });
+  },
+);
+
+test.each(["github.issue_label_added", "github.pull_request_label_added"])(
+  "rejects YAML without an added label for %s",
+  (event) => {
+    const missing = ADVANCED.replace("slack.mention", event);
+    expect(TriggerDocumentSchema.safeParse(parseDocument(missing).toJS()).success).toBe(false);
+    const blank = missing.replace("channels: [engineering]", 'label: "   "');
+    expect(TriggerDocumentSchema.safeParse(parseDocument(blank).toJS()).success).toBe(false);
+  },
+);

--- a/src/triggers/configuration/editor.ts
+++ b/src/triggers/configuration/editor.ts
@@ -2,19 +2,13 @@ import { parseDocument, stringify, type Document } from "yaml";
 import { z } from "zod";
 import { IDENTIFIER, TriggerDocumentSchema, type TriggerDocument } from "./schema.js";
 
-export const EDITOR_EVENTS = [
-  "slack.mention",
-  "discord.mention",
-  "github.issue_comment",
-  "linear.issue_created",
-  "manual.run",
-] as const;
-
-export type EditorEvent = (typeof EDITOR_EVENTS)[number];
-
-export function parseEditorEvent(value: string): EditorEvent {
-  return isEditorEvent(value) ? value : "manual.run";
-}
+import {
+  eventDefinition,
+  isEditorEvent,
+  type EditorEvent,
+  type QualifierValues,
+  type QualifierKey,
+} from "./events.js";
 
 export interface TriggerFormValue {
   name: string;
@@ -22,6 +16,7 @@ export interface TriggerFormValue {
   event: EditorEvent;
   connection: string;
   allowedUsers: string;
+  qualifiers: QualifierValues;
   daemon: string;
   cwd: string;
   agent: string;
@@ -78,6 +73,7 @@ function toFormValue(
     event,
     connection: definition.connection ?? "",
     allowedUsers: definition.filters?.from_users?.join(", ") ?? "*",
+    qualifiers: readQualifiers(event, definition.filters),
     daemon: trigger.run.target.daemon,
     cwd: trigger.run.target.cwd,
     agent: joinAgentId(agent.provider, agent.model),
@@ -121,6 +117,16 @@ export function patchTriggerYaml(yaml: string, value: TriggerFormValue): string 
   } else {
     setIfChanged(document, ["on", value.event, "connection"], value.connection);
     setIfChanged(document, ["on", value.event, "filters", "from_users"], users(value.allowedUsers));
+  }
+
+  const qualifiers = authoredQualifiers(value);
+  const ownedKeys = new Set(
+    [...eventDefinition(previousEvent).qualifiers, ...eventDefinition(value.event).qualifiers].map(
+      (qualifier) => qualifier.key,
+    ),
+  );
+  for (const key of ownedKeys) {
+    setOptional(document, ["on", value.event, "filters", key], qualifiers[key]);
   }
 
   setIfChanged(document, ["run", "target", "daemon"], value.daemon);
@@ -183,7 +189,13 @@ export function createTriggerYaml(value: TriggerFormValue): string {
   const definition =
     value.event === "manual.run"
       ? {}
-      : { connection: value.connection, filters: { from_users: users(value.allowedUsers) } };
+      : {
+          connection: value.connection,
+          filters: {
+            from_users: users(value.allowedUsers),
+            ...authoredQualifiers(value),
+          },
+        };
   return stringify(
     {
       name: value.name,
@@ -240,7 +252,9 @@ function parsePermissions(value: string): Record<string, "read" | "write" | "adm
 }
 
 /** What is wrong with each field, keyed by the field that has to change. */
-export type TriggerFieldErrors = Partial<Record<keyof TriggerFormValue, string>>;
+export type TriggerFieldErrors = Partial<
+  Record<keyof TriggerFormValue | `qualifiers.${QualifierKey}`, string>
+>;
 
 /**
  * Every reason this form cannot become a trigger document, addressed to the field that owns it.
@@ -261,6 +275,12 @@ export function triggerFormErrors(value: TriggerFormValue): TriggerFieldErrors {
     if (value.connection.trim().length === 0) errors.connection = "Connection is required.";
     if (value.allowedUsers.trim().length === 0) {
       errors.allowedUsers = "Name at least one user ID, or let everyone trigger it.";
+    }
+  }
+  for (const qualifier of eventDefinition(value.event).qualifiers) {
+    const selection = value.qualifiers[qualifier.key];
+    if (qualifier.required && (selection === undefined || selection.trim().length === 0)) {
+      errors[`qualifiers.${qualifier.key}`] = `${qualifier.label} is required.`;
     }
   }
   if (value.daemon.trim().length === 0) errors.daemon = "Daemon is required.";
@@ -381,6 +401,44 @@ function blankToUndefined(value: string): string | undefined {
   return normalized.length === 0 ? undefined : normalized;
 }
 
-function isEditorEvent(value: string): value is EditorEvent {
-  return EDITOR_EVENTS.some((event) => event === value);
+/** Provider-bound state and qualifier compatibility belong to the form model. */
+export function changeTriggerEvent(value: TriggerFormValue, event: EditorEvent): TriggerFormValue {
+  const previous = eventDefinition(value.event);
+  const next = eventDefinition(event);
+  const sameProvider = previous.provider === next.provider;
+  const qualifiers: QualifierValues = {};
+  if (sameProvider) {
+    for (const qualifier of next.qualifiers) {
+      if (
+        previous.qualifiers.some(
+          (candidate) => candidate.key === qualifier.key && candidate.kind === qualifier.kind,
+        )
+      ) {
+        const selection = value.qualifiers[qualifier.key];
+        if (selection !== undefined) qualifiers[qualifier.key] = selection;
+      }
+    }
+  }
+  return { ...value, event, qualifiers, connection: sameProvider ? value.connection : "" };
+}
+
+function readQualifiers(
+  event: EditorEvent,
+  filters: TriggerDocument["on"][string]["filters"],
+): QualifierValues {
+  const values: QualifierValues = {};
+  for (const qualifier of eventDefinition(event).qualifiers) {
+    const value = filters?.[qualifier.key];
+    if (value !== undefined) values[qualifier.key] = value;
+  }
+  return values;
+}
+
+function authoredQualifiers(value: TriggerFormValue): QualifierValues {
+  const filters: QualifierValues = {};
+  for (const qualifier of eventDefinition(value.event).qualifiers) {
+    const selection = value.qualifiers[qualifier.key];
+    if (selection !== undefined) filters[qualifier.key] = selection.trim();
+  }
+  return filters;
 }

--- a/src/triggers/configuration/events.ts
+++ b/src/triggers/configuration/events.ts
@@ -1,0 +1,74 @@
+/** The YAML filter keys the form knows how to qualify. */
+export type QualifierKey = "label";
+
+/** Draft values for the qualifiers declared by the selected event. */
+export type QualifierValues = Partial<Record<QualifierKey, string>>;
+
+export interface QualifierDefinition {
+  key: QualifierKey;
+  kind: "string";
+  label: string;
+  description: string;
+  required: boolean;
+}
+
+interface EventDefinition {
+  provider: "github" | "slack" | "discord" | "linear" | "manual";
+  label: string;
+  qualifiers: readonly QualifierDefinition[];
+}
+
+const ADDED_LABEL: QualifierDefinition = {
+  key: "label",
+  kind: "string",
+  label: "Added label",
+  description:
+    "Match the label added by this event, not labels already on the issue or pull request.",
+  required: true,
+};
+
+function event(
+  provider: EventDefinition["provider"],
+  label: string,
+  qualifiers: readonly QualifierDefinition[] = [],
+): EventDefinition {
+  return { provider, label, qualifiers };
+}
+
+const EVENTS = {
+  "slack.mention": event("slack", "Slack mention"),
+  "discord.mention": event("discord", "Discord mention"),
+  "github.issue_created": event("github", "GitHub issue created"),
+  "github.pull_request_created": event("github", "GitHub pull request created"),
+  "github.issue_comment_created": event("github", "GitHub issue comment created"),
+  "github.pull_request_comment_created": event("github", "GitHub pull request comment created"),
+  "github.issue_label_added": event("github", "GitHub issue label added", [ADDED_LABEL]),
+  "github.pull_request_label_added": event("github", "GitHub pull request label added", [
+    ADDED_LABEL,
+  ]),
+  "github.issue_comment": event("github", "GitHub issue or PR comment webhook"),
+  "github.issues": event("github", "GitHub issue webhook"),
+  "github.pull_request": event("github", "GitHub pull request webhook"),
+  "github.pull_request_review": event("github", "GitHub pull request review webhook"),
+  "github.pull_request_review_comment": event("github", "GitHub review comment webhook"),
+  "github.push": event("github", "GitHub push"),
+  "linear.issue_entered_scope": event("linear", "Linear issue entered scope"),
+  "linear.issue_assigned": event("linear", "Linear issue assigned"),
+  "linear.comment_created": event("linear", "Linear comment created"),
+  "manual.run": event("manual", "Manual run"),
+};
+
+export type EditorEvent = keyof typeof EVENTS;
+export const EDITOR_EVENTS = Object.keys(EVENTS).filter(isEditorEvent);
+
+export function isEditorEvent(value: string): value is EditorEvent {
+  return Object.hasOwn(EVENTS, value);
+}
+
+export function parseEditorEvent(value: string): EditorEvent {
+  return isEditorEvent(value) ? value : "manual.run";
+}
+
+export function eventDefinition(eventId: EditorEvent): EventDefinition {
+  return EVENTS[eventId];
+}

--- a/src/triggers/configuration/schema.ts
+++ b/src/triggers/configuration/schema.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { eventDefinition, isEditorEvent } from "./events.js";
 import { AuthoredGitHubAuthoritySchema } from "../../config/github-authority.js";
 
 type JsonPrimitive = string | number | boolean | null;
@@ -120,6 +121,19 @@ export const TriggerDocumentSchema = z
   })
   .strict()
   .superRefine((trigger, context) => {
+    for (const [event, definition] of Object.entries(trigger.on)) {
+      if (!isEditorEvent(event)) continue;
+      for (const qualifier of eventDefinition(event).qualifiers) {
+        const value = definition.filters?.[qualifier.key];
+        if (qualifier.required && (value === undefined || value.trim().length === 0)) {
+          context.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["on", event, "filters", qualifier.key],
+            message: `${qualifier.label} is required.`,
+          });
+        }
+      }
+    }
     if (Object.keys(trigger.on).length === 0) {
       context.addIssue({
         code: z.ZodIssueCode.custom,

--- a/src/triggers/event-fields.tsx
+++ b/src/triggers/event-fields.tsx
@@ -1,0 +1,41 @@
+/* oxlint-disable eslint-plugin-react-perf/jsx-no-new-function-as-prop -- qualifier controls bind the definition and value rendered beside them */
+import { FormField } from "../components/app/form-field.js";
+import {
+  eventDefinition,
+  type EditorEvent,
+  type QualifierKey,
+  type QualifierValues,
+} from "./configuration/events.js";
+import type { TriggerFieldErrors } from "./configuration/editor.js";
+
+/** Event definitions provide the fields; this component only renders their controls. */
+export function EventFields({
+  event,
+  values,
+  errors,
+  onChange,
+}: {
+  event: EditorEvent;
+  values: QualifierValues;
+  errors: TriggerFieldErrors;
+  onChange: (values: QualifierValues) => void;
+}) {
+  const update = (key: QualifierKey, value: string) => onChange({ ...values, [key]: value });
+  return eventDefinition(event).qualifiers.map((qualifier) => {
+    const error = errors[`qualifiers.${qualifier.key}`];
+    return (
+      <FormField
+        key={qualifier.key}
+        id={`trigger-qualifier-${qualifier.key}`}
+        name={qualifier.key}
+        label={qualifier.label}
+        description={qualifier.description}
+        kind="text"
+        value={values[qualifier.key] ?? ""}
+        onChange={(next) => update(qualifier.key, next)}
+        required={qualifier.required}
+        {...(error === undefined ? {} : { error })}
+      />
+    );
+  });
+}

--- a/src/triggers/panel.tsx
+++ b/src/triggers/panel.tsx
@@ -30,8 +30,8 @@ import { CodeEditor } from "../projects/configuration/code-editor.js";
 import { useRouteTenant } from "../projects/context.js";
 import type { Result } from "../contract/respond.js";
 import {
+  changeTriggerEvent,
   mergeTriggerForm,
-  parseEditorEvent,
   projectTriggerForm,
   triggerFormErrors,
   type TriggerFieldErrors,
@@ -40,6 +40,13 @@ import {
 import { saveTrigger, triggerSnapshot, type TriggerSnapshot } from "./functions.js";
 import { daemonProviderSnapshot } from "../daemons/functions.js";
 import type { HubProviderSnapshot, HubProviderSnapshotEntry } from "../hub/protocol.js";
+import { EventFields } from "./event-fields.js";
+import {
+  EDITOR_EVENTS,
+  eventDefinition,
+  isEditorEvent,
+  parseEditorEvent,
+} from "./configuration/events.js";
 import { selectedProviderModel } from "./provider-catalog.js";
 
 type BrowserTrigger = TriggerSnapshot["triggers"][number];
@@ -61,20 +68,16 @@ const TRIGGER_COLUMNS = [
   { header: "Status" },
 ] as const;
 
-/** The event names the form supports, and how each one reads in a sentence. */
-const EVENT_LABELS: Record<string, string> = {
-  "slack.mention": "Slack mention",
-  "discord.mention": "Discord mention",
-  "github.issue_comment": "GitHub issue comment",
-  "linear.issue_created": "Linear issue created",
-  "manual.run": "Manual run",
-};
-
-// The picker names the event, with its identifier underneath: an operator matching a trigger to
-// a YAML document needs the identifier, and a table scanning past it does not.
-const EVENT_OPTIONS: readonly ComboboxOption[] = Object.entries(EVENT_LABELS).map(
-  ([value, label]) => ({ value, label, detail: value, keywords: [value] }),
-);
+const EVENT_OPTIONS: readonly ComboboxOption[] = EDITOR_EVENTS.map((value) => {
+  const { label, provider } = eventDefinition(value);
+  return {
+    value,
+    label,
+    detail: value,
+    keywords: [label, value],
+    icon: <ProviderGlyph provider={provider} />,
+  };
+});
 
 const TRIGGERS_DESCRIPTION = "Launch agents on your compute when organization events arrive.";
 const TRIGGER_EDITOR_DESCRIPTION = "One event launches one agent on your compute.";
@@ -573,7 +576,7 @@ function TriggerForm({
   snapshot: TriggerSnapshot;
   onChange: (value: TriggerFormValue) => void;
 }) {
-  const provider = form.event.split(".")[0];
+  const { provider } = eventDefinition(form.event);
   const connections = snapshot.connections.filter((connection) => connection.provider === provider);
   const githubConnections = snapshot.connections.filter(
     (connection) => connection.provider === "github",
@@ -658,7 +661,9 @@ function TriggerForm({
                   options={EVENT_OPTIONS}
                   placeholder="Select an event"
                   empty="No events found."
-                  onChange={(option) => update("event", parseEditorEvent(option.value))}
+                  onChange={(option) =>
+                    onChange(changeTriggerEvent(form, parseEditorEvent(option.value)))
+                  }
                 />
               )}
             </FormField>
@@ -684,6 +689,12 @@ function TriggerForm({
               </FormField>
             )}
           </div>
+          <EventFields
+            event={form.event}
+            values={form.qualifiers}
+            errors={errors}
+            onChange={(qualifiers) => update("qualifiers", qualifiers)}
+          />
         </Card>
 
         {form.event === "manual.run" ? null : (
@@ -1231,6 +1242,7 @@ function defaultForm(snapshot: TriggerSnapshot): TriggerFormValue {
     event: slack === undefined ? "manual.run" : "slack.mention",
     connection: slack?.slug ?? "",
     allowedUsers: "*",
+    qualifiers: {},
     daemon: "",
     cwd: "/workspace",
     agent: "",
@@ -1249,5 +1261,5 @@ function defaultForm(snapshot: TriggerSnapshot): TriggerFormValue {
 }
 
 function eventLabel(event: string): string {
-  return EVENT_LABELS[event] ?? event;
+  return isEditorEvent(event) ? eventDefinition(event).label : event;
 }


### PR DESCRIPTION
The trigger form now lists the events Hub can actually handle, identifies each provider with its integration mark, and removes the extra focus outline from combobox search. GitHub issue-label-added and pull-request-label-added events require the added label and preserve it through form and YAML editing.

## Goals

- Show every supported Slack, Discord, GitHub, Linear, and manual trigger event in the event picker.
- Display the existing integration mark for each event.
- Model event qualifiers in an event-owned catalog instead of event-specific form branches.
- Require an added label for both GitHub label-added event types.
- Preserve advanced YAML filters while editing form-owned qualifier values.
- Cover required validation, save, reload, YAML projection, and editing through user journeys.

## Non-goals

- Add qualifiers for Slack channels or other existing filters.
- Add new runtime event types or matching behavior.

## Why

The runtime supported substantially more events than the form exposed. Event-specific controls would make each new qualifier another branch in the screen, so the event catalog now declares the small set of fields the shared form renders and serializes.

## Verification

- `npm test` — 1,241 passed, 15 skipped
- `npx playwright test e2e/triggers.spec.ts` — 4 passed
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm run db:check`
- `npm run docker:smoke`

## Risk surface

The trigger document schema now rejects GitHub label-added events without a nonblank `filters.label`. Other event filters remain unchanged, and form edits preserve filters the form does not own.