### PR TITLE
fix(daemons): honor configured deadlines during agent startup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,9 +214,6 @@ jobs:
       - name: Install provider CLIs for bundle validation
         run: npm install -g @anthropic-ai/claude-code@2.1.226 @openai/codex@0.144.0
 
-      - name: Install Chromium
-        run: npx playwright install --with-deps chromium
-
       - name: Build Hub production application
         run: npm run build
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ permissions:
 # companion PR creator commits it. Source-built jobs deliberately fail until it
 # is one exact 40-character SHA; mutable refs and repository variables are forbidden.
 env:
-  PASEO_E2E_COMMIT: 76caf0d047bc4437506fbcbbd241da4000769eec
+  PASEO_E2E_COMMIT: 8860f2eb145509ab208a61e45f79e953f9d5d1bb
 
 jobs:
   typecheck:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,10 @@ jobs:
 
       - run: npm ci
       - name: Install Chromium
-        run: npx playwright install --with-deps chromium
+        run: |
+          # Playwright downloads its own Chromium; the runner's Chrome apt feed is unrelated.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome*.list /etc/apt/sources.list.d/google-chrome*.sources
+          npx playwright install --with-deps chromium
       - name: Run built-app browser tests
         run: npm run test:e2e:browser
 

--- a/src/agent-sessions/index.test.ts
+++ b/src/agent-sessions/index.test.ts
@@ -4,21 +4,83 @@ import { AgentSessions } from "./index.js";
 import { createMemoryDatabase } from "../db/memory.js";
 import { OutputExecutorRegistry, replyOutputTool } from "../execution-capabilities/outputs.js";
 import { createExecutionCapabilityServer } from "../execution-capabilities/server.js";
-import type { AgentConnection, AgentSnapshot } from "../daemons/agents/index.js";
+import type { AgentConnection, AgentSnapshot, AgentStartup } from "../daemons/agents/index.js";
 import type { LaunchMachineIntent } from "../dispatcher/launch-machine-intent.js";
 import type { DaemonCreateAgentOptions } from "../daemons/protocol.js";
 
 class TestAgents implements AgentConnection {
+  private readonly creationKeys = new Map<string, AgentSnapshot>();
+  private heldPhase: "create" | "restore" | "send" | "control" | undefined;
+  private phaseStarted!: () => void;
+  private phaseReleased!: () => void;
+  private phaseGate: Promise<void> | undefined;
+  private pendingStartup: string | undefined;
+  hold(phase: "create" | "restore" | "send" | "control") {
+    this.heldPhase = phase;
+    this.phaseGate = new Promise<void>((resolve) => {
+      this.phaseReleased = resolve;
+    });
+    return new Promise<void>((resolve) => {
+      this.phaseStarted = resolve;
+    });
+  }
+  release() {
+    this.phaseReleased();
+  }
+  private readonly pendingControls = new Set<string>();
+  async inspectOperation(key: string) {
+    return {
+      agentId: null,
+      outcome: this.pendingControls.has(key) ? ("pending" as const) : ("settled" as const),
+    };
+  }
+  async cancelOperation(key: string, creationKey: string) {
+    return {
+      agentId: this.creationKeys.get(creationKey)?.id ?? null,
+      outcome: this.pendingStartup === key ? ("pending" as const) : ("settled" as const),
+    };
+  }
+  private async pause(
+    phase: "create" | "restore" | "send" | "control",
+    startup?: { key: string; signal?: AbortSignal },
+  ) {
+    if (this.heldPhase !== phase) return;
+    this.heldPhase = undefined;
+    this.pendingStartup = startup?.key;
+    this.phaseStarted();
+    const operation = this.phaseGate!.then(() => {
+      this.pendingStartup = undefined;
+      return;
+    });
+    let abort: (() => void) | undefined;
+    try {
+      await Promise.race([
+        operation,
+        new Promise<never>((_, reject) => {
+          abort = () => reject(startup?.signal?.reason);
+          startup?.signal?.addEventListener("abort", abort, { once: true });
+        }),
+      ]);
+      startup?.signal?.throwIfAborted();
+    } finally {
+      if (abort) startup?.signal?.removeEventListener("abort", abort);
+    }
+  }
   readonly agents = new Map<string, AgentSnapshot>();
   readonly deliveries: { agentId: string; text: string }[] = [];
   readonly creates: DaemonCreateAgentOptions[] = [];
   readonly messages = new Set<string>();
   archives = 0;
   restorations = 0;
-  async create(_key: string, options: DaemonCreateAgentOptions) {
-    this.creates.push(options);
-    const agent = { id: randomUUID(), workspaceId: randomUUID(), status: "idle" as const };
-    this.agents.set(agent.id, agent);
+  async create(key: string, options: DaemonCreateAgentOptions, startup?: AgentStartup) {
+    let agent = this.creationKeys.get(key);
+    if (!agent) {
+      this.creates.push(options);
+      agent = { id: randomUUID(), workspaceId: randomUUID(), status: "idle" };
+      this.creationKeys.set(key, agent);
+      this.agents.set(agent.id, agent);
+    }
+    await this.pause("create", startup);
     return agent;
   }
   async get(id: string) {
@@ -26,7 +88,8 @@ class TestAgents implements AgentConnection {
     if (!agent) throw new Error("missing");
     return agent;
   }
-  async send(agentId: string, messageId: string, text: string) {
+  async send(agentId: string, messageId: string, text: string, startup?: AgentStartup) {
+    await this.pause("send", startup);
     if (this.messages.has(messageId)) return;
     this.messages.add(messageId);
     this.deliveries.push({ agentId, text });
@@ -34,19 +97,44 @@ class TestAgents implements AgentConnection {
   async watch() {
     return () => {};
   }
-  async restore(workspaceId: string) {
+  async restore(workspaceId: string, startup?: AgentStartup) {
+    await this.pause("restore", startup);
     this.restorations++;
     for (const [id, agent] of this.agents)
       if (agent.workspaceId === workspaceId) this.agents.set(id, { ...agent, archivedAt: null });
     return true;
   }
-  async control(agentId: string, _workspaceId: string, action: "interrupt" | "archive") {
-    if (action === "archive") {
-      this.archives++;
-      this.agents.set(agentId, {
-        ...(await this.get(agentId)),
-        archivedAt: new Date().toISOString(),
-      });
+  async control(
+    agentId: string,
+    _workspaceId: string,
+    action: "interrupt" | "archive",
+    operationKey?: string,
+    signal?: AbortSignal,
+  ) {
+    if (operationKey) this.pendingControls.add(operationKey);
+    const operation = (async () => {
+      await this.pause("control", operationKey ? { key: operationKey } : undefined);
+      if (action === "archive") {
+        this.archives++;
+        this.agents.set(agentId, {
+          ...(await this.get(agentId)),
+          archivedAt: new Date().toISOString(),
+        });
+      }
+    })().finally(() => {
+      if (operationKey) this.pendingControls.delete(operationKey);
+    });
+    let abort: (() => void) | undefined;
+    try {
+      await Promise.race([
+        operation,
+        new Promise<never>((_, reject) => {
+          abort = () => reject(signal?.reason);
+          signal?.addEventListener("abort", abort, { once: true });
+        }),
+      ]);
+    } finally {
+      if (abort) signal?.removeEventListener("abort", abort);
     }
   }
 }
@@ -106,12 +194,19 @@ async function fixture() {
       configurationRevisionId: intent.configurationRevisionId,
       launchIntent: intent,
     });
+    const controller = new AbortController();
     return {
       executionId,
+      cancel: () => controller.abort(new Error("startup expired")),
       dispatch: () =>
         sessions.dispatch({
           executionId,
           intent,
+          startup: {
+            key: executionId,
+            deadlineAt: new Date(Date.now() + 60_000).toISOString(),
+            signal: controller.signal,
+          },
           connection,
           onEvent: () => {},
           createOptions: async () => ({
@@ -233,4 +328,102 @@ test("temporary environment credentials require a new agent instead of being reu
   const fresh = await f.arrival(null, "daemon", env);
   await fresh.dispatch();
   expect(f.connection.creates).toHaveLength(1);
+});
+
+test.each(["create", "restore", "send"] as const)(
+  "expiry during %s releases conversation ownership and accounts for late work",
+  async (phase) => {
+    const f = await fixture();
+    if (phase === "restore") {
+      const initial = await f.arrival();
+      await initial.dispatch();
+      await f.database.transitionAgentExecution(initial.executionId, "succeeded");
+      await f.sessions.control(await f.execution(initial.executionId), f.connection, "archive");
+    }
+    const entered = f.connection.hold(phase);
+    const first = await f.arrival();
+    const dispatch = first.dispatch();
+    const rejected = expect(dispatch).rejects.toThrow("startup expired");
+    await entered;
+    await f.database.transitionAgentExecution(first.executionId, "failed", {
+      hubAction: "archive",
+    });
+    first.cancel();
+    await rejected;
+    await expect(
+      f.sessions.control(await f.execution(first.executionId), f.connection, "archive"),
+    ).rejects.toThrow("cancellation is pending");
+
+    const competing = await f.arrival();
+    await expect(competing.dispatch()).rejects.toThrow("cancellation is pending");
+    await f.database.transitionAgentExecution(competing.executionId, "failed", {
+      hubAction: "archive",
+    });
+    f.connection.release();
+    await expect
+      .poll(async () => {
+        try {
+          await f.sessions.control(await f.execution(first.executionId), f.connection, "archive");
+          return true;
+        } catch {
+          return false;
+        }
+      })
+      .toBe(true);
+    await f.database.completeHubAction(first.executionId, "archive");
+    await f.sessions.control(await f.execution(competing.executionId), f.connection, "archive");
+    await f.database.completeHubAction(competing.executionId, "archive");
+    expect((await f.execution(first.executionId)).daemonAgentId).toBe(
+      phase === "send" ? [...f.connection.agents.keys()][0] : null,
+    );
+    const next = await f.arrival();
+    await next.dispatch();
+    expect(f.connection.creates).toHaveLength(1);
+    expect(f.connection.deliveries).toHaveLength(phase === "restore" ? 2 : 1);
+  },
+);
+
+test("a slow archive remains owned after its acknowledgement wait expires", async () => {
+  const f = await fixture();
+  const first = await f.arrival();
+  await first.dispatch();
+  await f.database.transitionAgentExecution(first.executionId, "succeeded", {
+    hubAction: "archive",
+  });
+  const entered = f.connection.hold("control");
+  const controller = new AbortController();
+  const cleanup = f.sessions.control(
+    await f.execution(first.executionId),
+    f.connection,
+    "archive",
+    controller.signal,
+  );
+  const rejected = expect(cleanup).rejects.toThrow("control wait expired");
+  await entered;
+  controller.abort(new Error("control wait expired"));
+  await rejected;
+  const next = await f.arrival();
+  await expect(next.dispatch()).rejects.toThrow("cleanup is pending");
+  await f.database.transitionAgentExecution(next.executionId, "failed", { hubAction: "archive" });
+  f.connection.release();
+  await expect.poll(() => f.connection.archives).toBe(1);
+  await f.database.completeHubAction(first.executionId, "archive");
+  await f.sessions.control(await f.execution(next.executionId), f.connection, "archive");
+  await f.database.completeHubAction(next.executionId, "archive");
+  const subsequent = await f.arrival();
+  await subsequent.dispatch();
+  expect(f.connection.creates).toHaveLength(1);
+  expect(f.connection.restorations).toBe(1);
+});
+
+test("a continuation cannot overtake a durable cleanup action that has not been acknowledged", async () => {
+  const f = await fixture();
+  const first = await f.arrival();
+  await first.dispatch();
+  await f.database.transitionAgentExecution(first.executionId, "succeeded", {
+    hubAction: "archive",
+  });
+  const next = await f.arrival();
+  await expect(next.dispatch()).rejects.toThrow("cleanup is pending");
+  expect(f.connection.deliveries).toHaveLength(1);
 });

--- a/src/agent-sessions/index.test.ts
+++ b/src/agent-sessions/index.test.ts
@@ -426,4 +426,7 @@ test("a continuation cannot overtake a durable cleanup action that has not been 
   const next = await f.arrival();
   await expect(next.dispatch()).rejects.toThrow("cleanup is pending");
   expect(f.connection.deliveries).toHaveLength(1);
+  // A rejected arrival has selected the session but has not started work on its agent.
+  await f.sessions.control(await f.execution(first.executionId), f.connection, "archive");
+  expect(f.connection.archives).toBe(1);
 });

--- a/src/agent-sessions/index.ts
+++ b/src/agent-sessions/index.ts
@@ -235,8 +235,16 @@ export class AgentSessions {
       }
       if (!session.agentId || !session.workspaceId) return;
       const executions = await this.database.listAgentSessionExecutions(id);
-      // A completed arrival cannot stop work belonging to a newer arrival.
-      if (executions.some((item) => item.status === "spawning" || item.status === "running"))
+      // Session selection alone is not work: a rejected arrival must not suppress cleanup.
+      // A completed arrival cannot stop a newer arrival already attached to this agent.
+      const agentId = session.agentId;
+      if (
+        executions.some(
+          (item) =>
+            item.daemonAgentId === agentId &&
+            (item.status === "spawning" || item.status === "running"),
+        )
+      )
         return;
       await connection.control(
         session.agentId,

--- a/src/agent-sessions/index.ts
+++ b/src/agent-sessions/index.ts
@@ -16,6 +16,7 @@ import type { AgentSessionRecord } from "./types.js";
 export type { AgentSessionRecord, AgentSessionAction } from "./types.js";
 
 export class AgentSessionError extends Error {}
+export class AgentOperationPendingError extends AgentSessionError {}
 
 /** Owns session selection, delivery, and cleanup under the same existing database lock. */
 export class AgentSessions {
@@ -32,6 +33,7 @@ export class AgentSessions {
     connection: AgentConnection;
     createOptions: () => Promise<DaemonCreateAgentOptions>;
     onEvent: (event: AgentEvent) => void;
+    startup?: import("../daemons/agents/index.js").AgentStartup;
   }): Promise<{
     agentId: string;
     unsubscribe: () => void;
@@ -52,6 +54,8 @@ export class AgentSessions {
     }
     const id = sessionId(input.intent.projectId, policy.key ?? `execution:${input.executionId}`);
     return this.database.withAdvisoryLock(`agent-session:${id}`, async () => {
+      input.startup?.signal.throwIfAborted();
+      await this.requireLiveExecution(input.executionId);
       const tools = executionToolDefinitions(
         input.intent.outputSchema,
         this.outputs.materialize(input.intent.allowOutputs, input.intent.outputContext),
@@ -64,7 +68,10 @@ export class AgentSessions {
         );
       }
       if (!session) {
-        const options = await input.createOptions();
+        const options = await waitForStartupPreparation(
+          input.createOptions(),
+          input.startup?.signal,
+        );
         const token = deriveAgentExecutionCompletionToken(this.secret, `session:${id}`);
         session = {
           id,
@@ -91,33 +98,51 @@ export class AgentSessions {
         await this.database.saveAgentSession(session);
       }
       await this.database.attachExecutionToSession(input.executionId, id);
+      await this.settlePreviousExecutions(
+        id,
+        input.executionId,
+        input.connection,
+        input.startup?.signal,
+      );
+      input.startup?.signal.throwIfAborted();
       let action: "created" | "continued" | "restored" = "continued";
       if (session.agentId === null) {
-        const agent = await input.connection.create(id, session.creationOptions);
+        const agent = await input.connection.create(id, session.creationOptions, input.startup);
+        input.startup?.signal.throwIfAborted();
+        await this.requireLiveExecution(input.executionId);
         session = { ...session, agentId: agent.id, workspaceId: agent.workspaceId };
         await this.database.saveAgentSession(session);
         action = "created";
       }
       if (session.agentId === null || session.workspaceId === null)
         throw new Error("Session agent is missing");
-      const agent = await input.connection.get(session.agentId);
+      const agent = await input.connection.get(session.agentId, input.startup?.signal);
       if (agent.archivedAt) {
-        await input.connection.restore(session.workspaceId);
+        await input.connection.restore(session.workspaceId, input.startup);
         action = "restored";
       }
+      input.startup?.signal.throwIfAborted();
+      await this.requireLiveExecution(input.executionId);
       await this.database.attachAgentToExecution(
         input.executionId,
         session.daemonId,
         session.agentId,
       );
       await this.database.attachExecutionToSession(input.executionId, id, action);
-      const unsubscribe = await input.connection.watch(session.agentId, input.onEvent);
+      const unsubscribe = await input.connection.watch(
+        session.agentId,
+        input.onEvent,
+        input.startup?.signal,
+      );
       try {
         await input.connection.send(
           session.agentId,
           input.executionId,
           `Hub execution: ${input.executionId}\nUse this executionId for Hub tool calls for this request.\n\n${input.intent.prompt}`,
+          input.startup,
         );
+        input.startup?.signal.throwIfAborted();
+        await this.requireLiveExecution(input.executionId);
       } catch (error) {
         unsubscribe();
         throw error;
@@ -126,21 +151,100 @@ export class AgentSessions {
     });
   }
 
+  private async settlePreviousExecutions(
+    id: string,
+    executionId: string,
+    connection: AgentConnection,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    for (const previous of await this.database.listAgentSessionExecutions(id)) {
+      if (
+        previous.id === executionId ||
+        previous.hubAction === null ||
+        previous.hubActionCompletedAt !== null
+      )
+        continue;
+      if (previous.status !== "failed" && previous.status !== "succeeded") continue;
+      await this.settleStartup(previous, connection, id, signal);
+      await this.requireControlSettled(previous, connection, id, signal);
+      throw new AgentOperationPendingError("Agent cleanup is pending durable acknowledgement");
+    }
+  }
+
+  private async requireLiveExecution(executionId: string): Promise<void> {
+    const execution = await this.database.findAgentExecutionById(executionId);
+    if (!execution || execution.status === "failed" || execution.status === "succeeded") {
+      throw new AgentSessionError("Agent execution is already terminal");
+    }
+  }
+
+  private async settleStartup(
+    execution: AgentExecutionRecord,
+    connection: AgentConnection,
+    creationKey: string,
+    signal?: AbortSignal,
+  ) {
+    const receipt = await connection.cancelOperation(execution.id, creationKey, signal);
+    if (receipt.outcome !== "settled") {
+      if (receipt.outcome === "pending")
+        throw new AgentOperationPendingError("Agent startup cancellation is pending");
+      throw new AgentSessionError(
+        "Agent startup outcome is unknown; inspect the daemon before retrying this conversation",
+      );
+    }
+    return receipt;
+  }
+
+  private async requireControlSettled(
+    execution: AgentExecutionRecord,
+    connection: AgentConnection,
+    creationKey: string,
+    signal?: AbortSignal,
+  ) {
+    const operation = await connection.inspectOperation(
+      `${execution.id}:control`,
+      creationKey,
+      signal,
+    );
+    if (operation.outcome === "pending")
+      throw new AgentOperationPendingError("Agent cleanup is pending");
+    if (operation.outcome === "unknown")
+      throw new AgentSessionError(
+        "Agent cleanup outcome is unknown; inspect the daemon before retrying this conversation",
+      );
+  }
+
   async control(
     execution: AgentExecutionRecord,
     connection: AgentConnection,
     action: "interrupt" | "archive",
+    signal?: AbortSignal,
   ): Promise<void> {
     if (!execution.agentSessionId) throw new Error("Execution has no agent session");
     const id = execution.agentSessionId;
     await this.database.withAdvisoryLock(`agent-session:${id}`, async () => {
-      const session = await this.database.findAgentSession(id);
-      if (!session?.agentId || !session.workspaceId) return;
+      signal?.throwIfAborted();
+      let session = await this.database.findAgentSession(id);
+      if (!session) return;
+      const receipt = await this.settleStartup(execution, connection, id, signal);
+      await this.requireControlSettled(execution, connection, id, signal);
+      if (session.agentId === null && receipt.agentId !== null) {
+        const agent = await connection.get(receipt.agentId, signal);
+        session = { ...session, agentId: agent.id, workspaceId: agent.workspaceId };
+        await this.database.saveAgentSession(session);
+      }
+      if (!session.agentId || !session.workspaceId) return;
       const executions = await this.database.listAgentSessionExecutions(id);
       // A completed arrival cannot stop work belonging to a newer arrival.
       if (executions.some((item) => item.status === "spawning" || item.status === "running"))
         return;
-      await connection.control(session.agentId, session.workspaceId, action);
+      await connection.control(
+        session.agentId,
+        session.workspaceId,
+        action,
+        `${execution.id}:control`,
+        signal,
+      );
     });
   }
 }
@@ -161,4 +265,24 @@ function fingerprint(value: unknown): string {
       ),
     )
     .digest("hex");
+}
+
+async function waitForStartupPreparation<T>(
+  operation: Promise<T>,
+  signal?: AbortSignal,
+): Promise<T> {
+  if (!signal) return operation;
+  signal.throwIfAborted();
+  let abort: (() => void) | undefined;
+  try {
+    return await Promise.race([
+      operation,
+      new Promise<never>((_, reject) => {
+        abort = () => reject(signal.reason);
+        signal.addEventListener("abort", abort, { once: true });
+      }),
+    ]);
+  } finally {
+    if (abort) signal.removeEventListener("abort", abort);
+  }
 }

--- a/src/daemons/agents/index.test.ts
+++ b/src/daemons/agents/index.test.ts
@@ -1,0 +1,115 @@
+import { z } from "zod";
+import { afterEach, expect, test, vi } from "vitest";
+import { DaemonAgents } from "./index.js";
+
+afterEach(() => vi.useRealTimers());
+
+function fixture() {
+  const frames: { type: string; requestId: string; operation?: unknown }[] = [];
+  const agents = new DaemonAgents((frame) => {
+    frames.push(
+      z
+        .object({
+          message: z.object({
+            type: z.string(),
+            requestId: z.string(),
+            operation: z.unknown().optional(),
+          }),
+        })
+        .parse(JSON.parse(frame)).message,
+    );
+  });
+  agents.receive({
+    type: "session",
+    message: {
+      type: "server_info",
+      payload: {
+        features: { hubAgentRpc: true, agentRequestReceipts: true, agentRequestCancellation: true },
+      },
+    },
+  });
+  const controller = new AbortController();
+  const startup = {
+    key: "execution",
+    deadlineAt: new Date(Date.now() + 300_000).toISOString(),
+    signal: controller.signal,
+  };
+  function reply(payload: Record<string, unknown> = {}) {
+    return agents.receive({
+      type: "session",
+      message: { type: "response", payload: { requestId: frames.at(-1)!.requestId, ...payload } },
+    });
+  }
+  async function begin(phase: "create" | "restore" | "send") {
+    let result: Promise<unknown>;
+    if (phase === "create")
+      result = agents.create(
+        "conversation",
+        {
+          executionId: "execution",
+          provider: "codex",
+          cwd: "/repo",
+          prompt: "hello",
+          env: {},
+          toolPolicy: { preapproved: [] },
+        },
+        startup,
+      );
+    else if (phase === "restore") result = agents.restore("workspace", startup);
+    else result = agents.send("agent", "message", "hello", startup);
+    if (phase === "restore") {
+      reply({ state: { kind: "recoverable" } });
+      await Promise.resolve();
+      await Promise.resolve();
+    }
+    return { result };
+  }
+  return { agents, frames, controller, startup, reply, begin };
+}
+
+test.each(["create", "restore", "send"] as const)(
+  "%s can acknowledge after thirty seconds under the execution deadline",
+  async (phase) => {
+    vi.useFakeTimers();
+    const f = fixture();
+    const { result } = await f.begin(phase);
+    let settled = false;
+    void result.then(() => {
+      settled = true;
+      return;
+    });
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(settled).toBe(false);
+    expect(f.frames.at(-1)?.operation).toEqual({
+      key: f.startup.key,
+      deadlineAt: f.startup.deadlineAt,
+    });
+    f.reply({ agent: { id: "agent", workspaceId: "workspace", status: "idle" } });
+    await result;
+    f.agents.close();
+  },
+);
+
+test.each(["create", "restore", "send"] as const)(
+  "%s abort settles its waiter and ignores a late acknowledgement",
+  async (phase) => {
+    const f = fixture();
+    const { result } = await f.begin(phase);
+    const failed = expect(result).rejects.toThrow("execution expired");
+    f.controller.abort(new Error("execution expired"));
+    await failed;
+    expect(f.reply({ agent: { id: "late", workspaceId: "workspace", status: "idle" } })).toBe(
+      false,
+    );
+    f.agents.close();
+  },
+);
+
+test("read requests retain a bounded acknowledgement wait", async () => {
+  vi.useFakeTimers();
+  const f = fixture();
+  const failed = expect(f.agents.get("agent")).rejects.toThrow("Daemon request timed out");
+  await vi.advanceTimersByTimeAsync(30_000);
+  await failed;
+  expect(f.reply({ agent: { id: "late", workspaceId: "workspace", status: "idle" } })).toBe(false);
+});

--- a/src/daemons/agents/index.ts
+++ b/src/daemons/agents/index.ts
@@ -16,13 +16,42 @@ export type AgentSnapshot = z.infer<typeof SnapshotSchema>;
 export type AgentEvent =
   | { type: "agent_update"; agent: AgentSnapshot; timestamp: string }
   | { type: "agent_stream"; agentId: string; event: DaemonAgentStreamEvent; timestamp: string };
+export interface AgentStartup {
+  key: string;
+  deadlineAt: string;
+  signal: AbortSignal;
+}
 export interface AgentConnection {
-  create(key: string, options: DaemonCreateAgentOptions): Promise<AgentSnapshot>;
-  get(agentId: string): Promise<AgentSnapshot>;
-  send(agentId: string, messageId: string, text: string): Promise<void>;
-  restore(workspaceId: string): Promise<boolean>;
-  control(agentId: string, workspaceId: string, action: "interrupt" | "archive"): Promise<void>;
-  watch(agentId: string, listener: (event: AgentEvent) => void): Promise<() => void>;
+  inspectOperation(
+    key: string,
+    creationKey: string,
+    signal?: AbortSignal,
+  ): Promise<{ agentId: string | null; outcome: "settled" | "pending" | "unknown" }>;
+  cancelOperation(
+    key: string,
+    creationKey: string,
+    signal?: AbortSignal,
+  ): Promise<{ agentId: string | null; outcome: "settled" | "pending" | "unknown" }>;
+  create(
+    key: string,
+    options: DaemonCreateAgentOptions,
+    startup?: AgentStartup,
+  ): Promise<AgentSnapshot>;
+  get(agentId: string, signal?: AbortSignal): Promise<AgentSnapshot>;
+  send(agentId: string, messageId: string, text: string, startup?: AgentStartup): Promise<void>;
+  restore(workspaceId: string, startup?: AgentStartup): Promise<boolean>;
+  control(
+    agentId: string,
+    workspaceId: string,
+    action: "interrupt" | "archive",
+    operationKey?: string,
+    signal?: AbortSignal,
+  ): Promise<void>;
+  watch(
+    agentId: string,
+    listener: (event: AgentEvent) => void,
+    signal?: AbortSignal,
+  ): Promise<() => void>;
 }
 
 const EnvelopeSchema = z.object({
@@ -37,10 +66,16 @@ const ResultSchema = z
   .passthrough();
 
 export class DaemonAgentError extends Error {}
+export class DaemonRequestTimeoutError extends Error {
+  constructor() {
+    super("Daemon request timed out");
+  }
+}
 
 /** The ordinary daemon protocol. This channel knows nothing about Hub executions or triggers. */
 export class DaemonAgents implements AgentConnection {
   private supported = false;
+  private cancellationSupported = false;
   private readonly pending = new Map<
     string,
     { resolve: (value: Record<string, unknown>) => void; reject: (error: Error) => void }
@@ -58,6 +93,9 @@ export class DaemonAgents implements AgentConnection {
         .object({ hubAgentRpc: z.literal(true), agentRequestReceipts: z.literal(true) })
         .safeParse(payload["features"]);
       this.supported = features.success;
+      this.cancellationSupported = z
+        .object({ agentRequestCancellation: z.literal(true) })
+        .safeParse(payload["features"]).success;
       return false;
     }
     const requestId = payload["requestId"];
@@ -96,44 +134,67 @@ export class DaemonAgents implements AgentConnection {
     this.listeners.clear();
   }
 
-  async create(key: string, options: DaemonCreateAgentOptions): Promise<AgentSnapshot> {
-    const response = await this.request({
-      type: "create_agent_request",
-      idempotencyKey: key,
-      config: {
-        provider: options.provider,
-        cwd: options.cwd,
-        model: options.model,
-        modeId: options.mode,
-        thinkingOptionId: options.thinkingOptionId,
-        providerOptions: options.providerOptions,
-        mcpServers: options.mcpServers,
-        toolPolicy: options.toolPolicy,
+  async create(
+    key: string,
+    options: DaemonCreateAgentOptions,
+    startup?: AgentStartup,
+  ): Promise<AgentSnapshot> {
+    const response = await this.request(
+      {
+        type: "create_agent_request",
+        idempotencyKey: key,
+        config: {
+          provider: options.provider,
+          cwd: options.cwd,
+          model: options.model,
+          modeId: options.mode,
+          thinkingOptionId: options.thinkingOptionId,
+          providerOptions: options.providerOptions,
+          mcpServers: options.mcpServers,
+          toolPolicy: options.toolPolicy,
+        },
+        env: options.env,
+        worktree: options.worktree,
       },
-      env: options.env,
-      worktree: options.worktree,
-    });
+      startup,
+    );
     return SnapshotSchema.parse(response["agent"]);
   }
-  async get(agentId: string): Promise<AgentSnapshot> {
-    const response = await this.request({ type: "fetch_agent_request", agentId });
+  async get(agentId: string, signal?: AbortSignal): Promise<AgentSnapshot> {
+    const response = await this.request(
+      { type: "fetch_agent_request", agentId },
+      undefined,
+      signal,
+    );
     if (response["agent"] === null)
       throw new DaemonAgentError(
         "Continuation agent was deleted; use a new key or choose a new agent",
       );
     return SnapshotSchema.parse(response["agent"]);
   }
-  async send(agentId: string, messageId: string, text: string): Promise<void> {
-    await this.request({
-      type: "send_agent_message_request",
-      agentId,
-      messageId,
-      text,
-      activeTurnBehavior: "steer",
-    });
+  async send(
+    agentId: string,
+    messageId: string,
+    text: string,
+    startup?: AgentStartup,
+  ): Promise<void> {
+    await this.request(
+      {
+        type: "send_agent_message_request",
+        agentId,
+        messageId,
+        text,
+        activeTurnBehavior: "steer",
+      },
+      startup,
+    );
   }
-  async restore(workspaceId: string): Promise<boolean> {
-    const result = await this.request({ type: "workspace.recovery.inspect.request", workspaceId });
+  async restore(workspaceId: string, startup?: AgentStartup): Promise<boolean> {
+    const result = await this.request(
+      { type: "workspace.recovery.inspect.request", workspaceId },
+      undefined,
+      startup?.signal,
+    );
     const state = z
       .object({ kind: z.string(), reason: z.string().optional() })
       .parse(result["state"]);
@@ -142,36 +203,60 @@ export class DaemonAgents implements AgentConnection {
       throw new DaemonAgentError(
         "Workspace cannot be restored; inspect its recovery state in Paseo",
       );
-    await this.request({ type: "workspace.recovery.restore.request", workspaceId });
+    await this.request({ type: "workspace.recovery.restore.request", workspaceId }, startup);
     return true;
   }
   async control(
     agentId: string,
     workspaceId: string,
     action: "interrupt" | "archive",
+    operationKey?: string,
+    signal?: AbortSignal,
   ): Promise<void> {
     await this.request(
       action === "archive"
-        ? { type: "archive_workspace_request", workspaceId }
-        : { type: "cancel_agent_request", agentId },
+        ? {
+            type: "archive_workspace_request",
+            workspaceId,
+            ...(operationKey ? { operation: { key: operationKey } } : {}),
+          }
+        : {
+            type: "cancel_agent_request",
+            agentId,
+            ...(operationKey ? { operation: { key: operationKey } } : {}),
+          },
+      undefined,
+      signal,
     );
   }
-  async watch(agentId: string, listener: (event: AgentEvent) => void): Promise<() => void> {
+  async watch(
+    agentId: string,
+    listener: (event: AgentEvent) => void,
+    signal?: AbortSignal,
+  ): Promise<() => void> {
     const listeners = this.listeners.get(agentId) ?? new Set();
     listeners.add(listener);
     this.listeners.set(agentId, listeners);
     try {
       if (!this.observing) {
-        await this.request({
-          type: "fetch_agents_request",
-          subscribe: { subscriptionId: "hub-continuation" },
-        });
+        await this.request(
+          {
+            type: "fetch_agents_request",
+            subscribe: { subscriptionId: "hub-continuation" },
+          },
+          undefined,
+          signal,
+        );
         this.observing = true;
       }
-      await this.request({
-        type: "agent.timeline.set_subscription.request",
-        agentIds: [...this.listeners.keys()],
-      });
+      await this.request(
+        {
+          type: "agent.timeline.set_subscription.request",
+          agentIds: [...this.listeners.keys()],
+        },
+        undefined,
+        signal,
+      );
     } catch (error) {
       listeners.delete(listener);
       throw error;
@@ -184,16 +269,70 @@ export class DaemonAgents implements AgentConnection {
   private emit(agentId: string, event: AgentEvent): void {
     for (const listener of this.listeners.get(agentId) ?? []) listener(event);
   }
-  private async request(message: Record<string, unknown>): Promise<Record<string, unknown>> {
+  async inspectOperation(key: string, creationKey: string, signal?: AbortSignal) {
+    this.requireCancellation();
+    const response = await this.request(
+      { type: "agent.requests.inspect.request", key, creationKey },
+      undefined,
+      signal,
+    );
+    return z
+      .object({
+        agentId: z.string().nullable(),
+        outcome: z.enum(["settled", "pending", "unknown"]),
+      })
+      .parse(response);
+  }
+  async cancelOperation(key: string, creationKey: string, signal?: AbortSignal) {
+    this.requireCancellation();
+    const response = await this.request(
+      { type: "agent.requests.cancel.request", key, creationKey },
+      undefined,
+      signal,
+    );
+    return z
+      .object({
+        agentId: z.string().nullable(),
+        outcome: z.enum(["settled", "pending", "unknown"]),
+      })
+      .parse(response);
+  }
+  private requireCancellation(): void {
+    if (!this.cancellationSupported)
+      throw new DaemonAgentError("Update the Paseo daemon to use cancelable agent startup");
+  }
+  private async request(
+    message: Record<string, unknown>,
+    startup?: AgentStartup,
+    signal = startup?.signal,
+  ): Promise<Record<string, unknown>> {
+    signal?.throwIfAborted();
+    if (startup) this.requireCancellation();
     if (!this.supported)
       throw new DaemonAgentError("Update the Paseo daemon to use agent continuation");
     const requestId = randomUUID();
     let timeout: ReturnType<typeof setTimeout> | undefined;
+    let abort: (() => void) | undefined;
     try {
       const result = await new Promise<Record<string, unknown>>((resolve, reject) => {
         this.pending.set(requestId, { resolve, reject });
-        timeout = setTimeout(() => reject(new Error("Daemon request timed out")), 30_000);
-        this.sendFrame(JSON.stringify({ type: "session", message: { ...message, requestId } }));
+        if (signal) {
+          abort = () => reject(signal.reason);
+          signal.addEventListener("abort", abort, { once: true });
+        }
+        if (!startup) timeout = setTimeout(() => reject(new DaemonRequestTimeoutError()), 30_000);
+        this.sendFrame(
+          JSON.stringify({
+            type: "session",
+            message: {
+              ...message,
+              requestId,
+              ...(startup
+                ? { operation: { key: startup.key, deadlineAt: startup.deadlineAt } }
+                : {}),
+            },
+          }),
+        );
       });
       const parsed = ResultSchema.parse(result);
       if (parsed.error || parsed.accepted === false)
@@ -201,6 +340,7 @@ export class DaemonAgents implements AgentConnection {
       return result;
     } finally {
       clearTimeout(timeout);
+      if (abort) signal?.removeEventListener("abort", abort);
       this.pending.delete(requestId);
     }
   }

--- a/src/daemons/daemons.test.ts
+++ b/src/daemons/daemons.test.ts
@@ -571,6 +571,7 @@ describe("daemon enrollment and execution", () => {
     hub.issueConnectionLeaseOnAuthorityMaterialization();
     hub.hangAuthorityMintPermanently();
     const dispatch = hub.beginDispatch({
+      timeoutMs: 30_000,
       env: { TOKEN: "${{ paseo.connections.some-connection.token }}" },
       github: {
         connection: "getpaseo-github",
@@ -1877,18 +1878,84 @@ describe("daemon enrollment and execution", () => {
     },
   );
 
-  it("bounds spawn acknowledgement and execution deadlines with the deterministic clock", async () => {
+  it("allows slow agent startup within the configured runtime", async () => {
+    await hub.connectDaemon();
+    hub.holdSpawnAcknowledgement();
+    const dispatch = hub.beginDispatch({ timeoutMs: 5 * 60_000 });
+    await hub.spawnBegins();
+    await hub.advanceDispatchTime(2 * 60_000);
+    hub.acceptSpawn();
+
+    const result = await dispatch;
+    assert.equal((await hub.execution(result.execution.id)).status, "running");
+    assert.equal(hub.createdAgentCount(), 1);
+  });
+
+  it.each([false, true])(
+    "preserves initial idle semantics while startup waits (initializing: %s)",
+    async (initializing) => {
+      await hub.connectDaemon();
+      await hub.installConfiguration({
+        yaml: [
+          "environments:",
+          "  - name: target",
+          "    kind: daemon",
+          `    daemon: ${hub.connectedDaemonSlug()}`,
+          "    cwd: /workspace/manual",
+          "triggers:",
+          "  - name: startup",
+          "    on: manual.run",
+          "    max_runtime: 5m",
+          "    filters:",
+          "      from_users: [alice]",
+          "    steps:",
+          "      - id: start",
+          "        environment: target",
+          "        max_runtime: 5m",
+          "        idle_timeout: 1m",
+          "        agent:",
+          "          provider: codex",
+          '        prompt: [{ text: "Hello" }]',
+        ].join("\n"),
+      });
+      hub.holdSpawnAcknowledgement();
+      const dispatch = hub.beginManual({
+        trigger: "startup",
+        deliveryKey: `startup-idle-${initializing}`,
+      });
+      await hub.spawnBegins();
+      const pending = await hub.pendingExecution();
+      assert.notEqual(pending.idleDeadlineAt, null);
+      if (initializing) await hub.pendingSpawnBeginsInitializing(pending.id);
+      await hub.advanceDispatchTime(45_000);
+      await hub.connectionHeartbeat();
+      await hub.advanceDispatchTime(15_000);
+      const current = await hub.execution(pending.id);
+      if (initializing) {
+        assert.equal(current.idleDeadlineAt, null);
+        assert.equal(current.status, "spawning");
+        assert.equal(current.deadlineAt?.getTime(), pending.deadlineAt?.getTime());
+      } else {
+        assert.equal(current.status, "failed");
+        assert.deepEqual(current.result, { status: "failed", reason: "step_idle_timeout" });
+      }
+      hub.acceptSpawn();
+      await dispatch;
+      if (!initializing) assert.equal((await hub.execution(pending.id)).status, "failed");
+    },
+  );
+
+  it("bounds hung startup by the configured execution deadline", async () => {
     await hub.connectDaemon();
     hub.holdSpawnAcknowledgement();
     const dispatch = hub.beginDispatch({ timeoutMs: 60_000 });
-    await hub.spawnBegins();
-    await hub.advanceDispatchTime(30_000);
-
-    await assert.rejects(
+    const rejected = assert.rejects(
       dispatch,
-      (error: unknown) =>
-        error instanceof DaemonDispatchFailure && error.reason === "daemon_timeout",
+      (error: unknown) => error instanceof DaemonDispatchFailure && error.reason === "timeout",
     );
+    await hub.spawnBegins();
+    await hub.advanceDispatchTime(60_000);
+    await rejected;
   });
 
   it("expires at the dispatch boundary before creating an agent", async () => {

--- a/src/daemons/lifecycle.ts
+++ b/src/daemons/lifecycle.ts
@@ -1,5 +1,9 @@
-import { DaemonAgentError } from "./agents/index.js";
-import { AgentSessions, AgentSessionError } from "../agent-sessions/index.js";
+import { DaemonAgentError, DaemonRequestTimeoutError } from "./agents/index.js";
+import {
+  AgentSessions,
+  AgentSessionError,
+  AgentOperationPendingError,
+} from "../agent-sessions/index.js";
 import type { AgentEvent } from "./agents/index.js";
 import {
   buildExecutionCapabilityMcpServer,
@@ -157,8 +161,11 @@ export class DaemonDispatchLifecycle {
     (failure?: DaemonDispatchFailure) => void
   >();
   private readonly deadlineTimersByExecution = new Map<string, () => void>();
+  private readonly stopped = new AbortController();
+  private readonly startupControllers = new Map<string, AbortController>();
   private readonly activeExecutionDispatches = new Map<string, Promise<unknown>>();
   private readonly reconcilingHubActions = new Map<string, Promise<void>>();
+  private readonly hubActionRetryTimers = new Map<string, () => void>();
   private readonly daemonRecoveries = new Set<Promise<void>>();
   private readonly recoveredSubscriptions = new Map<string, () => void>();
   private stopping = false;
@@ -176,11 +183,17 @@ export class DaemonDispatchLifecycle {
 
   async stop(): Promise<void> {
     this.stopping = true;
+    this.stopped.abort(new DaemonCreateResponseLostError());
+    for (const controller of this.startupControllers.values()) {
+      controller.abort(new DaemonCreateResponseLostError());
+    }
     for (const unsubscribe of this.recoveredSubscriptions.values()) unsubscribe();
     this.recoveredSubscriptions.clear();
     for (const clear of this.deadlineTimersByExecution.values()) clear();
     this.deadlineTimersByExecution.clear();
     this.startedExecutions.clear();
+    for (const clear of this.hubActionRetryTimers.values()) clear();
+    this.hubActionRetryTimers.clear();
     await Promise.allSettled([
       ...this.daemonRecoveries,
       ...this.reconcilingHubActions.values(),
@@ -1015,48 +1028,72 @@ export class DaemonDispatchLifecycle {
     if (this.stopping) return;
 
     const intent = current.launchIntent;
-    if (intent === null || this.options.publicBaseUrl === undefined)
+    const publicBaseUrl = this.options.publicBaseUrl;
+    if (intent === null || publicBaseUrl === undefined)
       throw new Error("execution launch intent cannot be recovered");
     if (intent.continuation !== undefined) {
-      if (current.daemonAgentId === null) {
-        await this.dispatchSession({
-          daemonId: daemon.id,
-          executionId: current.id,
-          intent,
-          hubExecutionEnv: {
+      if (current.status === "spawning" || current.daemonAgentId === null) {
+        if (current.deadlineAt === null) throw new Error("Execution deadline is missing");
+        await this.acquireAndSpawnAgent(
+          {
+            daemonId: daemon.id,
+            machineId: daemon.machineId,
             executionId: current.id,
-            completionToken: this.completionToken(current.id),
-            publicBaseUrl: this.options.publicBaseUrl,
+            intent,
+            hubExecutionEnv: {
+              executionId: current.id,
+              completionToken: this.completionToken(current.id),
+              publicBaseUrl,
+            },
           },
-        });
-      } else {
-        const unsubscribe = await connection.agents.watch(current.daemonAgentId, (event) =>
-          this.observeSessionEvent(current.id, daemon.id, event),
+          current.deadlineAt,
         );
-        this.recoveredSubscriptions.get(current.id)?.();
-        this.recoveredSubscriptions.set(current.id, unsubscribe);
-        this.armExecutionDeadline(current);
+      } else {
+        if (current.deadlineAt === null) throw new Error("Execution deadline is missing");
+        const agentId = current.daemonAgentId;
+        await this.withExecutionStartup(current.id, current.deadlineAt, async (signal) => {
+          const unsubscribe = await connection.agents.watch(
+            agentId,
+            (event) => this.observeSessionEvent(current.id, daemon.id, event),
+            signal,
+          );
+          if (signal.aborted) {
+            unsubscribe();
+            signal.throwIfAborted();
+          }
+          this.recoveredSubscriptions.get(current.id)?.();
+          this.recoveredSubscriptions.set(current.id, unsubscribe);
+          this.armExecutionDeadline(current);
+        });
       }
       return;
     }
-    const createOptions = await this.buildCreateAgentOptions(intent, {
-      executionId: current.id,
-      completionToken: this.completionToken(current.id),
-      publicBaseUrl: this.options.publicBaseUrl,
-    }).catch((error: unknown) => {
-      throw toDispatchPreparationFailure(error);
+    if (current.deadlineAt === null) throw new Error("Execution deadline is missing");
+    const deadlineAt = current.deadlineAt;
+    await this.withExecutionStartup(current.id, deadlineAt, async (signal) => {
+      const createOptions = await this.buildCreateAgentOptions(intent, {
+        executionId: current.id,
+        completionToken: this.completionToken(current.id),
+        publicBaseUrl,
+      }).catch((error: unknown) => {
+        throw toDispatchPreparationFailure(error);
+      });
+      signal.throwIfAborted();
+      this.subscribeRecoveredExecution(current.id, daemon.id, connection);
+      this.armExecutionDeadline(current);
+      const agent = await connection
+        .createAgent({ ...createOptions, deadlineAt: deadlineAt.toISOString() }, signal)
+        .catch((error: unknown) => {
+          throw toDaemonTransportFailure(error);
+        });
+      signal.throwIfAborted();
+      if (isInterruptedAgentState(agent.state)) {
+        await this.failAgentExecution(current.id, "agent_interrupted");
+        return;
+      }
+      await this.options.database.attachAgentToExecution(current.id, daemon.id, agent.id);
+      await this.restoreAgentState(current.id, agent);
     });
-    this.subscribeRecoveredExecution(current.id, daemon.id, connection);
-    this.armExecutionDeadline(current);
-    const agent = await connection.createAgent(createOptions).catch((error: unknown) => {
-      throw toDaemonTransportFailure(error);
-    });
-    if (isInterruptedAgentState(agent.state)) {
-      await this.failAgentExecution(current.id, "agent_interrupted");
-      return;
-    }
-    await this.options.database.attachAgentToExecution(current.id, daemon.id, agent.id);
-    await this.restoreAgentState(current.id, agent);
   }
 
   private subscribeRecoveredExecution(
@@ -1134,7 +1171,11 @@ export class DaemonDispatchLifecycle {
 
   private async completeAgentExecution(
     executionId: string,
-    options: { completedByAgent?: boolean; output?: unknown; deferHubAction?: boolean } = {},
+    options: {
+      completedByAgent?: boolean;
+      output?: unknown;
+      deferHubAction?: boolean;
+    } = {},
   ): Promise<AgentExecutionRecord> {
     const existing = await this.options.database.findAgentExecutionById(executionId);
     if (existing === undefined) throw new Error(`agent execution not found: ${executionId}`);
@@ -1236,6 +1277,7 @@ export class DaemonDispatchLifecycle {
       return undefined;
     }
 
+    this.startupControllers.get(executionId)?.abort(new DaemonDispatchFailure(reason));
     this.clearExecutionDeadline(executionId);
     this.releaseExecutionResources(executionId);
 
@@ -1286,6 +1328,22 @@ export class DaemonDispatchLifecycle {
 
   private reconcileHubActionSafely(execution: AgentExecutionRecord): Promise<void> {
     return this.reconcileHubAction(execution).catch((error: unknown) => {
+      if (
+        error instanceof AgentOperationPendingError ||
+        error instanceof DaemonRequestTimeoutError
+      ) {
+        if (!this.stopping && !this.hubActionRetryTimers.has(execution.id)) {
+          this.hubActionRetryTimers.set(
+            execution.id,
+            this.scheduleDeadline(async () => {
+              this.hubActionRetryTimers.delete(execution.id);
+              const current = await this.options.database.findAgentExecutionById(execution.id);
+              if (current) await this.reconcileHubActionSafely(current);
+            }, 1_000),
+          );
+        }
+        return;
+      }
       this.report(error, "daemon.execution.hub-action", {
         executionId: execution.id,
         hubAction: execution.hubAction,
@@ -1338,9 +1396,12 @@ export class DaemonDispatchLifecycle {
     const connection = this.options.connectionForDaemon(daemonId);
     if (connection === undefined) return;
     await withHubActionTimeout(
-      execution.agentSessionId === null
-        ? connection.controlExecution({ executionId: execution.id, action })
-        : this.sessionOwner().control(execution, connection.agents, action),
+      (signal) => {
+        const combined = AbortSignal.any([signal, this.stopped.signal]);
+        return execution.agentSessionId === null
+          ? connection.controlExecution({ executionId: execution.id, action }, combined)
+          : this.sessionOwner().control(execution, connection.agents, action, combined);
+      },
       this.dispatchTimeoutMs,
       (callback, delayMs) => this.scheduleDeadline(async () => callback(), delayMs),
     );
@@ -1511,37 +1572,53 @@ export class DaemonDispatchLifecycle {
     },
     deadlineAt: Date,
   ): Promise<string> {
-    let canceled = false;
-    const cancelHandlers = new Set<() => Promise<void>>();
-    const timeoutMs = Math.max(
-      0,
-      Math.min(this.dispatchTimeoutMs, deadlineAt.getTime() - this.now()),
-    );
-    try {
-      return await withDispatchTimeout(
-        this.acquireAndSpawnAgentWithoutTimeout(
-          input,
-          () => canceled,
-          (handler) => {
-            cancelHandlers.add(handler);
-          },
-        ),
-        timeoutMs,
-        () => {
-          canceled = true;
-          for (const handler of cancelHandlers) {
-            void handler().catch((error: unknown) => {
-              this.report(error, "daemon.dispatch.cancel", { executionId: input.executionId });
+    return this.withExecutionStartup(input.executionId, deadlineAt, async (signal) => {
+      const cancelHandlers = new Set<() => Promise<void>>();
+      const abort = () => {
+        for (const handler of cancelHandlers) {
+          void handler().catch((error: unknown) => {
+            this.report(error, "daemon.dispatch.cancel", {
+              executionId: input.executionId,
             });
-          }
-        },
+          });
+        }
+      };
+      signal.addEventListener("abort", abort, { once: true });
+      try {
+        return await this.acquireAndSpawnAgentWithoutTimeout(
+          input,
+          (handler) => cancelHandlers.add(handler),
+          signal,
+          deadlineAt,
+        );
+      } finally {
+        signal.removeEventListener("abort", abort);
+      }
+    });
+  }
+
+  private async withExecutionStartup<T>(
+    executionId: string,
+    deadlineAt: Date,
+    operation: (signal: AbortSignal) => Promise<T>,
+  ): Promise<T> {
+    const controller = new AbortController();
+    this.startupControllers.set(executionId, controller);
+    try {
+      if (!(await this.armLiveExecutionDeadline(executionId)))
+        throw new DaemonDispatchFailure("timeout");
+      return await withDispatchTimeout(
+        withStartupCancellation(operation(controller.signal), controller.signal),
+        Math.max(0, deadlineAt.getTime() - this.now()),
+        () => controller.abort(new DaemonDispatchFailure("timeout")),
         (callback, delayMs) => this.scheduleDeadline(async () => callback(), delayMs),
       );
     } catch (error) {
-      if (deadlineAt.getTime() <= this.now()) {
+      if (deadlineAt.getTime() <= this.now())
         throw new DaemonDispatchFailure("timeout", { cause: error });
-      }
       throw error;
+    } finally {
+      this.startupControllers.delete(executionId);
     }
   }
 
@@ -1561,16 +1638,32 @@ export class DaemonDispatchLifecycle {
     executionId: string;
     intent: LaunchMachineIntent;
     hubExecutionEnv: HubExecutionEnv;
+    signal?: AbortSignal;
   }): Promise<string> {
     const connection = this.options.connectionForDaemon(input.daemonId);
     if (!connection) throw new DaemonDispatchFailure("daemon_unreachable");
+    const execution = await this.options.database.findAgentExecutionById(input.executionId);
+    if (!execution?.deadlineAt) throw new Error("Execution deadline is missing");
     const dispatched = await this.sessionOwner().dispatch({
       executionId: input.executionId,
       intent: input.intent,
       connection: connection.agents,
       createOptions: () => this.buildCreateAgentOptions(input.intent, input.hubExecutionEnv),
       onEvent: (event) => this.observeSessionEvent(input.executionId, input.daemonId, event),
+      ...(input.signal
+        ? {
+            startup: {
+              key: input.executionId,
+              signal: input.signal,
+              deadlineAt: execution.deadlineAt.toISOString(),
+            },
+          }
+        : {}),
     });
+    if (input.signal?.aborted) {
+      dispatched.unsubscribe();
+      input.signal.throwIfAborted();
+    }
     this.recoveredSubscriptions.get(input.executionId)?.();
     this.recoveredSubscriptions.set(input.executionId, dispatched.unsubscribe);
     await this.startAgentExecution(input.executionId);
@@ -1602,10 +1695,11 @@ export class DaemonDispatchLifecycle {
       intent: LaunchMachineIntent;
       hubExecutionEnv: HubExecutionEnv;
     },
-    isCanceled: () => boolean,
     onCancel: (handler: () => Promise<void>) => void,
+    signal: AbortSignal,
+    deadlineAt: Date,
   ): Promise<string> {
-    if (input.intent.continuation !== undefined) return this.dispatchSession(input);
+    if (input.intent.continuation !== undefined) return this.dispatchSession({ ...input, signal });
     const connection = this.options.connectionForDaemon(input.daemonId);
     if (connection === undefined) {
       throw new DaemonDispatchFailure("daemon_unreachable");
@@ -1616,9 +1710,7 @@ export class DaemonDispatchLifecycle {
     ).catch((error: unknown) => {
       throw toDispatchPreparationFailure(error);
     });
-    if (isCanceled()) {
-      throw new DaemonSpawnAckTimeoutError(this.dispatchTimeoutMs);
-    }
+    signal.throwIfAborted();
     const pendingHandlers = new Set<Promise<void>>();
     let disposed = false;
     let settleTerminal: ((failure?: DaemonDispatchFailure) => void) | undefined;
@@ -1671,18 +1763,14 @@ export class DaemonDispatchLifecycle {
         throw new DaemonDispatchFailure("timeout");
       }
 
-      if (isCanceled()) {
-        throw new DaemonSpawnAckTimeoutError(this.dispatchTimeoutMs);
-      }
+      signal.throwIfAborted();
       const agent = await Promise.race([
         connection
-          .createAgent(createOptions)
+          .createAgent({ ...createOptions, deadlineAt: deadlineAt.toISOString() }, signal)
           .catch((error: unknown) => Promise.reject(toDaemonTransportFailure(error))),
         terminal.then<never>(() => new Promise<never>(() => undefined)),
       ]);
-      if (isCanceled()) {
-        throw new DaemonSpawnAckTimeoutError(this.dispatchTimeoutMs);
-      }
+      signal.throwIfAborted();
       await this.options.database.attachAgentToExecution(
         input.executionId,
         input.daemonId,
@@ -2192,6 +2280,22 @@ function assertNeverAgentStreamEvent(value: never): never {
   throw new Error(`unhandled daemon agent stream event: ${JSON.stringify(value)}`);
 }
 
+async function withStartupCancellation<T>(operation: Promise<T>, signal: AbortSignal): Promise<T> {
+  signal.throwIfAborted();
+  let abort: (() => void) | undefined;
+  try {
+    return await Promise.race([
+      operation,
+      new Promise<never>((_, reject) => {
+        abort = () => reject(signal.reason);
+        signal.addEventListener("abort", abort, { once: true });
+      }),
+    ]);
+  } finally {
+    if (abort) signal.removeEventListener("abort", abort);
+  }
+}
+
 async function withDispatchTimeout<T>(
   operation: Promise<T>,
   timeoutMs: number,
@@ -2216,19 +2320,21 @@ async function withDispatchTimeout<T>(
 }
 
 async function withHubActionTimeout(
-  operation: Promise<void>,
+  operation: (signal: AbortSignal) => Promise<void>,
   timeoutMs: number,
   schedule: (callback: () => void, delayMs: number) => () => void,
 ): Promise<void> {
   let clearTimer: (() => void) | undefined;
+  const controller = new AbortController();
   try {
     await Promise.race([
-      operation,
+      operation(controller.signal),
       new Promise<void>((_resolve, reject) => {
-        clearTimer = schedule(
-          () => reject(new Error("timed out waiting for daemon execution control ack")),
-          timeoutMs,
-        );
+        clearTimer = schedule(() => {
+          const failure = new DaemonRequestTimeoutError();
+          controller.abort(failure);
+          reject(failure);
+        }, timeoutMs);
       }),
     ]);
   } finally {

--- a/src/daemons/protocol.ts
+++ b/src/daemons/protocol.ts
@@ -14,6 +14,7 @@ export interface DaemonAgentSnapshot {
 
 export interface DaemonCreateAgentOptions {
   executionId: string;
+  deadlineAt?: string;
   provider: string;
   mode?: string;
   model?: string;
@@ -77,8 +78,11 @@ export type DaemonEventHandler = (event: DaemonEvent) => void | Promise<void>;
 
 export interface DaemonConnection {
   agents: import("./agents/index.js").AgentConnection;
-  createAgent(options: DaemonCreateAgentOptions): Promise<DaemonAgentSnapshot>;
-  controlExecution(options: DaemonExecutionControlOptions): Promise<void>;
+  createAgent(
+    options: DaemonCreateAgentOptions,
+    signal?: AbortSignal,
+  ): Promise<DaemonAgentSnapshot>;
+  controlExecution(options: DaemonExecutionControlOptions, signal?: AbortSignal): Promise<void>;
   getProviderSnapshot(options: { cwd?: string }): Promise<HubProviderSnapshot>;
   refreshProviderSnapshot(options: { cwd?: string; providers?: string[] }): Promise<void>;
   on(handler: DaemonEventHandler): () => void;

--- a/src/daemons/registry.ts
+++ b/src/daemons/registry.ts
@@ -181,8 +181,8 @@ export class ActiveDaemonRegistry {
     if (!active?.ready || !active.daemon.permissions.includes("hub.execute")) return undefined;
     return {
       agents: this.active.get(daemonId)!.agents,
-      createAgent: (options) => this.createAgent(daemonId, options),
-      controlExecution: (options) => this.controlExecution(daemonId, options),
+      createAgent: (options, signal) => this.createAgent(daemonId, options, signal),
+      controlExecution: (options, signal) => this.controlExecution(daemonId, options, signal),
       getProviderSnapshot: (options) => this.getProviderSnapshot(daemonId, options),
       refreshProviderSnapshot: (options) => this.refreshProviderSnapshot(daemonId, options),
       on: (handler) => {
@@ -257,7 +257,9 @@ export class ActiveDaemonRegistry {
   private createAgent(
     daemonId: string,
     options: DaemonCreateAgentOptions,
+    signal?: AbortSignal,
   ): Promise<{ id: string }> {
+    signal?.throwIfAborted();
     const active = this.active.get(daemonId);
     if (!active?.ready) return Promise.reject(new Error("daemon_not_connected"));
     const requestId = randomUUID();
@@ -266,6 +268,7 @@ export class ActiveDaemonRegistry {
       type: "hub.execution.agent.create.request",
       requestId,
       executionId,
+      deadlineAt: options.deadlineAt,
       provider: options.provider,
       cwd: options.cwd,
       prompt: options.prompt,
@@ -278,7 +281,13 @@ export class ActiveDaemonRegistry {
       mcpServers: options.mcpServers,
       worktree: options.worktree,
     });
-    return new Promise((resolve, reject) => {
+    let abort: (() => void) | undefined;
+    return new Promise<{ id: string }>((resolve, reject) => {
+      abort = () => {
+        this.pendingFor(daemonId).delete(requestId);
+        reject(signal?.reason);
+      };
+      signal?.addEventListener("abort", abort, { once: true });
       this.pendingFor(daemonId).set(requestId, {
         kind: "create",
         generation: active.generation,
@@ -293,13 +302,17 @@ export class ActiveDaemonRegistry {
         reject,
       });
       active.socket.send(JSON.stringify({ type: "session", message: request }));
+    }).finally(() => {
+      if (abort) signal?.removeEventListener("abort", abort);
     });
   }
 
   private controlExecution(
     daemonId: string,
     options: DaemonExecutionControlOptions,
+    signal?: AbortSignal,
   ): Promise<void> {
+    signal?.throwIfAborted();
     const active = this.active.get(daemonId);
     if (!active?.ready) return Promise.reject(new Error("daemon_not_connected"));
     const requestId = randomUUID();
@@ -309,7 +322,13 @@ export class ActiveDaemonRegistry {
       executionId: options.executionId,
       action: options.action,
     });
-    return new Promise((resolve, reject) => {
+    let abort: (() => void) | undefined;
+    return new Promise<void>((resolve, reject) => {
+      abort = () => {
+        this.pendingFor(daemonId).delete(requestId);
+        reject(signal?.reason);
+      };
+      signal?.addEventListener("abort", abort, { once: true });
       this.pendingFor(daemonId).set(requestId, {
         kind: "control",
         generation: active.generation,
@@ -319,6 +338,8 @@ export class ActiveDaemonRegistry {
         reject,
       });
       active.socket.send(JSON.stringify({ type: "session", message: request }));
+    }).finally(() => {
+      if (abort) signal?.removeEventListener("abort", abort);
     });
   }
 

--- a/src/daemons/test-utils/hub-harness.ts
+++ b/src/daemons/test-utils/hub-harness.ts
@@ -657,6 +657,13 @@ export class HubHarness {
       },
     });
   }
+  async connectionHeartbeat(): Promise<void> {
+    await this.requireDaemon().connectionHeartbeat();
+  }
+  async pendingSpawnBeginsInitializing(executionId: string): Promise<void> {
+    const agentId = this.requireDaemon().pendingSpawnAgentId();
+    await this.agentBeginsInitializing(executionId, agentId);
+  }
   holdSpawnAcknowledgement(): void {
     this.requireDaemon().holdSpawnAcknowledgement();
   }
@@ -2282,6 +2289,10 @@ class TestDaemon {
     this.holdAck = false;
     if (this.pendingCreate) this.acknowledge(this.pendingCreate);
   }
+  pendingSpawnAgentId(): string {
+    if (!this.pendingCreate) throw new Error("No pending create request");
+    return `agent-${this.pendingCreate.executionId}`;
+  }
   interruptPendingSpawn(): string {
     if (!this.pendingCreate) throw new Error("No pending create request");
     const agentId = `agent-${this.pendingCreate.executionId}`;
@@ -2316,6 +2327,14 @@ class TestDaemon {
       },
     });
     await new Promise((resolve) => setImmediate(resolve));
+  }
+  async connectionHeartbeat(): Promise<void> {
+    const socket = this.socket;
+    if (!socket) throw new Error("Daemon is disconnected");
+    await new Promise<void>((resolve) => {
+      socket.once("pong", () => resolve());
+      socket.ping();
+    });
   }
   createdAgent(): Record<string, unknown> {
     return [...this.agents.values()].at(-1) ?? {};

--- a/src/e2e/harness/fault-proxy.ts
+++ b/src/e2e/harness/fault-proxy.ts
@@ -15,6 +15,8 @@ export class HubFaultProxy {
   private daemonSocket: WebSocket | undefined;
   private hubSocket: WebSocket | undefined;
   private loseCreateResponse = false;
+  private loseSend = false;
+  private sendAttempts = 0;
   private createResponseDropped: (() => void) | undefined;
   private readonly droppedCreateResponse = new Promise<void>((resolve) => {
     this.createResponseDropped = resolve;
@@ -52,6 +54,13 @@ export class HubFaultProxy {
       proxy.server.listen(port, "127.0.0.1", resolve);
     });
     return proxy;
+  }
+
+  loseNextContinuationSend(): void {
+    this.loseSend = true;
+  }
+  continuationSendAttempts(): number {
+    return this.sendAttempts;
   }
 
   loseNextCreateResponse(): void {
@@ -230,6 +239,16 @@ export class HubFaultProxy {
       hubSocket.on("message", (data) => {
         const raw = readText(data);
         this.observeHubMessage(raw);
+        const envelope = z
+          .object({ message: z.object({ type: z.string() }) })
+          .safeParse(JSON.parse(raw));
+        if (envelope.success && envelope.data.message.type === "send_agent_message_request") {
+          this.sendAttempts++;
+          if (this.loseSend) {
+            this.loseSend = false;
+            return;
+          }
+        }
         if (daemonSocket.readyState === WebSocket.OPEN) daemonSocket.send(raw);
       });
       daemonSocket.on("close", (code, reason) => {

--- a/src/e2e/harness/hub-child.ts
+++ b/src/e2e/harness/hub-child.ts
@@ -113,36 +113,38 @@ async function main(): Promise<void> {
     daemon = enrollment?.status === "slug_conflict" ? undefined : enrollment;
   }
   if (daemon === undefined) throw new Error("Hub E2E seed daemon enrollment failed");
-  const config = await configuration.insertManualBundleRevision({
-    files: configurationBundleFixture(
-      dump({
-        environments: [
-          { name: "hub-e2e", kind: "daemon", daemon: daemon.slug, cwd: process.cwd() },
-        ],
-        triggers: [
-          {
-            name: "e2e-discord",
-            on: "e2e.discord",
-            max_runtime: "2h",
-            filters: { from_users: ["phase-five-operator"] },
-            steps: [
-              {
-                id: "e2e-step",
-                environment: "hub-e2e",
-                max_runtime: "1h",
-                idle_timeout: "5m",
-                agent: { provider: "hub-e2e" },
-                prompt: [{ text: "Deploy mcp-capability for phase-five-operator" }],
-              },
-            ],
-          },
-        ],
-      }),
-    ),
-    userId: "hub-e2e",
-    sourceEvidence: { kind: "harness-seed", userId: "hub-e2e" },
-  });
-  await configuration.activate(config.id);
+  if ((await configuration.getActive()) === undefined) {
+    const config = await configuration.insertManualBundleRevision({
+      files: configurationBundleFixture(
+        dump({
+          environments: [
+            { name: "hub-e2e", kind: "daemon", daemon: daemon.slug, cwd: process.cwd() },
+          ],
+          triggers: [
+            {
+              name: "e2e-discord",
+              on: "e2e.discord",
+              max_runtime: "2h",
+              filters: { from_users: ["phase-five-operator"] },
+              steps: [
+                {
+                  id: "e2e-step",
+                  environment: "hub-e2e",
+                  max_runtime: "1h",
+                  idle_timeout: "5m",
+                  agent: { provider: "hub-e2e" },
+                  prompt: [{ text: "Deploy mcp-capability for phase-five-operator" }],
+                },
+              ],
+            },
+          ],
+        }),
+      ),
+      userId: "hub-e2e",
+      sourceEvidence: { kind: "harness-seed", userId: "hub-e2e" },
+    });
+    await configuration.activate(config.id);
+  }
   const resources = new OrganizationResources(database);
   const application = createHubApplication({
     database,

--- a/src/e2e/harness/index.ts
+++ b/src/e2e/harness/index.ts
@@ -794,6 +794,29 @@ export class HubE2E {
     };
   }
 
+  loseNextContinuationSend(): void {
+    this.requireProxy().loseNextContinuationSend();
+  }
+
+  async restartBeforeContinuationSend(executionId: string): Promise<void> {
+    await this.observe(
+      async () => this.requireProxy().continuationSendAttempts() === 1,
+      "continuation send to reach the fault proxy",
+    );
+    const result = await this.requirePool().query<{ status: string }>(
+      "select status from agent_executions where id = $1",
+      [executionId],
+    );
+    if (result.rows[0]?.status !== "spawning")
+      throw new Error("Expected startup before the send acknowledgement");
+    await this.restartHub();
+    await this.daemonIsConnected();
+    await this.observe(
+      async () => this.requireProxy().continuationSendAttempts() === 2,
+      "the same continuation message to retry after Hub restart",
+    );
+  }
+
   async runCapabilityTrigger(deliveryKey: string, conversation?: string): Promise<ManualRun> {
     const response = await fetch(`${this.requireProxy().origin}/test/trigger`, {
       method: "POST",
@@ -821,7 +844,7 @@ export class HubE2E {
         executionId,
       ]);
       if (execution.rows[0]?.status === "failed")
-        throw new Error(JSON.stringify(execution.rows[0].result));
+        throw new Error(`${JSON.stringify(execution.rows[0].result)}\n${this.failureArtifacts()}`);
       return execution.rows[0]?.daemon_agent_id != null;
     }, "capability execution association");
     const execution = await this.requirePool().query<{

--- a/src/e2e/hub-foundation.e2e.test.ts
+++ b/src/e2e/hub-foundation.e2e.test.ts
@@ -50,6 +50,21 @@ describeHubE2E("Paseo Hub cross-repository contract", () => {
     await hub.completedCapabilityRun(separate.executionId);
   }, 120_000);
 
+  it("recovers a continuation whose agent was attached before its initial send", async () => {
+    await hub.connect();
+    await hub.daemonIsConnected();
+    await hub.enableAgentContinuation();
+    hub.loseNextContinuationSend();
+    const first = await hub.runCapabilityTrigger("continuation-restart", "restart-thread");
+    await hub.restartBeforeContinuationSend(first.executionId);
+    const completed = await hub.completedCapabilityRun(first.executionId);
+    assert.equal(completed.replySucceeded, true);
+    await hub.sessionIsArchived(first.executionId);
+    const next = await hub.runCapabilityTrigger("continuation-after-restart", "restart-thread");
+    assert.equal(next.agentId, first.agentId);
+    await hub.completedCapabilityRun(next.executionId);
+  }, 120_000);
+
   it("connects the source-built daemon through an enrollment token", async () => {
     const enrollment = await hub.connect();
     await hub.daemonIsConnected();

--- a/src/hub/protocol.ts
+++ b/src/hub/protocol.ts
@@ -185,6 +185,7 @@ export const HubExecutionAgentCreateRequestSchema = z.object({
   type: z.literal("hub.execution.agent.create.request"),
   requestId: z.string(),
   executionId: z.string(),
+  deadlineAt: z.string().datetime().optional(),
   provider: z.string(),
   cwd: z.string(),
   prompt: z.string(),


### PR DESCRIPTION
Agent startup now follows the existing configured execution deadlines instead of failing at an additional, hidden 30-second acknowledgement limit. Slow filesystem worktree creation, provider creation, and initial-prompt startup can use the configured `max_runtime`; expiry releases dispatch waiters and retains durable cleanup ownership.

### Goals

- Apply the absolute whole-run deadline during preparation and startup, including continuation create/restore/send.
- Preserve existing `idle_timeout` semantics and keep hung starts bounded.
- Prevent late acknowledgements and ambiguous reconnects from launching duplicate or terminal executions.
- Let pending cleanup settle before another continuation uses the conversation.

### Non-goals

- A separate startup timeout setting, changing provider phase budgets, or redefining setup-script readiness.
- Scheduled-trigger/offline-daemon changes, deployments, or automatically retrying unknown provider outcomes.

### Cause and timer ownership

| Boundary | Before | After |
| --- | --- | --- |
| Hub dispatch | 30 seconds around preparation, legacy create acknowledgement, and continuation dispatch | Remaining absolute execution deadline; live idle expiry also cancels the waiter |
| Continuation create/restore/send | Independent 30-second RPC limit | Existing execution deadline and cancellation context |
| Control/read acknowledgement | 30 seconds | Still bounded; archive timeout means an ambiguous acknowledgement, not proof of cancellation |
| Daemon work | Could continue after Hub failed; legacy control waited behind create | Companion request journal owns cancellation, late receipts, and replay safety |

`max_runtime` stays absolute from dispatch through completion. Existing workflow idle behavior is preserved: the initial idle deadline starts at dispatch; initializing/running status clears it; idle status re-arms it; meaningful activity refreshes an armed idle deadline. Connection heartbeats do not refresh it. Current daemon setup scripts already run asynchronously; filesystem worktree creation, provider creation, and initial-prompt start acknowledgement are inside the demonstrated wait. Historical reporter daemon versions and exact timings are unknown.

### Protocol/API change and compatibility

Requires the producer contract in https://github.com/getpaseo/paseo/pull/4588. Cross-repository CI pins its immutable commit `8860f2eb145509ab208a61e45f79e953f9d5d1bb`. Updated continuation checks `server_info.features.agentRequestCancellation` and gives an upgrade error before mutation on older daemons.

Hub writes `{operation: {key: executionId, deadlineAt}}` on create/restore/send and uses `executionId + ":control"` for durable control receipts. Legacy create gains `deadlineAt`. The daemon's existing `AgentRequests` journal consumes these keys and provides cancel/inspect results `{agentId, outcome: "pending" | "settled" | "unknown"}`. A receipt authorizes accounting and cleanup, never blind replay.

Expiry aborts the local create/restore/send waiter before cleanup takes the existing conversation lock. Pending control remains a durable Hub action; reconciliation retries its acknowledgement without launching another operation. A late create receipt can update the conversation for cleanup without attaching to or starting a terminal execution. A competing continuation cannot pass an unacknowledged cleanup action. Merely selecting the conversation does not count as started agent work and cannot suppress earlier cleanup. Interrupted or refused daemon operations remain unknown and require inspection; permanently noncooperative code remains explicitly pending and cannot authorize duplicate work.

Recovery now retries a still-spawning continuation with the same creation/message keys even if its agent ID was persisted before the initial send. Running continuations only resume observation. The restart test harness preserves the active configuration rather than overwriting it with seed data.

### QA

Failing-first behavioral evidence:

- Real Hub socket with a 120-second simulated create delay: baseline fails with exact `daemon_timeout` at 30 seconds; fixed code succeeds within configured runtime.
- Continuation create/restore/send responses after two simulated minutes: baseline RPCs fail at 30 seconds; fixed code accepts them.
- Hung startup expires at its configured deadline; heartbeat does not defer idle expiry; initializing status preserves the existing idle behavior without moving the absolute deadline.
- Expiry releases the conversation lock during held create, restore, and send. Late creation is accounted for cleanup, and subsequent continuation reuses one agent only after durable cleanup acknowledgement.
- Source-built daemon/Hub restart between persisted agent association and initial send: baseline never retries the prompt; fixed code completes it and the next continuation uses the same agent.

Local validation: full Hub suite passed 1,267 tests (18 skipped); 79 browser tests passed; focused startup/session tests passed; full typecheck, lint, formatting, database drift check, production build, and Docker smoke passed. The final committed runtime passed the full suite again (1,267 tests; 18 skipped; 540.34s), plus 16 focused ownership tests and both source-built continuation journeys. All eight source-built integration tests passed against the pinned companion commit, including a run with an empty Playwright browser path (95.18s). The source CI job no longer installs an unused browser. Browser CI retains its Playwright installation and removes only the unrelated runner Chrome apt feed, whose inconsistent package index blocked both jobs before tests. Companion QA passed 391 affected tests (4 skipped) across 13 files, including real isolated daemon sockets and filesystem rollback. No development or packaged daemon was restarted.

All nine CI checks passed on `a16b7d7d1110fb0c8a194b9655df91d5e4a3f341`, including browser and source-built daemon integration. Companion #4588 is also fully green, including Linux and Windows server tests. Both PRs remain unmerged.

### Related work

- https://github.com/getpaseo/paseo/pull/3578 and https://github.com/getpaseo/paseo/pull/3621 are merged provider-phase budget fixes. Hub's outer 30-second limit can still cut those phases off.
- https://github.com/getpaseo/paseo/pull/2558 covers broader workspace setup readiness, including shared daemon paths. This PR does not supersede that outcome.
- #86 covers workspace affinity; #126 covers scheduled triggers and offline workflow wakeup. Neither is duplicated here.

Risk surface: mixed daemon versions, interrupted journals, and provider cancellation refusal. Unknown outcomes fail closed rather than allowing a duplicate launch. No contributor PR is superseded by this change.
