### PR TITLE
Fix hosted replies and preserved workflow dispatch

### DIFF
--- a/src/configuration/store.ts
+++ b/src/configuration/store.ts
@@ -1,5 +1,5 @@
 import { parseTriggerDocument } from "../triggers/configuration/index.js";
-import { dump } from "js-yaml";
+import { dump, load } from "js-yaml";
 import { z } from "zod";
 import {
   compiledConfigurationHash,
@@ -318,6 +318,9 @@ export function parseProjectConfiguration(
   if (adapter.success) {
     if (revision.rawYaml === null)
       throw new Error("Trigger revision is missing its authored document");
+    // Preserved legacy workflows share the adapter but retain their original run policy.
+    const legacy = z.object({ legacy_multistep: z.object({}) }).safeParse(load(revision.rawYaml));
+    if (legacy.success) return toProjectConfiguration(configuration);
     const policy = parseTriggerDocument(revision.rawYaml).run.continuation;
     return toProjectConfiguration({
       ...configuration,

--- a/src/provider-applications/internal/runtime-owner.test.ts
+++ b/src/provider-applications/internal/runtime-owner.test.ts
@@ -12,8 +12,78 @@ import type {
   SlackProviderApplicationConfiguration,
 } from "../index.js";
 import { DynamicProviderRuntime } from "./runtime-owner.js";
+import { OutputExecutorRegistry, replyOutputTool } from "../../execution-capabilities/outputs.js";
+import { createGitHubReplyExecutor, githubReplyAvailable } from "../../triggers/github/reply.js";
 
 describe("dynamic provider runtime", () => {
+  it("exposes and delivers GitHub replies through the hosted provider registration", async () => {
+    const comments: unknown[] = [];
+    const runtime = new DynamicProviderRuntime({
+      database: createMemoryDatabase(),
+      auth: testAuth(),
+      applicationBaseUrl: "https://hub.test",
+      registrationFactory: () => ({
+        ...connectionRegistration("github", "A1"),
+        outputs: [
+          {
+            type: "github.reply",
+            tool: replyOutputTool,
+            available: githubReplyAvailable,
+            execute: createGitHubReplyExecutor({
+              client: {
+                createIssueComment: async (comment) => {
+                  comments.push(comment);
+                },
+              },
+            }),
+          },
+        ],
+      }),
+    });
+    const registry = new OutputExecutorRegistry();
+    for (const registration of runtime.registrations()) {
+      for (const output of registration.outputs) registry.register(output);
+    }
+    const candidate = await runtime.prepare(
+      "github",
+      providerConfiguration("github", "A1"),
+      "https://hub.test",
+      providerIdentity("github", "A1"),
+      1,
+    );
+    await candidate.start();
+    candidate.publish();
+    const outputContext = {
+      provider: "github",
+      target: { installationId: 42, repository: "acme/repo" },
+      event: { github: { item: { number: 7 } } },
+    };
+    const grants = [{ type: "github.reply", required: false }];
+    assert.equal(registry.materialize(grants, outputContext).length, 1);
+    assert.equal(
+      registry.materialize(grants, {
+        ...outputContext,
+        event: { github: { item: null } },
+      }).length,
+      0,
+    );
+    await registry.execute({
+      agentExecutionId: "execution-1",
+      toolType: "github.reply",
+      args: { content: "remembered" },
+      outputContext,
+    });
+    assert.deepEqual(comments, [
+      {
+        installationId: 42,
+        owner: "acme",
+        repo: "repo",
+        issueNumber: 7,
+        body: "remembered",
+      },
+    ]);
+  });
+
   it.each([
     "github.issues",
     "github.issue_comment",

--- a/src/provider-applications/internal/runtime-owner.ts
+++ b/src/provider-applications/internal/runtime-owner.ts
@@ -2,7 +2,7 @@ import type { AuthServer } from "../../auth/server.js";
 import { createHash } from "node:crypto";
 import type { GitHubConfigurationProvider } from "../../configuration/github-sync.js";
 import type { Database } from "../../db/types.js";
-import { outputContextProvider, replyOutputTool } from "../../execution-capabilities/outputs.js";
+import { replyOutputTool } from "../../execution-capabilities/outputs.js";
 import { logger } from "../../logger.js";
 import { reportFailure } from "../../failures/index.js";
 import { createDiscordRegistration } from "../../providers/discord/index.js";
@@ -399,26 +399,28 @@ export class DynamicProviderRuntime implements ProviderRuntimeOwner {
         },
       ],
       sources: [source],
-      outputs:
-        provider === "github"
-          ? []
-          : [
-              {
-                type: `${provider}.reply`,
-                tool: replyOutputTool,
-                available: outputContextProvider(provider),
-                execute: (input) => {
-                  const active = slot.active;
-                  const output = active?.registration.outputs.find(
-                    (candidate) => candidate.type === `${provider}.reply`,
-                  );
-                  if (active === undefined || output === undefined) {
-                    throw unavailable(`${provider}_output_unavailable`);
-                  }
-                  return this.withLease(active, () => output.execute(input));
-                },
-              },
-            ],
+      outputs: [
+        {
+          type: `${provider}.reply`,
+          tool: replyOutputTool,
+          available: (context) => {
+            const output = slot.active?.registration.outputs.find(
+              (candidate) => candidate.type === `${provider}.reply`,
+            );
+            return output !== undefined && (output.available?.(context) ?? true);
+          },
+          execute: (input) => {
+            const active = slot.active;
+            const output = active?.registration.outputs.find(
+              (candidate) => candidate.type === `${provider}.reply`,
+            );
+            if (active === undefined || output === undefined) {
+              throw unavailable(`${provider}_output_unavailable`);
+            }
+            return this.withLease(active, () => output.execute(input));
+          },
+        },
+      ],
       requests:
         provider === "discord"
           ? []

--- a/src/triggers/configuration/index.test.ts
+++ b/src/triggers/configuration/index.test.ts
@@ -176,4 +176,12 @@ it("applies the continuation default when reading old trigger revisions without 
   assert.equal(stored.triggers[0]?.steps[0]?.continuation, undefined);
   const legacy = parseProjectConfiguration({ ...revision, sourceEvidence: { kind: "manual" } });
   assert.equal(legacy.triggers[0]?.steps[0]?.continuation, undefined);
+  const migratedLegacy = parseProjectConfiguration({
+    ...revision,
+    rawYaml: JSON.stringify({
+      name: "preserved-workflow",
+      legacy_multistep: { trigger: stored.triggers[0], environments: stored.environments },
+    }),
+  });
+  assert.deepEqual(migratedLegacy, legacy);
 });


### PR DESCRIPTION
Live hosted QA after #118 found two failures: new GitHub agents received no reply tool, and preserved legacy workflows failed before dispatch because the continuation-default reader parsed their documents as new triggers.

Expose replies through the dynamic registration for every provider, using the active provider's availability check. Preserve the existing policy when an adapter revision contains a legacy workflow document. No schema or daemon protocol changes.

Both failures have failing-first regressions. The hosted-registration test verifies reply materialization and comment delivery; the configuration test reads a preserved legacy adapter revision without adding continuation. The provider, configuration, migration, and related suites pass (179 tests), and the source-built Hub/daemon E2E suite passes all seven tests. Final local verification also passes: 1,252 tests (17 skipped), all 79 browser tests, typecheck, lint, formatting, migration checks, build, and the production-container smoke test. Live GitHub QA will be repeated after deployment.

Risk surface: dynamic reply availability and reading stored organization-trigger revisions. Legacy workflow configuration and historical execution intents remain unchanged.

Refs #118, #121.
