### PR TITLE
Preserve full prompts in Hub workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ permissions:
 # companion PR creator commits it. Source-built jobs deliberately fail until it
 # is one exact 40-character SHA; mutable refs and repository variables are forbidden.
 env:
-  PASEO_E2E_COMMIT: 76caf0d047bc4437506fbcbbd241da4000769eec
+  PASEO_E2E_COMMIT: 433e67b18b7964a92d593bdc78c518143accfc8b
 
 jobs:
   typecheck:

--- a/e2e/helpers/hub.ts
+++ b/e2e/helpers/hub.ts
@@ -5363,7 +5363,7 @@ class ContractDaemon {
       headers: {
         authorization: `Bearer ${this.credential}`,
         "x-paseo-daemon-id": this.daemonId,
-        ...(this.providerCatalog ? { "x-paseo-session-protocol": "1" } : {}),
+        "x-paseo-session-protocol": "1",
       },
     });
     socket.on("message", (data) => this.acceptExecution(data));
@@ -5422,29 +5422,50 @@ class ContractDaemon {
     const envelope = ExecutionRequestSchema.safeParse(value);
     if (!envelope.success) return;
     const request = envelope.data.message;
-    const capability = request.mcpServers?.["hub"];
-    if (capability !== undefined) {
-      this.executionCapabilities.set(request.executionId, capability);
+    if (request.type === "create_agent_request") {
+      const capability = request.config.mcpServers["hub"];
+      if (!capability) throw new Error("Hub execution capability is missing");
+      const executionId = new URL(capability.url).pathname.split("/")[2];
+      if (!executionId) throw new Error("Hub execution ID is missing");
+      this.executionCapabilities.set(executionId, capability);
+      this.sendAgentResponse("status", {
+        requestId: request.requestId,
+        status: "agent_created",
+        agentId: `agent-${executionId}`,
+        agent: this.agentSnapshot(`agent-${executionId}`),
+      });
+      return;
     }
-    this.executionCreateEvents.get(request.executionId)?.resolve();
-    this.executionCreateEvents.delete(request.executionId);
-    this.socket?.send(
-      JSON.stringify({
-        type: "session",
-        message: {
-          type: "hub.execution.agent.create.response",
-          payload: {
-            requestId: request.requestId,
-            executionId: request.executionId,
-            agentId: `agent-${request.executionId}`,
-            agent: { id: `agent-${request.executionId}`, status: "running" },
-            success: true,
-            toolPolicyApplied: true,
-            error: null,
-          },
-        },
-      }),
-    );
+    if (request.type === "fetch_agent_request") {
+      this.sendAgentResponse("fetch_agent_response", {
+        requestId: request.requestId,
+        agent: this.agentSnapshot(request.agentId),
+      });
+      return;
+    }
+    if (request.type === "send_agent_message_request") {
+      const executionId = request.agentId.slice("agent-".length);
+      this.sendAgentResponse("send_agent_message_response", {
+        requestId: request.requestId,
+        accepted: true,
+      });
+      this.executionCreateEvents.get(executionId)?.resolve();
+      this.executionCreateEvents.delete(executionId);
+      return;
+    }
+    const responseType =
+      request.type === "agent.timeline.set_subscription.request"
+        ? "agent.timeline.set_subscription.response"
+        : request.type.replace("_request", "_response");
+    this.sendAgentResponse(responseType, { requestId: request.requestId });
+  }
+
+  private agentSnapshot(agentId: string) {
+    return { id: agentId, workspaceId: `workspace-${agentId}`, status: "idle" };
+  }
+
+  private sendAgentResponse(type: string, payload: Record<string, unknown>): void {
+    this.socket?.send(JSON.stringify({ type: "session", message: { type, payload } }));
   }
 
   private acceptHello(value: unknown): boolean {
@@ -5459,7 +5480,7 @@ class ContractDaemon {
             status: "server_info",
             serverId: `browser-${this.daemonId}`,
             permissions: ["hub.execute"],
-            features: { providersSnapshot: true },
+            features: { providersSnapshot: true, hubAgentRpc: true, agentRequestReceipts: true },
           },
         },
       }),
@@ -5812,22 +5833,41 @@ const WEBHOOK_SOURCE_CONTRACTS: readonly HttpContract[] = [
 
 const ExecutionRequestSchema = z.object({
   type: z.literal("session"),
-  message: z.object({
-    type: z.literal("hub.execution.agent.create.request"),
-    requestId: z.string(),
-    executionId: z.string(),
-    env: z.record(z.string(), z.string()).optional(),
-    mcpServers: z
-      .record(
-        z.string(),
-        z.object({
-          type: z.literal("http"),
-          url: z.string().url(),
-          headers: z.record(z.string(), z.string()).default({}),
-        }),
-      )
-      .optional(),
-  }),
+  message: z.discriminatedUnion("type", [
+    z.object({
+      type: z.literal("create_agent_request"),
+      requestId: z.string(),
+      config: z.object({
+        mcpServers: z.record(
+          z.string(),
+          z.object({
+            type: z.literal("http"),
+            url: z.string().url(),
+            headers: z.record(z.string(), z.string()).default({}),
+          }),
+        ),
+      }),
+    }),
+    z.object({
+      type: z.literal("fetch_agent_request"),
+      requestId: z.string(),
+      agentId: z.string(),
+    }),
+    z.object({
+      type: z.literal("send_agent_message_request"),
+      requestId: z.string(),
+      agentId: z.string(),
+    }),
+    z.object({
+      type: z.enum([
+        "fetch_agents_request",
+        "agent.timeline.set_subscription.request",
+        "cancel_agent_request",
+        "archive_workspace_request",
+      ]),
+      requestId: z.string(),
+    }),
+  ]),
 });
 
 function exact(

--- a/src/agent-sessions/index.test.ts
+++ b/src/agent-sessions/index.test.ts
@@ -72,9 +72,10 @@ async function fixture() {
       (await database.transitionAgentExecution(executionId, "succeeded")).execution,
   });
   async function arrival(
-    key: string | null = "conversation",
+    key: string | null | false = "conversation",
     target = "daemon",
     env: Record<string, string> = {},
+    prompt = "hello",
   ) {
     const executionId = randomUUID();
     const intent: LaunchMachineIntent = {
@@ -86,7 +87,7 @@ async function fixture() {
       environmentName: "target",
       environment: { kind: "daemon", daemonId: target, authoredSlug: target, cwd: "/repo" },
       agent: { provider: "codex" },
-      prompt: "hello",
+      prompt,
       env,
       allowOutputs: [{ type: "test.reply", max: 1 }],
       autoArchive: true,
@@ -94,7 +95,7 @@ async function fixture() {
       outputContext: { arrival: executionId },
       configurationRevisionId: randomUUID(),
       hubConfig: {},
-      continuation: { key, compatibility: { target } },
+      ...(key === false ? {} : { continuation: { key, compatibility: { target } } }),
     };
     await database.insertAgentExecution({
       id: executionId,
@@ -115,10 +116,8 @@ async function fixture() {
           connection,
           onEvent: () => {},
           createOptions: async () => ({
-            executionId,
             provider: "codex",
             cwd: "/repo",
-            prompt: "hello",
             env: {},
             toolPolicy: { preapproved: [] },
           }),
@@ -220,6 +219,23 @@ test("new-agent policy isolates arrivals and incompatible targets fail without r
   const changed = await f.arrival("conversation", "different-daemon");
   await expect(changed.dispatch()).rejects.toThrow("Continuation settings differ");
   expect(f.connection.creates).toHaveLength(3);
+});
+
+test("ordinary launches use agent sessions and preserve long prompts without enabling continuation", async () => {
+  const f = await fixture();
+  const prompt = "Investigate this request.\n" + "Full request context. ".repeat(1_000);
+  const first = await f.arrival(false, "daemon", {}, prompt);
+  const second = await f.arrival(false, "daemon", {}, prompt);
+  const a = await first.dispatch();
+  const replay = await first.dispatch();
+  const b = await second.dispatch();
+  expect(replay.agentId).toBe(a.agentId);
+  expect(b.agentId).not.toBe(a.agentId);
+  expect(f.connection.creates).toHaveLength(2);
+  expect(f.connection.deliveries).toEqual([
+    { agentId: a.agentId, text: prompt },
+    { agentId: b.agentId, text: prompt },
+  ]);
 });
 
 test("temporary environment credentials require a new agent instead of being reused", async () => {

--- a/src/agent-sessions/index.ts
+++ b/src/agent-sessions/index.ts
@@ -38,9 +38,9 @@ export class AgentSessions {
     action: "created" | "continued" | "restored";
   }> {
     const policy = input.intent.continuation;
-    if (!policy) throw new Error("Session dispatch requires continuation policy");
+    const continuationKey = policy?.key ?? null;
     if (
-      policy.key !== null &&
+      continuationKey !== null &&
       (input.intent.github !== undefined ||
         Object.values({ ...input.intent.environment.env, ...input.intent.env }).some(
           (value) => parseConnectionTemplate(value).length > 0,
@@ -50,13 +50,19 @@ export class AgentSessions {
         "Temporary environment credentials require New agent continuity. Existing agents cannot refresh their environment.",
       );
     }
-    const id = sessionId(input.intent.projectId, policy.key ?? `execution:${input.executionId}`);
+    const id = sessionId(
+      input.intent.projectId,
+      continuationKey ?? `execution:${input.executionId}`,
+    );
+    // External credential minting must not hold a database connection open during shutdown.
+    const storedSession = await this.database.findAgentSession(id);
+    const options = storedSession?.creationOptions ?? (await input.createOptions());
     return this.database.withAdvisoryLock(`agent-session:${id}`, async () => {
       const tools = executionToolDefinitions(
         input.intent.outputSchema,
         this.outputs.materialize(input.intent.allowOutputs, input.intent.outputContext),
       );
-      const compatibility = fingerprint({ settings: policy.compatibility, tools });
+      const compatibility = fingerprint({ settings: policy?.compatibility, tools });
       let session = await this.database.findAgentSession(id);
       if (session && session.compatibility !== compatibility) {
         throw new AgentSessionError(
@@ -64,13 +70,12 @@ export class AgentSessions {
         );
       }
       if (!session) {
-        const options = await input.createOptions();
         const token = deriveAgentExecutionCompletionToken(this.secret, `session:${id}`);
         session = {
           id,
           projectId: input.intent.projectId,
           organizationId: input.intent.organizationId,
-          continuationKey: policy.key,
+          continuationKey,
           daemonId: input.intent.environment.daemonId,
           agentId: null,
           workspaceId: null,
@@ -79,13 +84,17 @@ export class AgentSessions {
           capabilityTokenHash: hashAgentExecutionCompletionToken(token),
           creationOptions: {
             ...options,
-            mcpServers: {
-              hub: {
-                type: "http",
-                url: new URL(`/agent-sessions/${id}/mcp`, this.publicBaseUrl).toString(),
-                headers: { Authorization: `Bearer ${token}` },
-              },
-            },
+            ...(policy === undefined
+              ? {}
+              : {
+                  mcpServers: {
+                    hub: {
+                      type: "http",
+                      url: new URL(`/agent-sessions/${id}/mcp`, this.publicBaseUrl).toString(),
+                      headers: { Authorization: `Bearer ${token}` },
+                    },
+                  },
+                }),
           },
         };
         await this.database.saveAgentSession(session);
@@ -100,23 +109,32 @@ export class AgentSessions {
       }
       if (session.agentId === null || session.workspaceId === null)
         throw new Error("Session agent is missing");
-      const agent = await input.connection.get(session.agentId);
-      if (agent.archivedAt) {
-        await input.connection.restore(session.workspaceId);
-        action = "restored";
-      }
       await this.database.attachAgentToExecution(
         input.executionId,
         session.daemonId,
         session.agentId,
       );
+      const agent = await input.connection.get(session.agentId);
+      if (!agent.archivedAt && (agent.status === "closed" || agent.status === "error")) {
+        throw new AgentSessionError("agent_interrupted");
+      }
+      if (agent.archivedAt) {
+        await input.connection.restore(session.workspaceId);
+        action = "restored";
+      }
       await this.database.attachExecutionToSession(input.executionId, id, action);
       const unsubscribe = await input.connection.watch(session.agentId, input.onEvent);
       try {
+        const execution = await this.database.findAgentExecutionById(input.executionId);
+        if (!execution || execution.status === "failed" || execution.status === "succeeded") {
+          throw new AgentSessionError("execution_terminal");
+        }
         await input.connection.send(
           session.agentId,
           input.executionId,
-          `Hub execution: ${input.executionId}\nUse this executionId for Hub tool calls for this request.\n\n${input.intent.prompt}`,
+          policy === undefined
+            ? input.intent.prompt
+            : `Hub execution: ${input.executionId}\nUse this executionId for Hub tool calls for this request.\n\n${input.intent.prompt}`,
         );
       } catch (error) {
         unsubscribe();
@@ -130,17 +148,19 @@ export class AgentSessions {
     execution: AgentExecutionRecord,
     connection: AgentConnection,
     action: "interrupt" | "archive",
-  ): Promise<void> {
-    if (!execution.agentSessionId) throw new Error("Execution has no agent session");
+  ): Promise<boolean> {
+    if (!execution.agentSessionId) return true;
     const id = execution.agentSessionId;
-    await this.database.withAdvisoryLock(`agent-session:${id}`, async () => {
-      const session = await this.database.findAgentSession(id);
-      if (!session?.agentId || !session.workspaceId) return;
+    const session = await this.database.findAgentSession(id);
+    if (!session?.agentId || !session.workspaceId) return false;
+    const { agentId, workspaceId } = session;
+    return this.database.withAdvisoryLock(`agent-session:${id}`, async () => {
       const executions = await this.database.listAgentSessionExecutions(id);
       // A completed arrival cannot stop work belonging to a newer arrival.
       if (executions.some((item) => item.status === "spawning" || item.status === "running"))
-        return;
-      await connection.control(session.agentId, session.workspaceId, action);
+        return true;
+      await connection.control(agentId, workspaceId, action);
+      return true;
     });
   }
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -75,7 +75,7 @@ export interface HubRuntime {
   daemonModule: DaemonModule | null;
   connectionForDaemon(daemonId: string): import("./daemons/index.js").DaemonConnection | undefined;
   resourceCounts(): {
-    recoveredExecutionSubscriptions: number;
+    executionSubscriptions: number;
   };
   processWorkflowOutbox(): Promise<void>;
   handleUpgrade: ReturnType<typeof createDaemonUpgradeHandler> | null;
@@ -226,8 +226,7 @@ export function createHubApplication(options: HubRuntimeOptions): HubApplication
     connectionForDaemon: (daemonId) =>
       options.daemonConnectionForId?.(daemonId) ?? daemons?.connection(daemonId),
     resourceCounts: () => ({
-      recoveredExecutionSubscriptions:
-        daemonModule?.lifecycle.activeRecoveryObservationCount() ?? 0,
+      executionSubscriptions: daemonModule?.lifecycle.activeExecutionObservationCount() ?? 0,
     }),
     processWorkflowOutbox: () => workflowEngine.processAvailable(),
     handleUpgrade:

--- a/src/daemons/agents/index.test.ts
+++ b/src/daemons/agents/index.test.ts
@@ -1,0 +1,83 @@
+import { z } from "zod";
+import { expect, test } from "vitest";
+import { DaemonAgents } from "./index.js";
+import { DaemonResponseLostError, type DaemonCreateAgentOptions } from "../protocol.js";
+
+const prompt = "Full request context. ".repeat(1_000) + "End.";
+const options: DaemonCreateAgentOptions = {
+  provider: "codex",
+  cwd: "/workspace",
+  env: { REQUEST_ENV: "configured" },
+  providerOptions: { sandbox_mode: "workspace-write" },
+  toolPolicy: { preapproved: [{ kind: "mcp", server: "hub", tool: "finish_execution" }] },
+};
+
+test("ordinary creation keeps prompt delivery separate from optional titles and preserves provider configuration", async () => {
+  const requests: Record<string, unknown>[] = [];
+  const agents = new DaemonAgents((frame) => {
+    const { message } = z
+      .object({ message: z.record(z.string(), z.unknown()) })
+      .parse(JSON.parse(frame));
+    requests.push(message);
+    agents.receive({
+      type: "session",
+      message: {
+        type: message["type"] === "create_agent_request" ? "status" : "send_agent_message_response",
+        payload: {
+          requestId: message["requestId"],
+          status: "agent_created",
+          accepted: true,
+          agent: { id: "agent", workspaceId: "workspace", status: "idle" },
+        },
+      },
+    });
+  });
+  enable(agents);
+  const created = await agents.create("stable-creation-key", options);
+  await agents.send(created.id, "stable-message-key", prompt);
+  expect(requests).toHaveLength(2);
+  expect(requests[0]).toMatchObject({
+    type: "create_agent_request",
+    idempotencyKey: "stable-creation-key",
+    config: {
+      provider: options.provider,
+      cwd: options.cwd,
+      providerOptions: options.providerOptions,
+      toolPolicy: options.toolPolicy,
+    },
+    env: options.env,
+  });
+  expect(requests[0]).not.toHaveProperty("initialPrompt");
+  expect(requests[0]).not.toHaveProperty("config.title");
+  expect(requests[1]).toMatchObject({
+    type: "send_agent_message_request",
+    agentId: created.id,
+    messageId: "stable-message-key",
+    text: prompt,
+  });
+});
+
+test("requires ordinary agent RPCs and durable receipts instead of falling back to Hub creation", async () => {
+  const frames: string[] = [];
+  const agents = new DaemonAgents((frame) => frames.push(frame));
+  await expect(agents.create("key", options)).rejects.toThrow("Update the Paseo daemon");
+  expect(frames).toEqual([]);
+});
+
+test("a lost response remains recoverable instead of reporting a rejected creation", async () => {
+  const agents = new DaemonAgents(() => {});
+  enable(agents);
+  const creation = agents.create("key", options);
+  agents.close();
+  await expect(creation).rejects.toBeInstanceOf(DaemonResponseLostError);
+});
+
+function enable(agents: DaemonAgents): void {
+  agents.receive({
+    type: "session",
+    message: {
+      type: "server_info",
+      payload: { features: { hubAgentRpc: true, agentRequestReceipts: true } },
+    },
+  });
+}

--- a/src/daemons/agents/index.ts
+++ b/src/daemons/agents/index.ts
@@ -5,6 +5,7 @@ import {
   HubExecutionAgentSnapshotSchema,
 } from "../../hub/protocol.js";
 import type { DaemonCreateAgentOptions, DaemonAgentStreamEvent } from "../protocol.js";
+import { DaemonResponseLostError } from "../protocol.js";
 
 const SnapshotSchema = z.object({
   id: z.string(),
@@ -47,7 +48,10 @@ export class DaemonAgents implements AgentConnection {
   >();
   private readonly listeners = new Map<string, Set<(event: AgentEvent) => void>>();
   private observing = false;
-  constructor(private readonly sendFrame: (frame: string) => void) {}
+  constructor(
+    private readonly sendFrame: (frame: string) => void,
+    private readonly now: () => Date = () => new Date(),
+  ) {}
 
   receive(value: unknown): boolean {
     const envelope = EnvelopeSchema.safeParse(value);
@@ -73,7 +77,7 @@ export class DaemonAgents implements AgentConnection {
     if (type === "agent_update" && payload["kind"] === "upsert") {
       const agent = SnapshotSchema.safeParse(payload["agent"]);
       if (agent.success)
-        this.emit(agent.data.id, { type, agent: agent.data, timestamp: new Date().toISOString() });
+        this.emit(agent.data.id, { type, agent: agent.data, timestamp: this.now().toISOString() });
       return true;
     }
     if (type === "agent_stream") {
@@ -84,14 +88,19 @@ export class DaemonAgents implements AgentConnection {
           event: HubExecutionAgentStreamEventSchema,
         })
         .safeParse(payload);
-      if (stream.success) this.emit(stream.data.agentId, { type, ...stream.data });
+      if (stream.success)
+        this.emit(stream.data.agentId, {
+          type,
+          ...stream.data,
+          timestamp: this.now().toISOString(),
+        });
       return true;
     }
     return false;
   }
 
   close(): void {
-    for (const pending of this.pending.values()) pending.reject(new Error("daemon_disconnected"));
+    for (const pending of this.pending.values()) pending.reject(new DaemonResponseLostError());
     this.pending.clear();
     this.listeners.clear();
   }
@@ -185,14 +194,13 @@ export class DaemonAgents implements AgentConnection {
     for (const listener of this.listeners.get(agentId) ?? []) listener(event);
   }
   private async request(message: Record<string, unknown>): Promise<Record<string, unknown>> {
-    if (!this.supported)
-      throw new DaemonAgentError("Update the Paseo daemon to use agent continuation");
+    if (!this.supported) throw new DaemonAgentError("Update the Paseo daemon to run Hub agents");
     const requestId = randomUUID();
     let timeout: ReturnType<typeof setTimeout> | undefined;
     try {
       const result = await new Promise<Record<string, unknown>>((resolve, reject) => {
         this.pending.set(requestId, { resolve, reject });
-        timeout = setTimeout(() => reject(new Error("Daemon request timed out")), 30_000);
+        timeout = setTimeout(() => reject(new DaemonResponseLostError()), 30_000);
         this.sendFrame(JSON.stringify({ type: "session", message: { ...message, requestId } }));
       });
       const parsed = ResultSchema.parse(result);

--- a/src/daemons/daemons.test.ts
+++ b/src/daemons/daemons.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { afterEach, beforeEach, describe, it } from "vitest";
 import { DaemonDispatchFailure } from "./index.js";
-import { DaemonCreateResponseLostError } from "./protocol.js";
+import { DaemonResponseLostError } from "./protocol.js";
 import { ENROLLMENT_LIFETIME_MS } from "./registration.js";
 import { HubHarness } from "./test-utils/hub-harness.js";
 import { currentProjectConfigurationFiles } from "../test-utils/current-project-configuration.js";
@@ -246,20 +246,11 @@ describe("daemon enrollment and execution", () => {
     assert.equal(isRecord(launch.env) ? launch.env["PASEO_AGENT_MODE"] : undefined, undefined);
   });
 
-  it("surfaces daemon provider-option validation at the authored YAML path", async () => {
+  it("preserves the ordinary daemon provider-option validation error", async () => {
     await hub.connectDaemon();
-    hub.rejectNextCreate({
-      code: "provider_options_invalid",
-      provider: "codex",
-      issues: [
-        {
-          path: ["sandbox_workspace_write", "network-access"],
-          message: "Expected boolean, received string",
-        },
-      ],
-      message:
-        "Invalid providerOptions for 'codex': providerOptions.sandbox_workspace_write.network_access: Expected boolean, received string",
-    });
+    hub.rejectNextCreate(
+      "Invalid providerOptions for 'codex': providerOptions.sandbox_workspace_write.network_access: Expected boolean, received string",
+    );
 
     const handedOff = await hub.handoff({
       agent: {
@@ -272,25 +263,20 @@ describe("daemon enrollment and execution", () => {
     assert.deepEqual(failed.result, {
       status: "failed",
       reason:
-        "provider 'codex': agent.options.sandbox_workspace_write[\"network-access\"]: Expected boolean, received string",
+        "Invalid providerOptions for 'codex': providerOptions.sandbox_workspace_write.network_access: Expected boolean, received string",
     });
   });
 
   it("surfaces unsupported exact MCP preapproval without waiting for a timeout", async () => {
     await hub.connectDaemon();
-    hub.rejectNextCreate({
-      code: "tool_policy_unsupported",
-      provider: "test-provider",
-      message: "Provider test-provider does not support exact MCP tool preapproval",
-    });
+    hub.rejectNextCreate("Provider test-provider does not support exact MCP tool preapproval");
 
     const handedOff = await hub.handoff({ agent: { provider: "test-provider" } });
     const failed = await hub.waitForExecutionStatus(handedOff.execution.id, "failed");
 
     assert.deepEqual(failed.result, {
       status: "failed",
-      reason:
-        "tool_policy_unsupported: Provider test-provider does not support exact MCP tool preapproval",
+      reason: "Provider test-provider does not support exact MCP tool preapproval",
     });
   });
 
@@ -372,7 +358,7 @@ describe("daemon enrollment and execution", () => {
     const delivered = await hub.deliverCurrentProjectSlackMention(slackConnectionId);
     assert.equal(delivered.status, 200);
 
-    await hub.waitForCreatedAgentRequests(1);
+    await hub.waitForDeliveredPrompts(1);
     const classifier = await hub.waitForPendingExecution();
     const classifierLaunch = hub.createdAgentLaunch();
     assert.equal(classifierLaunch.provider, "claude");
@@ -402,7 +388,7 @@ describe("daemon enrollment and execution", () => {
       runStatus: "running",
       runFailure: null,
     });
-    await hub.waitForCreatedAgentRequests(2);
+    await hub.waitForDeliveredPrompts(2);
     const worker = await hub.waitForPendingExecution();
     const workerLaunch = hub.createdAgentLaunch();
     assert.equal(workerLaunch.provider, "codex");
@@ -485,6 +471,7 @@ describe("daemon enrollment and execution", () => {
 
       hub.releaseLaunchMaterialization();
       await hub.waitForRecoveredExecution(handedOff.execution.id);
+      await hub.waitForDeliveredPrompts(1);
       assert.equal(hub.createdAgentLaunch().prompt, "token=<secret>");
       assert.equal(Reflect.get(Object(hub.createdAgentLaunch().env), "TOKEN"), "resolved-secret");
       assert.deepEqual(hub.createdAgentLaunch().worktree, {
@@ -545,9 +532,9 @@ describe("daemon enrollment and execution", () => {
     assert.deepEqual(hub.authorityRevokedTokens(), ["durable-scoped-token-1"]);
   });
 
-  it("reconstructs authority on graceful restart and revokes the old lease before recovery remints", async () => {
+  it("fails recovery of revoked scoped credentials without recreating the agent or reminting", async () => {
     await hub.connectDaemon();
-    await hub.handoff({
+    const handedOff = await hub.handoff({
       github: {
         connection: "getpaseo-github",
         repositories: ["getpaseo/paseo"],
@@ -559,11 +546,15 @@ describe("daemon enrollment and execution", () => {
     assert.deepEqual(hub.authorityRevokedTokens(), []);
 
     await hub.restartApp();
-    await hub.waitForCreatedAgentRequests(2);
+    const failed = await hub.waitForExecutionStatus(handedOff.execution.id, "failed");
 
     assert.deepEqual(hub.authorityRevokedTokens(), ["durable-scoped-token-1"]);
-    assert.equal(hub.authorityMintInputs().length, 2);
-    assert.equal(hub.createdAgentRequestCount(), 2);
+    assert.deepEqual(failed.result, {
+      status: "failed",
+      reason: "execution_credentials_unavailable",
+    });
+    assert.equal(hub.authorityMintInputs().length, 1);
+    assert.equal(hub.createdAgentRequestCount(), 1);
   });
 
   it("bounds Hub shutdown when terminal cleanup follows a permanently unresolved authority mint", async () => {
@@ -650,6 +641,7 @@ describe("daemon enrollment and execution", () => {
     assert(execution !== undefined);
     await hub.waitForRecoveredExecution(execution.id);
 
+    await hub.waitForDeliveredPrompts(1);
     assert.equal(hub.createdAgentLaunch().prompt, "token=<secret>");
     assert.equal(Reflect.get(Object(hub.createdAgentLaunch().env), "TOKEN"), "resolved-secret");
     assert.deepEqual(hub.createdAgentLaunch().worktree, {
@@ -815,8 +807,8 @@ describe("daemon enrollment and execution", () => {
 
     const agentId = hub.interruptPendingSpawn();
     hub.interruptPendingSpawn();
-    await hub.failureNotified();
     const action = await hub.acceptSpawnAndObserveControl(pending.id);
+    await hub.failureNotified();
     await dispatch.catch(() => undefined);
 
     const execution = await hub.execution(pending.id);
@@ -844,40 +836,15 @@ describe("daemon enrollment and execution", () => {
     );
   });
 
-  it("retains MCP completion cleanup before spawn acknowledgement", async () => {
-    const daemonId = await hub.connectDaemon();
+  it("sends the prompt only after agent creation is acknowledged", async () => {
+    await hub.connectDaemon();
     hub.holdSpawnAcknowledgement();
     const dispatch = hub.beginDispatch({ autoArchive: true });
     await hub.spawnBegins();
-    const pending = await hub.pendingExecution();
-
-    assert.equal(await hub.completeExecution(pending.id), 200);
-    assert.deepEqual(hub.controlActions(), []);
-    await hub.completeCurrentTurn(`agent-${pending.id}`);
-    await hub.pendingControlAction(pending.id);
-    await hub.completePendingCleanup();
-
-    const completed = await hub.execution(pending.id);
-    assert.deepEqual(
-      {
-        status: completed.status,
-        daemon: completed.daemonId,
-        agent: completed.daemonAgentId,
-        hubAction: completed.hubAction,
-        hubActionCompleted: completed.hubActionCompletedAt !== null,
-        actions: hub.controlActions(),
-      },
-      {
-        status: "succeeded",
-        daemon: daemonId,
-        agent: null,
-        hubAction: "archive",
-        hubActionCompleted: true,
-        actions: ["archive"],
-      },
-    );
+    assert.equal(hub.createdAgentLaunch().prompt, undefined);
     hub.acceptSpawn();
     await dispatch;
+    assert.equal(hub.createdAgentLaunch().prompt, "Reply pong.");
   });
 
   it("retains deadline cleanup when spawn never materializes", async () => {
@@ -908,8 +875,8 @@ describe("daemon enrollment and execution", () => {
         daemon: daemonId,
         agent: null,
         hubAction: "archive",
-        hubActionCompleted: true,
-        actions: ["archive"],
+        hubActionCompleted: false,
+        actions: [],
         agents: 0,
       },
     );
@@ -927,7 +894,7 @@ describe("daemon enrollment and execution", () => {
       hub.markPendingSpawnInterrupted(status);
 
       await hub.restartApp();
-      await assert.rejects(dispatch, DaemonCreateResponseLostError);
+      await assert.rejects(dispatch, DaemonResponseLostError);
       await hub.failureNotified();
       await hub.completePendingCleanup(daemonId);
 
@@ -1022,7 +989,7 @@ describe("daemon enrollment and execution", () => {
 
     await hub.disconnectDaemon();
 
-    await assert.rejects(dispatch, DaemonCreateResponseLostError);
+    await assert.rejects(dispatch, DaemonResponseLostError);
     assert.deepEqual(
       {
         status: (await hub.execution(pending.id)).status,
@@ -1178,7 +1145,7 @@ describe("daemon enrollment and execution", () => {
     assert.equal((await hub.execution(result.execution.id)).hubActionReadyAt, null);
 
     await hub.reconnectDaemon();
-    await hub.runtimeResources({ recoveredExecutionSubscriptions: 1 });
+    await hub.runtimeResources({ executionSubscriptions: 1 });
     await hub.completeCurrentTurn(result.agentId);
     await hub.pendingControlAction(result.execution.id);
     await hub.completePendingCleanup();
@@ -1208,7 +1175,7 @@ describe("daemon enrollment and execution", () => {
     assert.equal(recovered.hubActionCompletedAt, null);
 
     await hub.reconnectDaemon();
-    await hub.runtimeResources({ recoveredExecutionSubscriptions: 1 });
+    await hub.runtimeResources({ executionSubscriptions: 1 });
     await hub.completeCurrentTurn(result.agentId);
     await hub.pendingControlAction(result.execution.id);
     await hub.completePendingCleanup();
@@ -1227,10 +1194,9 @@ describe("daemon enrollment and execution", () => {
     hub.holdControlAcknowledgements();
 
     await hub.restartApp();
-    await hub.runtimeResources({ recoveredExecutionSubscriptions: 2 });
+    await hub.runtimeResources({ executionSubscriptions: 2 });
     await hub.completeCurrentTurn(cleanup.agentId);
     assert.equal(await hub.pendingControlAction(cleanup.execution.id), "archive");
-    await hub.spawnBegins();
     hub.interruptAgent(live.agentId);
     assert.equal(await hub.pendingControlAction(live.execution.id), "interrupt");
 
@@ -1504,6 +1470,7 @@ describe("daemon enrollment and execution", () => {
     const result = await dispatch;
     assert.equal(result.status, 200);
 
+    await hub.waitForExecutionStatus(pending.id, "running");
     await hub.advanceDispatchTime(10_000);
 
     assert.equal((await hub.execution(pending.id)).status, "failed");
@@ -1691,10 +1658,10 @@ describe("daemon enrollment and execution", () => {
         result: { status: "failed", reason: "agent_interrupted" },
         daemonId,
         agentId: result.agentId,
-        createRequests: 2,
+        createRequests: 1,
         failureHooks: 1,
         resources: {
-          recoveredExecutionSubscriptions: 0,
+          executionSubscriptions: 0,
         },
       },
     );
@@ -1718,19 +1685,19 @@ describe("daemon enrollment and execution", () => {
       await hub.waitForRecoveredExecution(execution.id);
       assert.deepEqual(
         await hub.runtimeResources({
-          recoveredExecutionSubscriptions: 1,
+          executionSubscriptions: 1,
         }),
         {
-          recoveredExecutionSubscriptions: 1,
+          executionSubscriptions: 1,
         },
       );
       assert.equal(await hub.completeExecution(execution.id), 200);
       await hub.waitForExecutionStatus(execution.id, "succeeded");
       assert.deepEqual(
         await hub.runtimeResources({
-          recoveredExecutionSubscriptions: 0,
+          executionSubscriptions: 0,
         }),
-        { recoveredExecutionSubscriptions: 0 },
+        { executionSubscriptions: 0 },
       );
     }
 
@@ -1743,9 +1710,9 @@ describe("daemon enrollment and execution", () => {
     await hub.waitForExecutionStatus(execution.id, "running");
     await hub.restartApp();
     await hub.waitForRecoveredExecution(execution.id);
-    await hub.runtimeResources({ recoveredExecutionSubscriptions: 1 });
+    await hub.runtimeResources({ executionSubscriptions: 1 });
     assert.deepEqual(await hub.stopRuntimeResources(), {
-      recoveredExecutionSubscriptions: 0,
+      executionSubscriptions: 0,
     });
   });
 
@@ -1754,16 +1721,16 @@ describe("daemon enrollment and execution", () => {
     const timedOut = await hub.dispatch({ timeoutMs: 1_000 });
     assert.deepEqual(
       await hub.runtimeResources({
-        recoveredExecutionSubscriptions: 0,
+        executionSubscriptions: 1,
       }),
       {
-        recoveredExecutionSubscriptions: 0,
+        executionSubscriptions: 1,
       },
     );
     await hub.advanceDispatchTime(1_000);
     assert.equal((await hub.execution(timedOut.execution.id)).status, "failed");
     assert.deepEqual(await hub.runtimeResources(), {
-      recoveredExecutionSubscriptions: 0,
+      executionSubscriptions: 0,
     });
   });
 

--- a/src/daemons/lifecycle.test.ts
+++ b/src/daemons/lifecycle.test.ts
@@ -1,13 +1,8 @@
-import { DaemonAgents } from "./agents/index.js";
+import type { AgentConnection } from "./agents/index.js";
 import assert from "node:assert/strict";
 import { describe, it, vi } from "vitest";
 import { createMemoryDatabase } from "../db/memory.js";
-import type {
-  DaemonExecutionControlOptions,
-  DaemonEventHandler,
-  DaemonEvent,
-  DaemonConnection,
-} from "./protocol.js";
+import type { DaemonEvent, DaemonConnection } from "./protocol.js";
 import {
   createDaemonDispatchLifecycle,
   DaemonDispatchFailure,
@@ -258,6 +253,25 @@ async function acknowledgementFixture() {
     outputContext: {},
     configurationRevisionId: "revision-ack-test",
   });
+  await database.saveAgentSession({
+    id: "session",
+    organizationId: "org-ack-test",
+    projectId: "project-ack-test",
+    continuationKey: null,
+    daemonId: DAEMON_ID,
+    agentId: AGENT_ID,
+    workspaceId: "workspace",
+    compatibility: "test",
+    capabilityTokenHash: "test",
+    tools: [],
+    creationOptions: {
+      provider: "codex",
+      cwd: "/workspace",
+      env: {},
+      toolPolicy: { preapproved: [] },
+    },
+  });
+  await database.attachExecutionToSession(EXECUTION_ID, "session");
   await database.attachAgentToExecution(EXECUTION_ID, DAEMON_ID, AGENT_ID);
   await database.transitionAgentExecution(EXECUTION_ID, "succeeded", {
     completedByAgent: true,
@@ -277,24 +291,51 @@ function createLifecycle(
 ): DaemonDispatchLifecycle {
   return createDaemonDispatchLifecycle({
     database,
+    publicBaseUrl: "http://hub.test",
+    completionTokenSecret: "test-secret",
     connectionForDaemon: (daemonId) => (daemonId === DAEMON_ID ? connection : undefined),
   });
 }
 
 class AcknowledgementConnection implements DaemonConnection {
-  readonly agents = new DaemonAgents(() => {
-    throw new Error("Native agents are not used by this legacy fixture");
-  });
-  readonly actions: DaemonExecutionControlOptions["action"][] = [];
-  private readonly handlers = new Set<DaemonEventHandler>();
+  readonly agents: AgentConnection = {
+    create: async () => {
+      throw new Error("not used");
+    },
+    get: async () => {
+      throw new Error("not used");
+    },
+    send: async () => {
+      throw new Error("not used");
+    },
+    restore: async () => {
+      throw new Error("not used");
+    },
+    control: async (_agentId, _workspaceId, action) => {
+      this.actions.push(action);
+    },
+    watch: async (_agentId, listener) =>
+      this.on((event) => {
+        if (event.type === "agent_stream") listener(event);
+        else
+          listener({
+            type: "agent_update",
+            agent: { id: event.agentId, workspaceId: "workspace", status: event.agent.status },
+            timestamp: event.timestamp,
+          });
+      }),
+  };
+  readonly actions: Array<"interrupt" | "archive"> = [];
+  private readonly handlers = new Set<(event: DaemonEvent) => void | Promise<void>>();
 
-  on(handler: DaemonEventHandler): () => void {
+  on(handler: (event: DaemonEvent) => void | Promise<void>): () => void {
     this.handlers.add(handler);
     return () => this.handlers.delete(handler);
   }
 
   async emit(event: DaemonEvent): Promise<void> {
     for (const handler of this.handlers) await handler(event);
+    await new Promise<void>((resolve) => setImmediate(resolve));
   }
 
   async emitObserved(event: DaemonEvent): Promise<void> {
@@ -313,10 +354,6 @@ class AcknowledgementConnection implements DaemonConnection {
 
   async refreshProviderSnapshot(): Promise<never> {
     throw new Error("not used");
-  }
-
-  async controlExecution(options: DaemonExecutionControlOptions): Promise<void> {
-    this.actions.push(options.action);
   }
 }
 

--- a/src/daemons/lifecycle.ts
+++ b/src/daemons/lifecycle.ts
@@ -38,9 +38,7 @@ import {
 } from "../triggers/lifecycle.js";
 import type { TriggerProviderReactionState } from "../triggers/index.js";
 import {
-  DaemonCreateRejectedError,
-  DaemonCreateResponseLostError,
-  type DaemonAgentSnapshot,
+  DaemonResponseLostError,
   type DaemonAgentStreamEvent,
   type DaemonConnection,
   type DaemonCreateAgentOptions,
@@ -75,7 +73,7 @@ const DEFAULT_DISPATCH_TIMEOUT_MS = 30_000;
 const DEFAULT_AGENT_EXECUTION_TIMEOUT_MS = 60 * 60_000;
 const DEFAULT_AGENT_IDLE_TIMEOUT_MS = 5 * 60_000;
 
-type AgentStatus = NonNullable<DaemonAgentSnapshot["state"]>["status"];
+type AgentStatus = Extract<DaemonEvent, { type: "agent_update" }>["agent"]["status"];
 interface ExecutionDeadline {
   kind: "hard" | "idle";
   at: Date;
@@ -152,15 +150,11 @@ export class DaemonDispatchLifecycle {
   private readonly executionCapabilities: OutputExecutorRegistry;
   private readonly startedExecutions = new Set<string>();
   private readonly pendingStreamHandlersByExecution = new Map<string, Promise<void>>();
-  private readonly completionWatchersByExecution = new Map<
-    string,
-    (failure?: DaemonDispatchFailure) => void
-  >();
   private readonly deadlineTimersByExecution = new Map<string, () => void>();
   private readonly activeExecutionDispatches = new Map<string, Promise<unknown>>();
   private readonly reconcilingHubActions = new Map<string, Promise<void>>();
   private readonly daemonRecoveries = new Set<Promise<void>>();
-  private readonly recoveredSubscriptions = new Map<string, () => void>();
+  private readonly executionSubscriptions = new Map<string, () => void>();
   private stopping = false;
 
   constructor(private readonly options: DaemonDispatchLifecycleOptions) {
@@ -170,14 +164,14 @@ export class DaemonDispatchLifecycle {
     );
   }
 
-  activeRecoveryObservationCount(): number {
-    return this.recoveredSubscriptions.size;
+  activeExecutionObservationCount(): number {
+    return this.executionSubscriptions.size;
   }
 
   async stop(): Promise<void> {
     this.stopping = true;
-    for (const unsubscribe of this.recoveredSubscriptions.values()) unsubscribe();
-    this.recoveredSubscriptions.clear();
+    for (const unsubscribe of this.executionSubscriptions.values()) unsubscribe();
+    this.executionSubscriptions.clear();
     for (const clear of this.deadlineTimersByExecution.values()) clear();
     this.deadlineTimersByExecution.clear();
     this.startedExecutions.clear();
@@ -517,7 +511,7 @@ export class DaemonDispatchLifecycle {
 
       return { execution, agentId };
     } catch (error) {
-      if (error instanceof DaemonCreateResponseLostError) throw error;
+      if (error instanceof DaemonResponseLostError) throw error;
       const failure = toDaemonDispatchFailure(error);
       this.logDispatchFailure(failure, {
         daemonId: intent.environment.daemonId,
@@ -653,7 +647,8 @@ export class DaemonDispatchLifecycle {
           isHubFinishExecutionToolName(item.name) &&
           typeof item.callId === "string" &&
           isHubFinishExecutionStatus(item.status) &&
-          !(await this.options.database.findAgentExecutionById(executionId))?.agentSessionId
+          (await this.options.database.findAgentExecutionById(executionId))?.launchIntent
+            ?.continuation === undefined
         ) {
           await this.options.database.recordAgentExecutionHubAcknowledgement(executionId, {
             kind: "finish_execution",
@@ -716,7 +711,6 @@ export class DaemonDispatchLifecycle {
     if (ready !== undefined) {
       await this.reconcileHubActionSafely(ready);
       this.releaseExecutionResources(executionId);
-      this.completionWatchersByExecution.get(executionId)?.();
     }
   }
 
@@ -727,12 +721,7 @@ export class DaemonDispatchLifecycle {
     observedAt: Date,
   ): Promise<void> {
     if (status === "error" || status === "closed") {
-      const failed = await this.failAgentExecution(executionId, "agent_interrupted");
-      if (failed !== undefined) {
-        this.completionWatchersByExecution.get(executionId)?.(
-          new DaemonDispatchFailure("agent_interrupted"),
-        );
-      }
+      await this.failAgentExecution(executionId, "agent_interrupted");
       return;
     }
 
@@ -893,9 +882,6 @@ export class DaemonDispatchLifecycle {
     if (options.deferHubAction === true && execution.hubAction === "archive") {
       await this.reconcileHubActionSafely(execution);
     }
-    if (!(options.deferHubAction === true && execution.hubAction === "archive")) {
-      this.completionWatchersByExecution.get(input.executionId)?.();
-    }
     if (execution.status !== "succeeded") {
       throw new AgentExecutionCompletionFailure("expired");
     }
@@ -929,7 +915,7 @@ export class DaemonDispatchLifecycle {
       }
       const connection = this.options.connectionForDaemon(execution.daemonId);
       if (connection !== undefined) {
-        this.subscribeRecoveredExecution(execution.id, execution.daemonId, connection);
+        await this.subscribeRecoveredExecution(execution.id, execution.daemonId, connection);
       }
     }
     await Promise.all(executions.map((execution) => this.reconcileHubActionSafely(execution)));
@@ -940,7 +926,6 @@ export class DaemonDispatchLifecycle {
       this.clearExecutionDeadline(executionId);
       this.releaseExecutionResources(executionId);
       this.startedExecutions.delete(executionId);
-      this.completionWatchersByExecution.get(executionId)?.(new DaemonDispatchFailure("timeout"));
     }
     await this.recoverPendingHubActions();
   }
@@ -1017,70 +1002,51 @@ export class DaemonDispatchLifecycle {
     const intent = current.launchIntent;
     if (intent === null || this.options.publicBaseUrl === undefined)
       throw new Error("execution launch intent cannot be recovered");
-    if (intent.continuation !== undefined) {
-      if (current.daemonAgentId === null) {
-        await this.dispatchSession({
-          daemonId: daemon.id,
-          executionId: current.id,
-          intent,
-          hubExecutionEnv: {
-            executionId: current.id,
-            completionToken: this.completionToken(current.id),
-            publicBaseUrl: this.options.publicBaseUrl,
-          },
-        });
-      } else {
-        const unsubscribe = await connection.agents.watch(current.daemonAgentId, (event) =>
-          this.observeSessionEvent(current.id, daemon.id, event),
-        );
-        this.recoveredSubscriptions.get(current.id)?.();
-        this.recoveredSubscriptions.set(current.id, unsubscribe);
-        this.armExecutionDeadline(current);
-      }
+    // An existing agent cannot receive replacement process environment credentials.
+    if (
+      current.agentSessionId !== null &&
+      this.options.executionAuthority &&
+      !this.options.executionAuthority.canResume({
+        executionId: current.id,
+        projectId: intent.projectId,
+        triggerContext: intent.triggerContext,
+        env: { ...intent.environment.env, ...intent.env },
+        ...(intent.github === undefined ? {} : { github: intent.github }),
+      })
+    ) {
+      await this.failAgentExecution(current.id, "execution_credentials_unavailable");
       return;
     }
-    const createOptions = await this.buildCreateAgentOptions(intent, {
+    await this.dispatchSession({
+      daemonId: daemon.id,
       executionId: current.id,
-      completionToken: this.completionToken(current.id),
-      publicBaseUrl: this.options.publicBaseUrl,
-    }).catch((error: unknown) => {
-      throw toDispatchPreparationFailure(error);
+      intent,
+      hubExecutionEnv: {
+        executionId: current.id,
+        completionToken: this.completionToken(current.id),
+        publicBaseUrl: this.options.publicBaseUrl,
+      },
+    }).catch(async (error: unknown) => {
+      if (error instanceof AgentSessionError || error instanceof DaemonAgentError) {
+        await this.failAgentExecution(current.id, toDaemonDispatchFailure(error).reason);
+        return;
+      }
+      throw error;
     });
-    this.subscribeRecoveredExecution(current.id, daemon.id, connection);
-    this.armExecutionDeadline(current);
-    const agent = await connection.createAgent(createOptions).catch((error: unknown) => {
-      throw toDaemonTransportFailure(error);
-    });
-    if (isInterruptedAgentState(agent.state)) {
-      await this.failAgentExecution(current.id, "agent_interrupted");
-      return;
-    }
-    await this.options.database.attachAgentToExecution(current.id, daemon.id, agent.id);
-    await this.restoreAgentState(current.id, agent);
   }
 
-  private subscribeRecoveredExecution(
+  private async subscribeRecoveredExecution(
     executionId: string,
     daemonId: string,
     connection: DaemonConnection,
-  ): void {
-    this.recoveredSubscriptions.get(executionId)?.();
-    this.recoveredSubscriptions.set(
-      executionId,
-      connection.on(async (event) => {
-        if (event.executionId !== executionId) return;
-        await this.queueDaemonEvent(executionId, daemonId, event);
-      }),
+  ): Promise<void> {
+    const execution = await this.options.database.findAgentExecutionById(executionId);
+    if (!execution?.daemonAgentId) return;
+    const unsubscribe = await connection.agents.watch(execution.daemonAgentId, (event) =>
+      this.observeSessionEvent(executionId, daemonId, event),
     );
-  }
-
-  private async restoreAgentState(executionId: string, agent: DaemonAgentSnapshot): Promise<void> {
-    if (agent.state === undefined) {
-      await this.startAgentExecution(executionId);
-      return;
-    }
-    const observedAt = new Date(this.now());
-    await this.handleAgentStatus(executionId, agent.state.status, "restore", observedAt);
+    this.executionSubscriptions.get(executionId)?.();
+    this.executionSubscriptions.set(executionId, unsubscribe);
   }
 
   async failPendingExecutionsForDisconnectedMachine(
@@ -1337,14 +1303,12 @@ export class DaemonDispatchLifecycle {
     if (action === null || daemonId === null) return;
     const connection = this.options.connectionForDaemon(daemonId);
     if (connection === undefined) return;
-    await withHubActionTimeout(
-      execution.agentSessionId === null
-        ? connection.controlExecution({ executionId: execution.id, action })
-        : this.sessionOwner().control(execution, connection.agents, action),
+    const completed = await withHubActionTimeout(
+      this.sessionOwner().control(execution, connection.agents, action),
       this.dispatchTimeoutMs,
       (callback, delayMs) => this.scheduleDeadline(async () => callback(), delayMs),
     );
-    await this.options.database.completeHubAction(execution.id, action);
+    if (completed) await this.options.database.completeHubAction(execution.id, action);
   }
 
   private async notifyMachineTerminated(
@@ -1512,28 +1476,17 @@ export class DaemonDispatchLifecycle {
     deadlineAt: Date,
   ): Promise<string> {
     let canceled = false;
-    const cancelHandlers = new Set<() => Promise<void>>();
     const timeoutMs = Math.max(
       0,
       Math.min(this.dispatchTimeoutMs, deadlineAt.getTime() - this.now()),
     );
     try {
       return await withDispatchTimeout(
-        this.acquireAndSpawnAgentWithoutTimeout(
-          input,
-          () => canceled,
-          (handler) => {
-            cancelHandlers.add(handler);
-          },
-        ),
+        this.acquireAndSpawnAgentWithoutTimeout(input, () => canceled),
         timeoutMs,
         () => {
           canceled = true;
-          for (const handler of cancelHandlers) {
-            void handler().catch((error: unknown) => {
-              this.report(error, "daemon.dispatch.cancel", { executionId: input.executionId });
-            });
-          }
+          this.releaseExecutionResources(input.executionId);
         },
         (callback, delayMs) => this.scheduleDeadline(async () => callback(), delayMs),
       );
@@ -1564,15 +1517,28 @@ export class DaemonDispatchLifecycle {
   }): Promise<string> {
     const connection = this.options.connectionForDaemon(input.daemonId);
     if (!connection) throw new DaemonDispatchFailure("daemon_unreachable");
-    const dispatched = await this.sessionOwner().dispatch({
-      executionId: input.executionId,
-      intent: input.intent,
-      connection: connection.agents,
-      createOptions: () => this.buildCreateAgentOptions(input.intent, input.hubExecutionEnv),
-      onEvent: (event) => this.observeSessionEvent(input.executionId, input.daemonId, event),
-    });
-    this.recoveredSubscriptions.get(input.executionId)?.();
-    this.recoveredSubscriptions.set(input.executionId, dispatched.unsubscribe);
+    const dispatched = await this.sessionOwner()
+      .dispatch({
+        executionId: input.executionId,
+        intent: input.intent,
+        connection: connection.agents,
+        createOptions: () =>
+          this.buildCreateAgentOptions(input.intent, input.hubExecutionEnv).catch(
+            (error: unknown) => {
+              throw toDispatchPreparationFailure(error);
+            },
+          ),
+        onEvent: (event) => this.observeSessionEvent(input.executionId, input.daemonId, event),
+      })
+      .catch(async (error: unknown) => {
+        const execution = await this.options.database.findAgentExecutionById(input.executionId);
+        if (execution && isTerminalExecutionStatus(execution.status)) {
+          await this.reconcileHubActionSafely(execution);
+        }
+        throw error;
+      });
+    this.executionSubscriptions.get(input.executionId)?.();
+    this.executionSubscriptions.set(input.executionId, dispatched.unsubscribe);
     await this.startAgentExecution(input.executionId);
     await this.armLiveExecutionDeadline(input.executionId);
     return dispatched.agentId;
@@ -1603,116 +1569,17 @@ export class DaemonDispatchLifecycle {
       hubExecutionEnv: HubExecutionEnv;
     },
     isCanceled: () => boolean,
-    onCancel: (handler: () => Promise<void>) => void,
   ): Promise<string> {
-    if (input.intent.continuation !== undefined) return this.dispatchSession(input);
-    const connection = this.options.connectionForDaemon(input.daemonId);
-    if (connection === undefined) {
-      throw new DaemonDispatchFailure("daemon_unreachable");
+    if (isCanceled()) throw new DaemonSpawnAckTimeoutError(this.dispatchTimeoutMs);
+    if (!(await this.armLiveExecutionDeadline(input.executionId))) {
+      throw new DaemonDispatchFailure("timeout");
     }
-    const createOptions = await this.buildCreateAgentOptions(
-      input.intent,
-      input.hubExecutionEnv,
-    ).catch((error: unknown) => {
-      throw toDispatchPreparationFailure(error);
-    });
+    const agentId = await this.dispatchSession(input);
     if (isCanceled()) {
+      this.releaseExecutionResources(input.executionId);
       throw new DaemonSpawnAckTimeoutError(this.dispatchTimeoutMs);
     }
-    const pendingHandlers = new Set<Promise<void>>();
-    let disposed = false;
-    let settleTerminal: ((failure?: DaemonDispatchFailure) => void) | undefined;
-    const terminal = new Promise<void>((resolve, reject) => {
-      settleTerminal = (failure) => {
-        if (failure === undefined) {
-          resolve();
-          return;
-        }
-        reject(failure);
-      };
-    });
-    void terminal.catch(() => undefined);
-    this.completionWatchersByExecution.set(input.executionId, (failure) => {
-      settleTerminal?.(failure);
-    });
-    const cleanup = async (): Promise<void> => {
-      if (disposed) {
-        return;
-      }
-      disposed = true;
-      unsubscribeEvents();
-      this.completionWatchersByExecution.delete(input.executionId);
-      await Promise.all(Array.from(pendingHandlers));
-    };
-
-    const trackHandler = (operation: Promise<void>): Promise<void> => {
-      const tracked = operation.catch((error: unknown) => {
-        if (!disposed) {
-          this.report(error, "daemon.launch.event", { executionId: input.executionId });
-        }
-      });
-      pendingHandlers.add(tracked);
-      void tracked.finally(() => {
-        pendingHandlers.delete(tracked);
-      });
-      return tracked;
-    };
-
-    const unsubscribeEvents = connection.on((event: DaemonEvent) => {
-      if (event.executionId !== input.executionId) {
-        return undefined;
-      }
-      return trackHandler(this.queueDaemonEvent(input.executionId, input.daemonId, event));
-    });
-    onCancel(cleanup);
-
-    try {
-      if (!(await this.armLiveExecutionDeadline(input.executionId))) {
-        throw new DaemonDispatchFailure("timeout");
-      }
-
-      if (isCanceled()) {
-        throw new DaemonSpawnAckTimeoutError(this.dispatchTimeoutMs);
-      }
-      const agent = await Promise.race([
-        connection
-          .createAgent(createOptions)
-          .catch((error: unknown) => Promise.reject(toDaemonTransportFailure(error))),
-        terminal.then<never>(() => new Promise<never>(() => undefined)),
-      ]);
-      if (isCanceled()) {
-        throw new DaemonSpawnAckTimeoutError(this.dispatchTimeoutMs);
-      }
-      await this.options.database.attachAgentToExecution(
-        input.executionId,
-        input.daemonId,
-        agent.id,
-      );
-      await this.startAgentExecution(input.executionId);
-      void (async () => {
-        try {
-          await terminal;
-        } catch (error: unknown) {
-          const failure = toDaemonDispatchFailure(error);
-          this.logDispatchFailure(failure, {
-            daemonId: input.daemonId,
-            authoredSlug: input.intent.environment.authoredSlug,
-            machineId: input.machineId,
-            executionId: input.executionId,
-            ...(input.deliveryId === undefined ? {} : { deliveryId: input.deliveryId }),
-          });
-          await this.failAgentExecution(input.executionId, failure.reason);
-        } finally {
-          await cleanup();
-        }
-      })().catch((error: unknown) => {
-        this.report(error, "daemon.dispatch.watch", { executionId: input.executionId });
-      });
-      return agent.id;
-    } catch (error) {
-      await cleanup();
-      throw error;
-    }
+    return agentId;
   }
 
   private async waitForPendingStreamHandlers(executionId: string): Promise<void> {
@@ -1780,8 +1647,8 @@ export class DaemonDispatchLifecycle {
   }
 
   private releaseExecutionResources(executionId: string): void {
-    this.recoveredSubscriptions.get(executionId)?.();
-    this.recoveredSubscriptions.delete(executionId);
+    this.executionSubscriptions.get(executionId)?.();
+    this.executionSubscriptions.delete(executionId);
   }
 
   private async expireExecutionAtCurrentDeadline(
@@ -1810,9 +1677,6 @@ export class DaemonDispatchLifecycle {
       ...(failure.deadlineKind === undefined ? {} : { deadlineKind: failure.deadlineKind }),
     });
     if (failed !== undefined) {
-      this.completionWatchersByExecution.get(executionId)?.(
-        new DaemonDispatchFailure(failure.reason),
-      );
       return true;
     }
 
@@ -2007,8 +1871,8 @@ function deriveHubAction(
   return status === "failed" ? "interrupt" : null;
 }
 
-function isInterruptedAgentState(state: DaemonAgentSnapshot["state"]): boolean {
-  return state?.status === "closed" || state?.status === "error";
+function isInterruptedAgentState(state: { status: AgentStatus }): boolean {
+  return state.status === "closed" || state.status === "error";
 }
 
 function toDaemonDispatchFailure(error: unknown): DaemonDispatchFailure {
@@ -2022,10 +1886,6 @@ function toDaemonDispatchFailure(error: unknown): DaemonDispatchFailure {
     return new DaemonDispatchFailure("daemon_timeout", { cause: error });
   }
 
-  if (error instanceof DaemonCreateRejectedError) {
-    return new DaemonDispatchFailure(daemonCreateFailureReason(error), { cause: error });
-  }
-
   return new DaemonDispatchFailure("internal", { cause: error });
 }
 
@@ -2036,14 +1896,6 @@ function toDispatchPreparationFailure(error: unknown): DaemonDispatchFailure {
       : "internal";
   const code = DISPATCH_PREPARATION_FAILURE_CODES.has(candidate) ? candidate : "internal";
   return new DaemonDispatchFailure(code, { cause: error });
-}
-
-function toDaemonTransportFailure(error: unknown): Error {
-  if (error instanceof DaemonCreateResponseLostError) return error;
-  const classified = toDaemonDispatchFailure(error);
-  return classified.reason === "internal"
-    ? new DaemonDispatchFailure("daemon_unreachable", { cause: error })
-    : classified;
 }
 
 const DISPATCH_PREPARATION_FAILURE_CODES = new Set([
@@ -2072,7 +1924,6 @@ async function buildCreateAgentOptions(
   materializedEnv: Readonly<Record<string, string>>,
 ): Promise<DaemonCreateAgentOptions> {
   return {
-    executionId: hubExecutionEnv.executionId,
     provider: intent.agent.provider,
     ...(intent.agent.mode === undefined ? {} : { mode: intent.agent.mode }),
     ...(intent.agent.model === undefined ? {} : { model: intent.agent.model }),
@@ -2083,7 +1934,6 @@ async function buildCreateAgentOptions(
       ? {}
       : { providerOptions: structuredClone(intent.agent.options) }),
     cwd: intent.environment.cwd,
-    prompt: intent.prompt,
     env: buildAgentEnv(intent, materializedEnv),
     mcpServers: {
       hub: buildExecutionCapabilityMcpServer(hubExecutionEnv),
@@ -2112,26 +1962,6 @@ function buildAgentEnv(
     ...(intent.agent.mode === undefined ? {} : { PASEO_AGENT_MODE: intent.agent.mode }),
     PASEO_HUB_CONFIG_JSON: JSON.stringify(intent.hubConfig),
   };
-}
-
-function daemonCreateFailureReason(error: DaemonCreateRejectedError): string {
-  if (error.code === "provider_options_invalid" && error.issues !== undefined) {
-    const provider = error.provider === undefined ? "provider" : `provider '${error.provider}'`;
-    const issues = error.issues
-      .map((issue) => `${yamlProviderOptionPath(issue.path)}: ${issue.message}`)
-      .join("; ");
-    return `${provider}: ${issues}`;
-  }
-  return error.code === undefined ? error.message : `${error.code}: ${error.message}`;
-}
-
-function yamlProviderOptionPath(path: readonly (string | number)[]): string {
-  return path.reduce<string>((formatted, segment) => {
-    if (typeof segment === "number") return `${formatted}[${segment}]`;
-    return /^[A-Za-z_$][A-Za-z0-9_$]*$/u.test(segment)
-      ? `${formatted}.${segment}`
-      : `${formatted}[${JSON.stringify(segment)}]`;
-  }, "agent.options");
 }
 
 function optionalDeliveryId(triggerContext: unknown): { deliveryId?: string } {
@@ -2215,16 +2045,16 @@ async function withDispatchTimeout<T>(
   }
 }
 
-async function withHubActionTimeout(
-  operation: Promise<void>,
+async function withHubActionTimeout<T>(
+  operation: Promise<T>,
   timeoutMs: number,
   schedule: (callback: () => void, delayMs: number) => () => void,
-): Promise<void> {
+): Promise<T> {
   let clearTimer: (() => void) | undefined;
   try {
-    await Promise.race([
+    return await Promise.race([
       operation,
-      new Promise<void>((_resolve, reject) => {
+      new Promise<never>((_resolve, reject) => {
         clearTimer = schedule(
           () => reject(new Error("timed out waiting for daemon execution control ack")),
           timeoutMs,

--- a/src/daemons/protocol.ts
+++ b/src/daemons/protocol.ts
@@ -3,17 +3,10 @@ import type { JsonValue } from "../config/compiler.js";
 import type {
   HubExecutionAgentSnapshot,
   HubExecutionAgentStreamEvent,
-  HubExecutionControlAction,
   HubProviderSnapshot,
 } from "../hub/protocol.js";
 
-export interface DaemonAgentSnapshot {
-  id: string;
-  state?: HubExecutionAgentSnapshot;
-}
-
 export interface DaemonCreateAgentOptions {
-  executionId: string;
   provider: string;
   mode?: string;
   model?: string;
@@ -21,7 +14,6 @@ export interface DaemonCreateAgentOptions {
   providerOptions?: Readonly<Record<string, JsonValue>>;
   toolPolicy: ToolPolicy;
   cwd: string;
-  prompt: string;
   env: Record<string, string>;
   mcpServers?: Record<string, McpHttpServerConfig>;
   worktree?: WorktreeTarget;
@@ -41,11 +33,6 @@ export interface McpHttpServerConfig {
   type: "http";
   url: string;
   headers?: Record<string, string>;
-}
-
-export interface DaemonExecutionControlOptions {
-  executionId: string;
-  action: HubExecutionControlAction;
 }
 
 export type DaemonTimelineItem = Extract<
@@ -73,36 +60,16 @@ export interface DaemonAgentUpdateEvent {
 
 export type DaemonEvent = DaemonAgentStreamDaemonEvent | DaemonAgentUpdateEvent;
 
-export type DaemonEventHandler = (event: DaemonEvent) => void | Promise<void>;
-
 export interface DaemonConnection {
   agents: import("./agents/index.js").AgentConnection;
-  createAgent(options: DaemonCreateAgentOptions): Promise<DaemonAgentSnapshot>;
-  controlExecution(options: DaemonExecutionControlOptions): Promise<void>;
   getProviderSnapshot(options: { cwd?: string }): Promise<HubProviderSnapshot>;
   refreshProviderSnapshot(options: { cwd?: string; providers?: string[] }): Promise<void>;
-  on(handler: DaemonEventHandler): () => void;
 }
 
-/** The daemon may have durably created the agent before its acknowledgement was lost. */
-export class DaemonCreateResponseLostError extends Error {
+/** A durable daemon request may have succeeded before its acknowledgement was lost. */
+export class DaemonResponseLostError extends Error {
   constructor() {
-    super("daemon create response was lost");
-    this.name = "DaemonCreateResponseLostError";
-  }
-}
-
-export class DaemonCreateRejectedError extends Error {
-  constructor(
-    message: string,
-    readonly code?: string,
-    readonly provider?: string,
-    readonly issues?: readonly {
-      path: readonly (string | number)[];
-      message: string;
-    }[],
-  ) {
-    super(message);
-    this.name = "DaemonCreateRejectedError";
+    super("daemon response was lost");
+    this.name = "DaemonResponseLostError";
   }
 }

--- a/src/daemons/provider-catalog.test.ts
+++ b/src/daemons/provider-catalog.test.ts
@@ -27,11 +27,6 @@ describe("daemon provider catalog", () => {
       agents: new DaemonAgents(() => {
         throw new Error("Native agents are not used by this fixture");
       }),
-      createAgent: async () => {
-        throw new Error("not used");
-      },
-      controlExecution: async () => undefined,
-      on: () => () => undefined,
       refreshProviderSnapshot: async ({ cwd }) => {
         calls.push(`refresh:${cwd}`);
       },

--- a/src/daemons/registry.test.ts
+++ b/src/daemons/registry.test.ts
@@ -1,13 +1,14 @@
+import { z } from "zod";
 import assert from "node:assert/strict";
 import { createHash, randomUUID } from "node:crypto";
 import { createServer } from "node:http";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import { WebSocket, type RawData } from "ws";
 import type { DaemonRecord } from "../db/types.js";
 import { HubDaemonHelloSchema } from "../hub/protocol.js";
 import { createLogger } from "../logger.js";
 import { assertOneFailure, FailureLogStream } from "../test-utils/failure-logs.js";
-import { DaemonCreateRejectedError, DaemonCreateResponseLostError } from "./protocol.js";
+import { DaemonResponseLostError } from "./protocol.js";
 import { ActiveDaemonRegistry, createDaemonUpgradeHandler } from "./registry.js";
 import { DaemonRegistryHarness } from "./test-utils/daemon-registry-harness.js";
 
@@ -147,23 +148,31 @@ describe("daemon socket generations", () => {
 
     assert.equal(replacement.supersededClosed, false);
     await assert.rejects(oldCreate.promise, {
-      name: DaemonCreateResponseLostError.name,
-      message: "daemon create response was lost",
+      name: DaemonResponseLostError.name,
+      message: "daemon response was lost",
     });
     assert.deepEqual(await daemon.completeCreate("new-create", "agent-new"), {
       id: "agent-new",
+      workspaceId: "workspace-agent-new",
+      status: "idle",
     });
   });
 
   it("forwards only structured MCP grants with opaque provider options", async () => {
     const pending = await daemon.pendingCreate("contract-create");
 
-    assert.deepEqual(pending.request["providerOptions"], {
-      permission: { edit: "ask", bash: "deny" },
-    });
-    assert.deepEqual(pending.request["toolPolicy"], {
-      preapproved: [{ kind: "mcp", server: "hub", tool: "finish_execution" }],
-    });
+    assert.deepEqual(
+      z.record(z.string(), z.unknown()).parse(pending.request["config"])["providerOptions"],
+      {
+        permission: { edit: "ask", bash: "deny" },
+      },
+    );
+    assert.deepEqual(
+      z.record(z.string(), z.unknown()).parse(pending.request["config"])["toolPolicy"],
+      {
+        preapproved: [{ kind: "mcp", server: "hub", tool: "finish_execution" }],
+      },
+    );
   });
 
   it("delegates provider, model, mode, and structured option validation to the daemon", async () => {
@@ -228,22 +237,6 @@ describe("daemon socket generations", () => {
     await daemon.shutdownCompletes();
   });
 
-  it("fails closed when a daemon does not acknowledge the Hub execution contract", async () => {
-    await assert.rejects(daemon.completeCreateWithoutContract("legacy-create"), {
-      name: DaemonCreateRejectedError.name,
-      message:
-        "The connected Paseo daemon did not confirm Hub MCP preapproval; update Paseo before running this workflow",
-    });
-  });
-
-  it("forwards agent status updates to the execution subscriber", async () => {
-    const event = await daemon.reportAgentStatus("execution-1", "idle");
-
-    assert.equal(event.type, "agent_update");
-    assert.equal(event.executionId, "execution-1");
-    if (event.type === "agent_update") assert.equal(event.agent.status, "idle");
-  });
-
   it("logs an offline-presence storage rejection exactly once", async () => {
     const canary = "offline-presence-secret-7e12";
     daemon.failOfflinePresence(new Error(canary));
@@ -291,30 +284,10 @@ describe("daemon socket generations", () => {
     });
   });
 
-  it("logs a rejecting subscriber exactly once and still calls its peers", async () => {
-    const canary = "subscriber-secret-b21c";
-    let peerCalls = 0;
-    daemon.subscribe(() => Promise.reject(new Error(canary)));
-    daemon.subscribe(() => {
-      peerCalls += 1;
-    });
-    await daemon.reportAgentStatus("execution-subscriber", "idle");
-    await new Promise((resolve) => setImmediate(resolve));
-
-    expect(peerCalls).toBe(1);
-    assertOneFailure(stream, {
-      operation: "daemon.event.subscriber",
-      component: "daemons",
-      canary,
-    });
-  });
-
-  it("pairs execution-control acknowledgements by request, execution, and action", async () => {
+  it("pairs ordinary control acknowledgements by request", async () => {
     const pending = await daemon.pendingControl("execution-1", "archive");
 
-    daemon.respondControl(pending, { executionId: "execution-stale" });
-    assert.equal(await daemon.requestSettled(pending.promise), false);
-    daemon.respondControl(pending, { action: "interrupt" });
+    daemon.respondControl(pending, { requestId: "request-stale" });
     assert.equal(await daemon.requestSettled(pending.promise), false);
     daemon.respondControl(pending);
 
@@ -326,7 +299,7 @@ describe("daemon socket generations", () => {
 
     await daemon.replaceConnection();
 
-    await assert.rejects(pending.promise, /daemon disconnected/u);
+    await assert.rejects(pending.promise, DaemonResponseLostError);
   });
 
   it("survives an invalid WebSocket close code instead of crashing the process", async () => {

--- a/src/daemons/registry.ts
+++ b/src/daemons/registry.ts
@@ -9,14 +9,8 @@ import type { Database, DaemonRecord } from "../db/types.js";
 import { reportFailure, type FailureKind } from "../failures/index.js";
 import { logger as defaultLogger } from "../logger.js";
 import {
-  HubExecutionAgentCreateRequestSchema,
-  HubExecutionAgentCreateResponseSchema,
   HubExecutionAgentValidateRequestSchema,
   HubExecutionAgentValidateResponseSchema,
-  HubExecutionAgentStreamSchema,
-  HubExecutionAgentUpdateSchema,
-  HubExecutionControlRequestSchema,
-  HubExecutionControlResponseSchema,
   GetProvidersSnapshotRequestSchema,
   GetProvidersSnapshotResponseSchema,
   RefreshProvidersSnapshotRequestSchema,
@@ -25,32 +19,9 @@ import {
   HubDaemonHelloSchema,
   HubDaemonServerInfoEnvelopeSchema,
 } from "../hub/protocol.js";
-import {
-  DaemonCreateResponseLostError,
-  DaemonCreateRejectedError,
-  type DaemonConnection,
-  type DaemonAgentSnapshot,
-  type DaemonCreateAgentOptions,
-  type DaemonExecutionControlOptions,
-  type DaemonEventHandler,
-} from "./protocol.js";
+import { type DaemonConnection } from "./protocol.js";
 import type { HubProviderSnapshot } from "../hub/protocol.js";
 
-interface PendingCreateRequest {
-  kind: "create";
-  generation: number;
-  executionId: string;
-  resolve(value: DaemonAgentSnapshot): void;
-  reject(error: Error): void;
-}
-interface PendingControlRequest {
-  kind: "control";
-  generation: number;
-  executionId: string;
-  action: DaemonExecutionControlOptions["action"];
-  resolve(): void;
-  reject(error: Error): void;
-}
 interface PendingAgentValidationRequest {
   kind: "agent-validation";
   generation: number;
@@ -74,8 +45,6 @@ interface AgentValidationIssue {
   message: string;
 }
 type PendingRequest =
-  | PendingCreateRequest
-  | PendingControlRequest
   | PendingAgentValidationRequest
   | PendingProviderSnapshotRequest
   | PendingProviderRefreshRequest;
@@ -100,7 +69,6 @@ type DaemonRevokedHandler = (daemon: DaemonRecord) => void | Promise<void>;
 export class ActiveDaemonRegistry {
   private readonly active = new Map<string, ActiveSocket>();
   private readonly pendingByDaemon = new Map<string, Map<string, PendingRequest>>();
-  private readonly subscribersByDaemon = new Map<string, Set<DaemonEventHandler>>();
   private readonly connectedHandlers = new Set<DaemonConnectedHandler>();
   private readonly revokedHandlers = new Set<DaemonRevokedHandler>();
   private readonly presenceWrites = new Set<Promise<void>>();
@@ -120,7 +88,10 @@ export class ActiveDaemonRegistry {
     const previous = this.active.get(daemon.id);
     if (previous) this.rejectGeneration(daemon.id, previous.generation);
     const active: ActiveSocket = {
-      agents: new DaemonAgents((frame) => socket.send(frame)),
+      agents: new DaemonAgents(
+        (frame) => socket.send(frame),
+        () => this.clock.nowDate(),
+      ),
       generation: ++this.generation,
       socket,
       daemon,
@@ -190,15 +161,8 @@ export class ActiveDaemonRegistry {
     if (!active?.ready || !active.daemon.permissions.includes("hub.execute")) return undefined;
     return {
       agents: this.active.get(daemonId)!.agents,
-      createAgent: (options) => this.createAgent(daemonId, options),
-      controlExecution: (options) => this.controlExecution(daemonId, options),
       getProviderSnapshot: (options) => this.getProviderSnapshot(daemonId, options),
       refreshProviderSnapshot: (options) => this.refreshProviderSnapshot(daemonId, options),
-      on: (handler) => {
-        const subscribers = this.subscribersFor(daemonId);
-        subscribers.add(handler);
-        return () => subscribers.delete(handler);
-      },
     };
   }
 
@@ -258,77 +222,9 @@ export class ActiveDaemonRegistry {
     await Promise.all(sockets);
     await Promise.all(this.presenceWrites);
     for (const [daemonId, pending] of this.pendingByDaemon) {
-      for (const request of pending.values()) request.reject(disconnectError(request));
+      for (const request of pending.values()) request.reject(new Error("daemon disconnected"));
       this.pendingByDaemon.delete(daemonId);
     }
-  }
-
-  private createAgent(
-    daemonId: string,
-    options: DaemonCreateAgentOptions,
-  ): Promise<{ id: string }> {
-    const active = this.active.get(daemonId);
-    if (!active?.ready) return Promise.reject(new Error("daemon_not_connected"));
-    const requestId = randomUUID();
-    const executionId = options.executionId;
-    const request = HubExecutionAgentCreateRequestSchema.parse({
-      type: "hub.execution.agent.create.request",
-      requestId,
-      executionId,
-      provider: options.provider,
-      cwd: options.cwd,
-      prompt: options.prompt,
-      model: options.model,
-      modeId: options.mode,
-      thinkingOptionId: options.thinkingOptionId,
-      providerOptions: options.providerOptions,
-      toolPolicy: options.toolPolicy,
-      env: options.env,
-      mcpServers: options.mcpServers,
-      worktree: options.worktree,
-    });
-    return new Promise((resolve, reject) => {
-      this.pendingFor(daemonId).set(requestId, {
-        kind: "create",
-        generation: active.generation,
-        executionId,
-        resolve: (value) => {
-          if (value === undefined) {
-            reject(new Error("daemon create returned no agent"));
-            return;
-          }
-          resolve(value);
-        },
-        reject,
-      });
-      active.socket.send(JSON.stringify({ type: "session", message: request }));
-    });
-  }
-
-  private controlExecution(
-    daemonId: string,
-    options: DaemonExecutionControlOptions,
-  ): Promise<void> {
-    const active = this.active.get(daemonId);
-    if (!active?.ready) return Promise.reject(new Error("daemon_not_connected"));
-    const requestId = randomUUID();
-    const request = HubExecutionControlRequestSchema.parse({
-      type: "hub.execution.control.request",
-      requestId,
-      executionId: options.executionId,
-      action: options.action,
-    });
-    return new Promise((resolve, reject) => {
-      this.pendingFor(daemonId).set(requestId, {
-        kind: "control",
-        generation: active.generation,
-        executionId: options.executionId,
-        action: options.action,
-        resolve,
-        reject,
-      });
-      active.socket.send(JSON.stringify({ type: "session", message: request }));
-    });
   }
 
   private getProviderSnapshot(
@@ -385,7 +281,6 @@ export class ActiveDaemonRegistry {
 
   private receive(active: ActiveSocket, raw: string): void {
     if (this.active.get(active.daemon.id)?.generation !== active.generation) return;
-    const receivedAt = this.clock.nowDate().toISOString();
     let value: unknown;
     try {
       value = JSON.parse(raw);
@@ -408,10 +303,6 @@ export class ActiveDaemonRegistry {
     if (!envelope.success) return;
     const message = envelope.data.message;
     if (message.type === "rpc_error") return this.receiveRpcError(active, message.payload);
-    const created = HubExecutionAgentCreateResponseSchema.safeParse(message);
-    if (created.success) return this.receiveCreate(active, created.data);
-    const controlled = HubExecutionControlResponseSchema.safeParse(message);
-    if (controlled.success) return this.receiveControl(active, controlled.data);
     const validated = HubExecutionAgentValidateResponseSchema.safeParse(message);
     if (validated.success) return this.receiveAgentValidation(active, validated.data);
     const providerSnapshot = GetProvidersSnapshotResponseSchema.safeParse(message);
@@ -419,28 +310,6 @@ export class ActiveDaemonRegistry {
       return this.receiveProviderSnapshot(active, providerSnapshot.data);
     const providerRefresh = RefreshProvidersSnapshotResponseSchema.safeParse(message);
     if (providerRefresh.success) return this.receiveProviderRefresh(active, providerRefresh.data);
-    const update = HubExecutionAgentUpdateSchema.safeParse(message);
-    if (update.success) {
-      const event = {
-        type: "agent_update",
-        executionId: update.data.payload.executionId,
-        agentId: update.data.payload.agentId,
-        agent: update.data.payload.agent,
-        timestamp: receivedAt,
-      } as const;
-      this.notifySubscribers(active.daemon.id, event);
-      return;
-    }
-    const stream = HubExecutionAgentStreamSchema.safeParse(message);
-    if (!stream.success) return;
-    const event = {
-      type: "agent_stream",
-      executionId: stream.data.payload.executionId,
-      agentId: stream.data.payload.agentId,
-      event: stream.data.payload.event,
-      timestamp: receivedAt,
-    } as const;
-    this.notifySubscribers(active.daemon.id, event);
   }
 
   private acceptServerInfo(
@@ -479,18 +348,6 @@ export class ActiveDaemonRegistry {
       }
       return undefined;
     });
-  }
-
-  private notifySubscribers(daemonId: string, event: Parameters<DaemonEventHandler>[0]): void {
-    for (const subscriber of this.subscribersFor(daemonId)) {
-      this.observeHandler(
-        () => subscriber(event),
-        "daemon.event.subscriber",
-        daemonId,
-        undefined,
-        event.executionId,
-      );
-    }
   }
 
   private observeHandler(
@@ -585,75 +442,6 @@ export class ActiveDaemonRegistry {
     pending.resolve();
   }
 
-  private receiveControl(
-    active: ActiveSocket,
-    response: z.infer<typeof HubExecutionControlResponseSchema>,
-  ): void {
-    const requests = this.pendingFor(active.daemon.id);
-    const pending = requests.get(response.payload.requestId);
-    if (
-      !pending ||
-      pending.kind !== "control" ||
-      pending.generation !== active.generation ||
-      pending.executionId !== response.payload.executionId ||
-      pending.action !== response.payload.action
-    ) {
-      return;
-    }
-    requests.delete(response.payload.requestId);
-    if (!response.payload.success) {
-      pending.reject(new Error(response.payload.error ?? "daemon execution control failed"));
-      return;
-    }
-    pending.resolve();
-  }
-
-  private receiveCreate(
-    active: ActiveSocket,
-    response: z.infer<typeof HubExecutionAgentCreateResponseSchema>,
-  ): void {
-    const requests = this.pendingFor(active.daemon.id);
-    const pending = requests.get(response.payload.requestId);
-    if (!pending || pending.kind !== "create" || pending.generation !== active.generation) return;
-    const related = relatedCreateRequests(requests, active.generation, pending.executionId);
-    for (const [requestId] of related) requests.delete(requestId);
-    if (response.payload.success && response.payload.toolPolicyApplied !== true) {
-      for (const [, request] of related) {
-        request.reject(
-          new DaemonCreateRejectedError(
-            "The connected Paseo daemon did not confirm Hub MCP preapproval; update Paseo before running this workflow",
-            "tool_policy_not_confirmed",
-          ),
-        );
-      }
-      return;
-    }
-    if (!response.payload.success || !response.payload.agentId) {
-      const error = response.payload.error;
-      for (const [, request] of related) {
-        request.reject(
-          typeof error === "object" && error !== null
-            ? new DaemonCreateRejectedError(
-                error.message,
-                error.code,
-                "provider" in error ? error.provider : undefined,
-                "issues" in error ? error.issues : undefined,
-              )
-            : new DaemonCreateRejectedError(
-                "The connected Paseo daemon returned the legacy Hub create error contract; update Paseo before running this workflow",
-                "tool_policy_not_confirmed",
-              ),
-        );
-      }
-      return;
-    }
-    const snapshot = {
-      id: response.payload.agentId,
-      ...(response.payload.agent === null ? {} : { state: response.payload.agent }),
-    };
-    for (const [, request] of related) request.resolve(snapshot);
-  }
-
   private receiveRpcError(
     active: ActiveSocket,
     payload: { requestId: string; error: string },
@@ -678,35 +466,9 @@ export class ActiveDaemonRegistry {
     for (const [requestId, request] of pending) {
       if (request.generation !== generation) continue;
       pending.delete(requestId);
-      request.reject(disconnectError(request));
+      request.reject(new Error("daemon disconnected"));
     }
   }
-
-  private subscribersFor(daemonId: string): Set<DaemonEventHandler> {
-    const existing = this.subscribersByDaemon.get(daemonId);
-    if (existing) return existing;
-    const subscribers = new Set<DaemonEventHandler>();
-    this.subscribersByDaemon.set(daemonId, subscribers);
-    return subscribers;
-  }
-}
-
-function relatedCreateRequests(
-  requests: ReadonlyMap<string, PendingRequest>,
-  generation: number,
-  executionId: string,
-): Array<[string, PendingCreateRequest]> {
-  const related: Array<[string, PendingCreateRequest]> = [];
-  for (const [requestId, request] of requests) {
-    if (
-      request.kind === "create" &&
-      request.generation === generation &&
-      request.executionId === executionId
-    ) {
-      related.push([requestId, request]);
-    }
-  }
-  return related;
 }
 
 function samePermissions(actual: readonly string[], expected: readonly string[]): boolean {
@@ -775,12 +537,6 @@ function readText(data: RawData): string {
   if (Array.isArray(data)) return Buffer.concat(data).toString();
   if (data instanceof ArrayBuffer) return Buffer.from(data).toString();
   return data.toString();
-}
-
-function disconnectError(request: PendingRequest): Error {
-  return request.kind === "create"
-    ? new DaemonCreateResponseLostError()
-    : new Error("daemon disconnected");
 }
 
 export interface DaemonClock {

--- a/src/daemons/test-utils/daemon-registry-harness.ts
+++ b/src/daemons/test-utils/daemon-registry-harness.ts
@@ -1,15 +1,10 @@
 import { randomUUID } from "node:crypto";
 import { WebSocket, WebSocketServer, type RawData } from "ws";
 import { z } from "zod";
+import type { AgentSnapshot } from "../agents/index.js";
 import type { Logger } from "pino";
 import type { DaemonRecord } from "../../db/types.js";
-import type { HubExecutionAgentSnapshot } from "../../hub/protocol.js";
-import type {
-  DaemonAgentSnapshot,
-  DaemonConnection,
-  DaemonEvent,
-  DaemonEventHandler,
-} from "../protocol.js";
+import type { DaemonConnection } from "../protocol.js";
 import { ActiveDaemonRegistry } from "../registry.js";
 
 const SessionRequestSchema = z.object({
@@ -56,14 +51,12 @@ export class DaemonRegistryHarness {
     return harness;
   }
 
-  async pendingCreate(executionId: string): Promise<PendingRequest<DaemonAgentSnapshot>> {
+  async pendingCreate(executionId: string): Promise<PendingRequest<AgentSnapshot>> {
     const connection = this.connection();
-    const promise = connection.createAgent({
-      executionId,
+    const promise = connection.agents.create(executionId, {
       provider: "opencode",
       mode: "full-access",
       cwd: "/workspace",
-      prompt: "Do the work",
       env: {},
       providerOptions: { permission: { edit: "ask", bash: "deny" } },
       toolPolicy: {
@@ -73,7 +66,7 @@ export class DaemonRegistryHarness {
     void promise.catch(() => undefined);
     return {
       promise,
-      request: await this.currentSocket().next("hub.execution.agent.create.request"),
+      request: await this.currentSocket().next("create_agent_request"),
     };
   }
 
@@ -81,11 +74,17 @@ export class DaemonRegistryHarness {
     executionId: string,
     action: "interrupt" | "archive",
   ): Promise<PendingRequest<void>> {
-    const promise = this.connection().controlExecution({ executionId, action });
+    const promise = this.connection().agents.control(
+      `agent-${executionId}`,
+      `workspace-${executionId}`,
+      action,
+    );
     void promise.catch(() => undefined);
     return {
       promise,
-      request: await this.currentSocket().next("hub.execution.control.request"),
+      request: await this.currentSocket().next(
+        action === "archive" ? "archive_workspace_request" : "cancel_agent_request",
+      ),
     };
   }
 
@@ -176,16 +175,14 @@ export class DaemonRegistryHarness {
     });
   }
 
-  respondControl(
-    pending: PendingRequest<void>,
-    overrides: { executionId?: string; action?: "interrupt" | "archive" } = {},
-  ): void {
+  respondControl(pending: PendingRequest<void>, overrides: { requestId?: string } = {}): void {
     this.currentSocket().send({
-      type: "hub.execution.control.response",
+      type:
+        pending.request.type === "archive_workspace_request"
+          ? "archive_workspace_response"
+          : "cancel_agent_response",
       payload: {
-        requestId: pending.request.requestId,
-        executionId: overrides.executionId ?? pending.request.executionId,
-        action: overrides.action ?? pending.request.action,
+        requestId: overrides.requestId ?? pending.request.requestId,
         success: true,
         error: null,
       },
@@ -257,10 +254,6 @@ export class DaemonRegistryHarness {
     return this.registry.onConnected(handler);
   }
 
-  subscribe(handler: DaemonEventHandler): () => void {
-    return this.connection().on(handler);
-  }
-
   failOfflinePresence(error: Error): void {
     this.presence.failNext(error);
   }
@@ -284,55 +277,17 @@ export class DaemonRegistryHarness {
     return this.currentSocket().waitUntilClosed();
   }
 
-  async completeCreate(executionId: string, agentId: string): Promise<DaemonAgentSnapshot> {
+  async completeCreate(executionId: string, agentId: string): Promise<AgentSnapshot> {
     const pending = await this.pendingCreate(executionId);
     this.currentSocket().send({
-      type: "hub.execution.agent.create.response",
+      type: "status",
       payload: {
+        status: "agent_created",
         requestId: pending.request.requestId,
-        executionId,
-        agentId,
-        agent: null,
-        success: true,
-        toolPolicyApplied: true,
-        error: null,
+        agent: { id: agentId, workspaceId: `workspace-${agentId}`, status: "idle" },
       },
     });
     return pending.promise;
-  }
-
-  async completeCreateWithoutContract(executionId: string): Promise<DaemonAgentSnapshot> {
-    const pending = await this.pendingCreate(executionId);
-    this.currentSocket().send({
-      type: "hub.execution.agent.create.response",
-      payload: {
-        requestId: pending.request.requestId,
-        executionId,
-        agentId: `agent-${executionId}`,
-        agent: null,
-        success: true,
-        error: null,
-      },
-    });
-    return pending.promise;
-  }
-
-  async reportAgentStatus(
-    executionId: string,
-    status: HubExecutionAgentSnapshot["status"],
-  ): Promise<DaemonEvent> {
-    const event = new Promise<DaemonEvent>((resolve) => {
-      const unsubscribe = this.connection().on((value) => {
-        unsubscribe();
-        resolve(value);
-      });
-    });
-    const agentId = `agent-${executionId}`;
-    this.currentSocket().send({
-      type: "hub.execution.agent.update",
-      payload: { executionId, agentId, agent: agentSnapshot(agentId, status) },
-    });
-    return event;
   }
 
   async stop(): Promise<void> {
@@ -487,7 +442,7 @@ class RegistrySocket {
         status: "server_info",
         serverId: "test-daemon",
         permissions,
-        features: { providersSnapshot: true },
+        features: { providersSnapshot: true, hubAgentRpc: true, agentRequestReceipts: true },
       },
     });
   }
@@ -553,37 +508,6 @@ function daemonRecord(): DaemonRecord {
     disconnectedAt: null,
     lastSeenAt: now,
     createdAt: now,
-  };
-}
-
-function agentSnapshot(
-  id: string,
-  status: HubExecutionAgentSnapshot["status"],
-): HubExecutionAgentSnapshot {
-  const timestamp = "2026-01-01T00:00:00.000Z";
-  return {
-    id,
-    provider: "opencode",
-    cwd: "/workspace",
-    model: null,
-    createdAt: timestamp,
-    updatedAt: timestamp,
-    lastUserMessageAt: null,
-    status,
-    capabilities: {
-      supportsStreaming: true,
-      supportsSessionPersistence: true,
-      supportsDynamicModes: true,
-      supportsMcpServers: true,
-      supportsReasoningStream: true,
-      supportsToolInvocations: true,
-    },
-    currentModeId: null,
-    availableModes: [],
-    pendingPermissions: [],
-    persistence: null,
-    title: null,
-    labels: {},
   };
 }
 

--- a/src/daemons/test-utils/hub-harness.ts
+++ b/src/daemons/test-utils/hub-harness.ts
@@ -14,9 +14,7 @@ import { createHubApplication, type HubRuntime } from "../../app.js";
 import { createFetchServer } from "../../http/node-server.js";
 import { startApplication, stopApplication } from "../../server/runtime.js";
 import {
-  HubExecutionAgentCreateRequestSchema,
   HubExecutionAgentValidateRequestSchema,
-  HubExecutionControlRequestSchema,
   type HubExecutionControlAction,
   type HubExecutionAgentSnapshot,
 } from "../../hub/protocol.js";
@@ -109,9 +107,45 @@ const LegacyEnrollmentSchema = z.object({
 const ExecutionSessionRequestSchema = z.object({
   type: z.literal("session"),
   message: z.discriminatedUnion("type", [
-    HubExecutionAgentCreateRequestSchema,
     HubExecutionAgentValidateRequestSchema,
-    HubExecutionControlRequestSchema,
+    z.object({
+      type: z.literal("create_agent_request"),
+      requestId: z.string(),
+      idempotencyKey: z.string(),
+      config: z
+        .object({
+          provider: z.string(),
+          cwd: z.string(),
+          mcpServers: z.record(z.string(), z.object({ url: z.string() }).passthrough()),
+        })
+        .passthrough(),
+      env: z.record(z.string(), z.string()).optional(),
+      worktree: z.unknown().optional(),
+    }),
+    z.object({
+      type: z.literal("fetch_agent_request"),
+      requestId: z.string(),
+      agentId: z.string(),
+    }),
+    z.object({ type: z.literal("fetch_agents_request"), requestId: z.string() }),
+    z.object({ type: z.literal("agent.timeline.set_subscription.request"), requestId: z.string() }),
+    z.object({
+      type: z.literal("send_agent_message_request"),
+      requestId: z.string(),
+      agentId: z.string(),
+      messageId: z.string(),
+      text: z.string(),
+    }),
+    z.object({
+      type: z.literal("cancel_agent_request"),
+      requestId: z.string(),
+      agentId: z.string(),
+    }),
+    z.object({
+      type: z.literal("archive_workspace_request"),
+      requestId: z.string(),
+      workspaceId: z.string(),
+    }),
   ]),
 });
 
@@ -754,7 +788,7 @@ export class HubHarness {
     await waitFor(async () => (await this.execution(id)).status === status);
     return this.execution(id);
   }
-  rejectNextCreate(error: HubCreateError): void {
+  rejectNextCreate(error: string): void {
     this.requireDaemon().rejectNextCreate(error);
   }
   advanceDispatchTime(ms: number): Promise<void> {
@@ -787,8 +821,11 @@ export class HubHarness {
     };
   }
   async waitForCreatedAgentLaunch() {
-    await waitFor(async () => this.requireDaemon().createdAgentCount() > 0);
+    await waitFor(async () => this.requireDaemon().deliveredPromptCount() > 0);
     return this.createdAgentLaunch();
+  }
+  async waitForDeliveredPrompts(count: number): Promise<void> {
+    await waitFor(async () => this.requireDaemon().deliveredPromptCount() >= count);
   }
   async waitForCreatedAgentRequests(count: number): Promise<void> {
     await waitFor(async () => this.requireDaemon().createdAgentRequestCount() >= count);
@@ -979,7 +1016,7 @@ export class HubHarness {
   createdAgentRequestCount(): number {
     return this.requireDaemon().createdAgentRequestCount();
   }
-  async runtimeResources(expected?: { recoveredExecutionSubscriptions: number }) {
+  async runtimeResources(expected?: { executionSubscriptions: number }) {
     if (expected !== undefined) {
       try {
         await waitFor(async () => deepEqual(this.requireHub().resourceCounts(), expected));
@@ -2090,7 +2127,7 @@ class TestDaemon {
   private holdControlAck = false;
   private materializeSpawn = true;
   private omitSnapshotOnReconnect = false;
-  private nextCreateError: HubCreateError | undefined;
+  private nextCreateError: string | undefined;
   private resolveSpawn!: () => void;
   private readonly spawnObserved = new Promise<void>((resolve) => {
     this.resolveSpawn = resolve;
@@ -2196,6 +2233,7 @@ class TestDaemon {
       headers: {
         authorization: `Bearer ${this.credential}`,
         "x-paseo-daemon-id": this.daemonId,
+        "x-paseo-session-protocol": "1",
       },
     });
     socket.on("message", (data) => this.receive(data));
@@ -2247,7 +2285,7 @@ class TestDaemon {
   omitAgentSnapshotOnReconnect(): void {
     this.omitSnapshotOnReconnect = true;
   }
-  rejectNextCreate(error: HubCreateError): void {
+  rejectNextCreate(error: string): void {
     this.nextCreateError = error;
   }
   holdSpawnAcknowledgement(): void {
@@ -2299,8 +2337,9 @@ class TestDaemon {
   async emitEarlyActivity(): Promise<void> {
     if (!this.pendingCreate) throw new Error("No pending create request");
     this.send({
-      type: "hub.execution.agent.stream",
+      type: "agent_stream",
       payload: {
+        timestamp: new Date().toISOString(),
         executionId: this.pendingCreate.executionId,
         agentId: `agent-${this.pendingCreate.executionId}`,
         event: {
@@ -2322,6 +2361,9 @@ class TestDaemon {
   }
   createdAgentCount(): number {
     return this.agents.size;
+  }
+  deliveredPromptCount(): number {
+    return [...this.agents.values()].filter((agent) => typeof agent["prompt"] === "string").length;
   }
   createdAgentRequestCount(): number {
     return this.createRequests;
@@ -2347,11 +2389,12 @@ class TestDaemon {
     if (!agent) throw new Error("Unknown agent");
     agent["status"] = status;
     this.send({
-      type: "hub.execution.agent.update",
+      type: "agent_update",
       payload: {
         executionId: this.executionId(agentId),
         agentId,
-        agent: agentSnapshot(agentId, status),
+        kind: "upsert",
+        agent: { ...agentSnapshot(agentId, status), workspaceId: `workspace-${agentId}` },
       },
     });
   }
@@ -2366,8 +2409,9 @@ class TestDaemon {
   }
   async starts(agentId: string): Promise<void> {
     this.send({
-      type: "hub.execution.agent.stream",
+      type: "agent_stream",
       payload: {
+        timestamp: new Date().toISOString(),
         executionId: this.executionId(agentId),
         agentId,
         event: {
@@ -2380,8 +2424,9 @@ class TestDaemon {
   }
   async outputs(agentId: string, content: string): Promise<void> {
     this.send({
-      type: "hub.execution.agent.stream",
+      type: "agent_stream",
       payload: {
+        timestamp: new Date().toISOString(),
         executionId: this.executionId(agentId),
         agentId,
         event: {
@@ -2400,8 +2445,9 @@ class TestDaemon {
   }
   async startsTurn(agentId: string): Promise<void> {
     this.send({
-      type: "hub.execution.agent.stream",
+      type: "agent_stream",
       payload: {
+        timestamp: new Date().toISOString(),
         executionId: this.executionId(agentId),
         agentId,
         event: { type: "turn_started", provider: "opencode" },
@@ -2411,8 +2457,9 @@ class TestDaemon {
   }
   async failsTurn(agentId: string): Promise<void> {
     this.send({
-      type: "hub.execution.agent.stream",
+      type: "agent_stream",
       payload: {
+        timestamp: new Date().toISOString(),
         executionId: this.executionId(agentId),
         agentId,
         event: {
@@ -2425,8 +2472,9 @@ class TestDaemon {
   }
   async completesTurn(agentId: string): Promise<void> {
     this.send({
-      type: "hub.execution.agent.stream",
+      type: "agent_stream",
       payload: {
+        timestamp: new Date().toISOString(),
         executionId: this.executionId(agentId),
         agentId,
         event: {
@@ -2442,8 +2490,9 @@ class TestDaemon {
       },
     });
     this.send({
-      type: "hub.execution.agent.stream",
+      type: "agent_stream",
       payload: {
+        timestamp: new Date().toISOString(),
         executionId: this.executionId(agentId),
         agentId,
         event: { type: "turn_completed", provider: "opencode" },
@@ -2453,8 +2502,9 @@ class TestDaemon {
   }
   async completesTurnWithoutFinishTimeline(agentId: string): Promise<void> {
     this.send({
-      type: "hub.execution.agent.stream",
+      type: "agent_stream",
       payload: {
+        timestamp: new Date().toISOString(),
         executionId: this.executionId(agentId),
         agentId,
         event: { type: "turn_completed", provider: "opencode" },
@@ -2496,7 +2546,7 @@ class TestDaemon {
           status: "server_info",
           serverId: this.daemonId,
           permissions: this.permissions,
-          features: {},
+          features: { hubAgentRpc: true, agentRequestReceipts: true },
         },
       });
       return;
@@ -2511,30 +2561,73 @@ class TestDaemon {
       });
       return;
     }
-    if (request.type === "hub.execution.control.request") {
-      this.controls.push(request.action);
-      this.controlActionsByExecution.set(request.executionId, request.action);
-      const pending = this.pendingControlActions.get(request.executionId);
-      this.pendingControlActions.delete(request.executionId);
-      pending?.(request.action);
-      if (this.holdControlAck) {
-        this.heldControls.set(request.executionId, request);
-      } else {
-        this.acknowledgeControl(request);
-      }
+    if (request.type === "fetch_agent_request") {
+      const agent = this.agents.get(request.agentId);
+      this.send({
+        type: "fetch_agent_response",
+        payload: {
+          requestId: request.requestId,
+          agent: agent
+            ? {
+                ...agentSnapshot(request.agentId, readAgentStatus(agent["status"])),
+                workspaceId: `workspace-${request.agentId}`,
+              }
+            : null,
+        },
+      });
+      return;
+    }
+    if (
+      request.type === "fetch_agents_request" ||
+      request.type === "agent.timeline.set_subscription.request"
+    ) {
+      this.send({
+        type:
+          request.type === "fetch_agents_request"
+            ? "fetch_agents_response"
+            : "agent.timeline.set_subscription.response",
+        payload: { requestId: request.requestId },
+      });
+      return;
+    }
+    if (request.type === "send_agent_message_request") {
+      const agent = this.agents.get(request.agentId);
+      if (!agent) throw new Error("Unknown agent");
+      agent["prompt"] = request.text;
+      this.send({
+        type: "send_agent_message_response",
+        payload: { requestId: request.requestId, accepted: true },
+      });
+      return;
+    }
+    if (request.type === "cancel_agent_request" || request.type === "archive_workspace_request") {
+      const agentId =
+        request.type === "cancel_agent_request"
+          ? request.agentId
+          : request.workspaceId.slice("workspace-".length);
+      const executionId = this.executionId(agentId);
+      const action = request.type === "cancel_agent_request" ? "interrupt" : "archive";
+      const control = { requestId: request.requestId, executionId, action } as const;
+      this.controls.push(action);
+      this.controlActionsByExecution.set(executionId, action);
+      const pending = this.pendingControlActions.get(executionId);
+      this.pendingControlActions.delete(executionId);
+      pending?.(action);
+      if (this.holdControlAck) this.heldControls.set(executionId, control);
+      else this.acknowledgeControl(control);
       return;
     }
     this.createRequests += 1;
-    const pending = {
-      requestId: request.requestId,
-      executionId: request.executionId,
-    };
-    const agentId = `agent-${request.executionId}`;
+    const executionId = new URL(request.config.mcpServers["hub"]!.url).pathname.split("/")[2]!;
+    const pending = { requestId: request.requestId, executionId };
+    const agentId = `agent-${executionId}`;
     if (this.materializeSpawn && !this.agents.has(agentId)) {
       this.agents.set(agentId, {
-        ...request,
+        ...request.config,
+        modeId: request.config["modeId"],
         env: request.env,
-        executionId: request.executionId,
+        worktree: request.worktree,
+        executionId,
         status: "running",
       });
     }
@@ -2542,18 +2635,16 @@ class TestDaemon {
     if (this.holdAck) this.pendingCreate = pending;
     else this.acknowledge(pending);
   }
+
   private acknowledge(pending: { requestId: string; executionId: string }): void {
     const error = this.nextCreateError;
     this.nextCreateError = undefined;
     if (error !== undefined) {
       this.send({
-        type: "hub.execution.agent.create.response",
+        type: "status",
         payload: {
+          status: "agent_create_failed",
           requestId: pending.requestId,
-          executionId: pending.executionId,
-          agentId: null,
-          agent: null,
-          success: false,
           error,
         },
       });
@@ -2563,15 +2654,12 @@ class TestDaemon {
     const agentId = `agent-${pending.executionId}`;
     const status = readAgentStatus(this.agents.get(agentId)?.["status"]);
     this.send({
-      type: "hub.execution.agent.create.response",
+      type: "status",
       payload: {
+        status: "agent_created",
         requestId: pending.requestId,
-        executionId: pending.executionId,
         agentId,
-        agent: this.omitSnapshotOnReconnect ? null : agentSnapshot(agentId, status),
-        success: true,
-        toolPolicyApplied: true,
-        error: null,
+        agent: { ...agentSnapshot(agentId, status), workspaceId: `workspace-${agentId}` },
       },
     });
     this.pendingCreate = undefined;
@@ -2582,14 +2670,8 @@ class TestDaemon {
     action: HubExecutionControlAction;
   }): void {
     this.send({
-      type: "hub.execution.control.response",
-      payload: {
-        requestId: request.requestId,
-        executionId: request.executionId,
-        action: request.action,
-        success: true,
-        error: null,
-      },
+      type: request.action === "archive" ? "archive_workspace_response" : "cancel_agent_response",
+      payload: { requestId: request.requestId, error: null },
     });
   }
   private executionId(agentId: string): string {
@@ -2605,16 +2687,6 @@ class TestDaemon {
 function isHubHello(value: unknown): boolean {
   return typeof value === "object" && value !== null && "type" in value && value.type === "hello";
 }
-
-type HubCreateError =
-  | {
-      code: "provider_options_invalid";
-      provider: string;
-      issues: readonly { path: readonly (string | number)[]; message: string }[];
-      message: string;
-    }
-  | { code: "tool_policy_unsupported"; provider: string; message: string }
-  | { code: "create_failed"; message: string };
 
 function agentSnapshot(
   agentId: string,

--- a/src/e2e/harness/fault-proxy.ts
+++ b/src/e2e/harness/fault-proxy.ts
@@ -21,6 +21,7 @@ export class HubFaultProxy {
   });
   private denial: ((value: Denial) => void) | undefined;
   private providerSnapshot: ((value: Record<string, unknown>) => void) | undefined;
+  private readonly creationExecutions = new Map<string, string>();
   private readonly createsByExecution = new Map<string, number>();
   private readonly agentIdsByExecution = new Map<string, Set<string>>();
   private readonly createdAgentsByExecution = new Map<
@@ -253,11 +254,18 @@ export class HubFaultProxy {
 
   private observeHubMessage(raw: string): void {
     const message = sessionMessage(parseRecord(raw));
-    const executionId = message && readString(message, "executionId");
-    if (!executionId) return;
-    if (message["type"] === "hub.execution.agent.create.request") {
-      this.createsByExecution.set(executionId, (this.createsByExecution.get(executionId) ?? 0) + 1);
-    }
+    if (message?.["type"] !== "create_agent_request") return;
+    const config = recordAt(message, "config");
+    const servers = config && recordAt(config, "mcpServers");
+    const hub = servers && recordAt(servers, "hub");
+    const url = hub && readString(hub, "url");
+    const requestId = readString(message, "requestId");
+    if (!url || !requestId) return;
+    const path = new URL(url).pathname.split("/");
+    if (path[1] !== "agent-executions" || !path[2]) return;
+    const executionId = path[2];
+    this.creationExecutions.set(requestId, executionId);
+    this.createsByExecution.set(executionId, (this.createsByExecution.get(executionId) ?? 0) + 1);
   }
 
   private observeDaemonMessage(data: RawData): boolean {
@@ -310,9 +318,11 @@ export class HubFaultProxy {
   }
 
   private observeCreateResponse(message: Record<string, unknown> | undefined): boolean {
-    if (message?.["type"] !== "hub.execution.agent.create.response") return false;
+    if (message?.["type"] !== "status") return false;
     const payload = recordAt(message, "payload");
-    const executionId = payload && readString(payload, "executionId");
+    if (payload?.["status"] !== "agent_created") return false;
+    const requestId = readString(payload, "requestId");
+    const executionId = requestId && this.creationExecutions.get(requestId);
     const agentId = payload && readString(payload, "agentId");
     if (executionId && agentId) {
       const ids = this.agentIdsByExecution.get(executionId) ?? new Set<string>();

--- a/src/e2e/harness/index.ts
+++ b/src/e2e/harness/index.ts
@@ -24,10 +24,10 @@ const PROJECT_SLUG = "default";
 const PersistedDaemonAgentSchema = z.object({
   id: z.string(),
   lastStatus: z.enum(["error", "initializing", "idle", "running", "closed"]),
-  owner: z.object({
-    kind: z.literal("daemon"),
-    daemonId: z.string(),
-    executionId: z.string(),
+  config: z.object({
+    mcpServers: z
+      .record(z.string(), z.object({ url: z.string().optional() }).passthrough())
+      .optional(),
   }),
 });
 const CanonicalToolCallSchema = z
@@ -346,7 +346,9 @@ export class HubE2E {
     return requiredString(result, "agentId");
   }
 
-  async installProductionConfiguration(): Promise<void> {
+  async installProductionConfiguration(
+    prompt = "Deploy requested for phase-five-operator",
+  ): Promise<void> {
     const daemon = await this.requirePool().query<{ slug: string }>(
       "select slug from daemons where presence = 'connected' order by connected_at desc limit 1",
     );
@@ -372,7 +374,7 @@ export class HubE2E {
       "        auto_archive: true",
       "        agent:",
       "          provider: hub-e2e",
-      '        prompt: [{ text: "Deploy requested for phase-five-operator" }] ',
+      `        prompt: [{ text: ${JSON.stringify(prompt)} }]`,
       "        allow_outputs:",
       "          - type: hub.e2e",
       "  - name: e2e-discord",
@@ -915,7 +917,7 @@ export class HubE2E {
 
   async sessionEvidence(executionId: string) {
     const result = await this.requirePool().query<{
-      data: { agentId: string; workspaceId: string };
+      data: { agentId: string; workspaceId: string; daemonId: string };
     }>(
       `select s.data from agent_sessions s join agent_executions e on e.agent_session_id = s.id where e.id = $1`,
       [executionId],
@@ -1011,15 +1013,6 @@ export class HubE2E {
     void this.waitForManualRun(dispatch).catch(() => undefined);
     await this.requireProxy().createResponseWasDropped();
     const executionId = await this.executionForManualRun(dispatch.providerEventReceiptId);
-    await this.observe(
-      async () => this.outputIsPersisted(executionId),
-      "ambiguous agent output to persist before Hub restart",
-    );
-    await this.observe(
-      async () =>
-        (await this.manualRunEvidence(dispatch.providerEventReceiptId)).status === "running",
-      "ambiguous execution to enter running state before Hub restart",
-    );
     return {
       providerEventReceiptId: dispatch.providerEventReceiptId,
       executionId,
@@ -1085,10 +1078,6 @@ export class HubE2E {
     );
     await this.daemonIsConnected();
     await this.observe(async () => {
-      const creation = proxy.creation(executionId);
-      return proxy.createAttempts(executionId) > createsBefore && creation.status === "closed";
-    }, "restarted daemon idempotent create with closed current state");
-    await this.observe(async () => {
       const execution = await this.requirePool().query<{ status: string }>(
         "select status from agent_executions where id = $1",
         [executionId],
@@ -1114,14 +1103,14 @@ export class HubE2E {
     return {
       persistedDaemonAgents: persistedAgents.length,
       executionAgentId: row.daemon_agent_id,
-      ownerAgentId: persistedAgent.id,
-      ownerDaemonId: persistedAgent.owner.daemonId,
+      persistedAgentId: persistedAgent.id,
+      sessionDaemonId: (await this.sessionEvidence(executionId)).daemonId,
       associationDaemonId: row.daemon_id,
       createAttempts: proxy.createAttempts(executionId),
       promptAttempts: prompts.filter((prompt) => prompt["executionId"] === executionId).length,
       recoveryCreateAttempts: proxy.createAttempts(executionId) - createsBefore,
       statusImmediatelyBeforeRestart: beforeRestart.lastStatus,
-      recoveredStatusAfterRestart: proxy.creation(executionId).status,
+      recoveredStatusAfterRestart: persistedAgent.lastStatus,
       executionStatus: row.status,
       executionResult: row.result,
     };
@@ -1148,9 +1137,11 @@ export class HubE2E {
       deliveryReceipts: delivery.receipts,
       executions: delivery.executions,
       persistedDaemonAgents: persistedAgents.length,
-      ownerMatchingAgentId: persistedAgent.id,
-      ownerDaemonId: persistedAgent.owner.daemonId,
-      ownerMatchesAssociation: persistedAgent.owner.daemonId === row.daemon_id,
+      persistedAgentId: persistedAgent.id,
+      sessionDaemonId: (await this.sessionEvidence(executionId)).daemonId,
+      sessionMatchesAssociation:
+        (await this.sessionEvidence(executionId)).daemonId === row.daemon_id &&
+        (await this.sessionEvidence(executionId)).agentId === row.daemon_agent_id,
       executionAgentId: row.daemon_agent_id,
       persistedAssociations: association.rows[0]?.count ?? 0,
       createAttempts: this.requireProxy().createAttempts(executionId),
@@ -1202,7 +1193,9 @@ export class HubE2E {
         }),
     );
     return records.filter(
-      (record) => record?.owner.executionId === executionId && record.owner.kind === "daemon",
+      (record) =>
+        record !== undefined &&
+        record.config.mcpServers?.["hub"]?.url?.endsWith(`/agent-executions/${executionId}/mcp`),
     );
   }
 

--- a/src/e2e/hub-foundation.e2e.test.ts
+++ b/src/e2e/hub-foundation.e2e.test.ts
@@ -64,6 +64,22 @@ describeHubE2E("Paseo Hub cross-repository contract", () => {
     await hub.disconnect();
   }, 120_000);
 
+  it("delivers a long prompt through ordinary agent creation without enabling continuation", async () => {
+    await hub.connect();
+    await hub.daemonIsConnected();
+    const prompt =
+      "Deploy requested for phase-five-operator\n" +
+      "Full request context. ".repeat(1_000) +
+      "End.";
+    await hub.installProductionConfiguration(prompt);
+    const run = await hub.runManual("long-prompt", "requested");
+    const completed = await hub.completedRun(run.executionId);
+    assert.equal(completed.prompt, prompt);
+    assert.equal(completed.status, "succeeded");
+    const session = await hub.sessionEvidence(run.executionId);
+    assert.equal(session.agentId, run.agentId);
+  }, 120_000);
+
   it("validates and installs the exact authored bundle through the source-built CLI", async () => {
     await hub.connect();
     await hub.daemonIsConnected();
@@ -179,21 +195,21 @@ describeHubE2E("Paseo Hub cross-repository contract", () => {
     assert.deepEqual(run.beforeRestart, {
       receipts: 1,
       executions: 1,
-      status: "running",
+      status: "spawning",
       daemonId: enrollment.daemonId,
       agentId: null,
     });
 
     await hub.recoverAmbiguousManualRun(run.executionId);
     const recovery = await hub.replayEvidence(run.executionId, run.providerEventReceiptId);
-    assert.equal(recovery.executionAgentId, recovery.ownerMatchingAgentId);
+    assert.equal(recovery.executionAgentId, recovery.persistedAgentId);
     assert.deepEqual(recovery, {
       deliveryReceipts: 1,
       executions: 1,
       persistedDaemonAgents: 1,
-      ownerMatchingAgentId: recovery.executionAgentId,
-      ownerDaemonId: enrollment.daemonId,
-      ownerMatchesAssociation: true,
+      persistedAgentId: recovery.executionAgentId,
+      sessionDaemonId: enrollment.daemonId,
+      sessionMatchesAssociation: true,
       executionAgentId: recovery.executionAgentId,
       persistedAssociations: 1,
       createAttempts: 2,
@@ -209,11 +225,11 @@ describeHubE2E("Paseo Hub cross-repository contract", () => {
       output: "phase-five:requested",
       status: "succeeded",
       daemonId: enrollment.daemonId,
-      agentId: recovery.ownerMatchingAgentId,
+      agentId: recovery.persistedAgentId,
     });
   }, 120_000);
 
-  it("fails the same owned running agent when a real daemon restart interrupts it", async () => {
+  it("fails the same running agent when a real daemon restart interrupts it", async () => {
     const enrollment = await hub.connect();
     await hub.daemonIsConnected();
     await hub.installProductionConfiguration();
@@ -223,12 +239,12 @@ describeHubE2E("Paseo Hub cross-repository contract", () => {
     assert.deepEqual(recovery, {
       persistedDaemonAgents: 1,
       executionAgentId: run.agentId,
-      ownerAgentId: run.agentId,
-      ownerDaemonId: enrollment.daemonId,
+      persistedAgentId: run.agentId,
+      sessionDaemonId: enrollment.daemonId,
       associationDaemonId: enrollment.daemonId,
-      createAttempts: 2,
+      createAttempts: 1,
       promptAttempts: 1,
-      recoveryCreateAttempts: 1,
+      recoveryCreateAttempts: 0,
       statusImmediatelyBeforeRestart: "running",
       recoveredStatusAfterRestart: "closed",
       executionStatus: "failed",

--- a/src/execution-authority/index.test.ts
+++ b/src/execution-authority/index.test.ts
@@ -17,6 +17,35 @@ function createExecutionAuthority(
 }
 
 describe("Hub execution authority", () => {
+  it("resumes scoped credentials only while their original lease is live", async () => {
+    const options = {
+      connectionsForProject: () => async () => "unused",
+      githubAuthority: githubAuthorityFake(),
+    };
+    const authority = createExecutionAuthority(options);
+    const input = {
+      executionId: "recovery",
+      projectId: "project-1",
+      triggerContext: {},
+      github: {
+        connection: "github",
+        repositories: ["getpaseo/paseo"],
+        permissions: { contents: "read" as const },
+        durationMs: 60_000,
+      },
+    };
+    assert.equal(authority.canResume(input), false);
+    await authority.materialize(input);
+    assert.equal(authority.canResume(input), true);
+    await authority.stop();
+    assert.equal(authority.canResume(input), false);
+    assert.equal(createExecutionAuthority(options).canResume(input), false);
+    assert.equal(
+      authority.canResume({ ...input, github: undefined, env: { STATIC: "value" } }),
+      true,
+    );
+  });
+
   it.each(["discord", "slack", "github", "manual"] as const)(
     "resolves explicit connection templates for the %s trigger source without automatic GitHub authority",
     async (provider) => {

--- a/src/execution-authority/index.ts
+++ b/src/execution-authority/index.ts
@@ -41,6 +41,7 @@ export interface MaterializedExecutionAuthority {
 
 export interface ExecutionAuthority {
   materialize(input: ExecutionAuthorityMaterialization): Promise<MaterializedExecutionAuthority>;
+  canResume(input: ExecutionAuthorityMaterialization): boolean;
   onExecutionTerminal(executionId: string): Promise<void>;
   resourceCounts(): ExecutionAuthorityResourceCounts;
   stop(): Promise<ExecutionAuthorityStopResult>;
@@ -380,7 +381,16 @@ export function createExecutionAuthority(
     return stopPromise;
   }
 
-  return { materialize, onExecutionTerminal, resourceCounts, stop };
+  function canResume(input: ExecutionAuthorityMaterialization): boolean {
+    const needsCredentials =
+      input.github !== undefined ||
+      Object.values(input.env ?? {}).some((value) => parseConnectionTemplate(value).length > 0);
+    if (!needsCredentials) return true;
+    const state = states.get(input.executionId);
+    return state !== undefined && !state.terminal && state.leases.size > 0;
+  }
+
+  return { materialize, canResume, onExecutionTerminal, resourceCounts, stop };
 
   function collectResidualExposures(
     activeStates: Array<[string, ExecutionState]>,

--- a/src/hub/protocol.test.ts
+++ b/src/hub/protocol.test.ts
@@ -1,44 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, it } from "vitest";
-import {
-  GetProvidersSnapshotResponseSchema,
-  HubExecutionAgentCreateRequestSchema,
-} from "./protocol.js";
-
-describe("Hub execution create protocol", () => {
-  it("accepts only structured refs for the injected Hub MCP server", () => {
-    const request = {
-      type: "hub.execution.agent.create.request",
-      requestId: "request-1",
-      executionId: "execution-1",
-      provider: "codex",
-      cwd: "/repo",
-      prompt: "run",
-      providerOptions: { sandbox_mode: "read-only" },
-      toolPolicy: {
-        preapproved: [{ kind: "mcp", server: "hub", tool: "finish_execution" }],
-      },
-    };
-
-    assert.equal(HubExecutionAgentCreateRequestSchema.safeParse(request).success, true);
-    assert.equal(
-      HubExecutionAgentCreateRequestSchema.safeParse({
-        ...request,
-        toolPolicy: { preapproved: [{ kind: "native", tool: "Bash" }] },
-      }).success,
-      false,
-    );
-    assert.equal(
-      HubExecutionAgentCreateRequestSchema.safeParse({
-        ...request,
-        toolPolicy: {
-          preapproved: [{ kind: "mcp", server: "unrelated", tool: "finish_execution" }],
-        },
-      }).success,
-      false,
-    );
-  });
-});
+import { GetProvidersSnapshotResponseSchema } from "./protocol.js";
 
 describe("Hub provider snapshot protocol", () => {
   it("keeps model thinking options and provider modes", () => {

--- a/src/hub/protocol.ts
+++ b/src/hub/protocol.ts
@@ -1,13 +1,6 @@
 import { z } from "zod";
-import { WorktreeTargetSchema } from "../config/index.js";
 
 const AgentStatusSchema = z.enum(["error", "initializing", "idle", "running", "closed"]);
-
-const McpHttpServerConfigSchema = z.object({
-  type: z.literal("http"),
-  url: z.string(),
-  headers: z.record(z.string(), z.string()).optional(),
-});
 
 type WireJsonValue =
   | string
@@ -71,14 +64,6 @@ const ProviderSnapshotEntrySchema = z.object({
   description: z.string().optional(),
   defaultModeId: z.string().nullable().optional(),
 });
-
-const McpToolRefSchema = z
-  .object({
-    kind: z.literal("mcp"),
-    server: z.literal("hub"),
-    tool: z.string(),
-  })
-  .strict();
 
 export const HubExecutionAgentSnapshotSchema = z
   .object({
@@ -181,25 +166,6 @@ export const HubExecutionAgentStreamEventSchema = z.discriminatedUnion("type", [
     .passthrough(),
 ]);
 
-export const HubExecutionAgentCreateRequestSchema = z.object({
-  type: z.literal("hub.execution.agent.create.request"),
-  requestId: z.string(),
-  executionId: z.string(),
-  provider: z.string(),
-  cwd: z.string(),
-  prompt: z.string(),
-  workspaceId: z.string().optional(),
-  model: z.string().optional(),
-  modeId: z.string().optional(),
-  thinkingOptionId: z.string().optional(),
-  providerOptions: z.record(z.string(), JsonValueSchema).optional(),
-  toolPolicy: z.object({ preapproved: z.array(McpToolRefSchema) }).strict(),
-  featureValues: z.record(z.string(), z.unknown()).optional(),
-  env: z.record(z.string(), z.string()).optional(),
-  mcpServers: z.record(z.string(), McpHttpServerConfigSchema).optional(),
-  worktree: WorktreeTargetSchema.optional(),
-});
-
 export const HubExecutionAgentValidateRequestSchema = z.object({
   type: z.literal("hub.execution.agent.validate.request"),
   requestId: z.string(),
@@ -256,79 +222,7 @@ export const RefreshProvidersSnapshotResponseSchema = z.object({
   }),
 });
 
-export const HubExecutionAgentCreateResponseSchema = z.object({
-  type: z.literal("hub.execution.agent.create.response"),
-  payload: z.object({
-    requestId: z.string(),
-    executionId: z.string(),
-    agentId: z.string().nullable(),
-    agent: HubExecutionAgentSnapshotSchema.nullable(),
-    success: z.boolean(),
-    toolPolicyApplied: z.literal(true).optional(),
-    error: z
-      .union([
-        z.string(),
-        z.discriminatedUnion("code", [
-          z.object({
-            code: z.literal("provider_options_invalid"),
-            provider: z.string(),
-            issues: z.array(
-              z.object({
-                path: z.array(z.union([z.string(), z.number()])),
-                message: z.string(),
-              }),
-            ),
-            message: z.string(),
-          }),
-          z.object({
-            code: z.literal("tool_policy_unsupported"),
-            provider: z.string(),
-            message: z.string(),
-          }),
-          z.object({ code: z.literal("create_failed"), message: z.string() }),
-        ]),
-      ])
-      .nullable(),
-  }),
-});
-
-export const HubExecutionAgentUpdateSchema = z.object({
-  type: z.literal("hub.execution.agent.update"),
-  payload: z.object({
-    executionId: z.string(),
-    agentId: z.string(),
-    agent: HubExecutionAgentSnapshotSchema,
-  }),
-});
-
-export const HubExecutionAgentStreamSchema = z.object({
-  type: z.literal("hub.execution.agent.stream"),
-  payload: z.object({
-    executionId: z.string(),
-    agentId: z.string(),
-    event: HubExecutionAgentStreamEventSchema,
-  }),
-});
-
 export const HubExecutionControlActionSchema = z.enum(["interrupt", "archive"]);
-
-export const HubExecutionControlRequestSchema = z.object({
-  type: z.literal("hub.execution.control.request"),
-  requestId: z.string(),
-  executionId: z.string(),
-  action: HubExecutionControlActionSchema,
-});
-
-export const HubExecutionControlResponseSchema = z.object({
-  type: z.literal("hub.execution.control.response"),
-  payload: z.object({
-    requestId: z.string(),
-    executionId: z.string(),
-    action: HubExecutionControlActionSchema,
-    success: z.boolean(),
-    error: z.string().nullable(),
-  }),
-});
 
 const RpcErrorSchema = z.object({
   type: z.literal("rpc_error"),
@@ -343,10 +237,6 @@ const RpcErrorSchema = z.object({
 export const HubExecutionOutboundSchema = z.object({
   type: z.literal("session"),
   message: z.discriminatedUnion("type", [
-    HubExecutionAgentCreateResponseSchema,
-    HubExecutionAgentUpdateSchema,
-    HubExecutionAgentStreamSchema,
-    HubExecutionControlResponseSchema,
     HubExecutionAgentValidateResponseSchema,
     GetProvidersSnapshotResponseSchema,
     RefreshProvidersSnapshotResponseSchema,

--- a/src/workflows/reactions.test.ts
+++ b/src/workflows/reactions.test.ts
@@ -1,4 +1,3 @@
-import { DaemonAgents } from "../daemons/agents/index.js";
 import assert from "node:assert/strict";
 import { randomUUID } from "node:crypto";
 import { describe, it } from "vitest";
@@ -329,17 +328,17 @@ async function runTwoStepWorkflow<
     createdAt: now,
   });
   const connection: DaemonConnection = {
-    agents: new DaemonAgents(() => {
-      throw new Error("Native agents are not used by this fixture");
-    }),
-    on: () => () => undefined,
-    createAgent: async (agentOptions) => {
-      if (options.outcome === "prelaunch_failure") {
-        throw new Error("daemon rejected agent");
-      }
-      return { id: agentOptions.executionId };
+    agents: {
+      create: async (key) => {
+        if (options.outcome === "prelaunch_failure") throw new Error("daemon rejected agent");
+        return { id: key, workspaceId: "workspace", status: "idle" };
+      },
+      get: async (id) => ({ id, workspaceId: "workspace", status: "idle" }),
+      send: async () => {},
+      control: async () => {},
+      restore: async () => false,
+      watch: async () => () => {},
     },
-    controlExecution: async () => undefined,
     getProviderSnapshot: async () => {
       throw new Error("not used");
     },


### PR DESCRIPTION
Hub workflows can deliver long instructions and context without hitting the agent title limit. All launches now use the ordinary daemon agent requests, preserving the complete rendered prompt and stable identities across retries.

### Goals

- Deliver full rendered prompts for every trigger source without requiring continuation.
- Reuse the existing agent-session owner for creation, message delivery, observation, recovery, and cleanup.
- Preserve authored provider configuration, MCP grants, completion contracts, and idempotent creation/message delivery.

### Non-goals

- Changing daemon code, increasing title limits, or truncating instructions.
- Changing startup budgets, adding workspace affinity, or migrating already-running executions from the old creation path.

### Why

The separate Hub create RPC assigned the rendered prompt to both the agent title and initial prompt. The title validator rejected normal requests longer than 200 characters. Hub already had an ordinary agent-request adapter for continuation; this makes that the common path and removes the duplicate Hub creation/control protocol.

**Protocol/API change:** Hub sends `create_agent_request` with a stable `idempotencyKey`, then `send_agent_message_request` with the execution ID as `messageId`. It uses ordinary fetch, subscription, cancel, archive, and restore requests. The existing daemon capabilities `hubAgentRpc` and `agentRequestReceipts` are required; unsupported daemons receive an upgrade error. No daemon patch is required. Source-built CI pins the tested, unchanged daemon commit `433e67b18b7964a92d593bdc78c518143accfc8b`.

### QA

- Reproduced the original failure through the real in-process daemon Hub relationship: 200 characters succeeded, 201 failed title validation before prompt delivery.
- Eight source-built integration tests passed with a real Hub process, PostgreSQL, and an unchanged daemon using the controlled ACP provider. A 21 KB prompt arrived intact; attachment delivery, continuation, archive/restore, and restart behavior passed.
- Dropped a create acknowledgement, restarted Hub, and retried: two create requests produced one persisted daemon agent and one execution, which completed successfully. A daemon restart retained the same agent association and did not resend its prompt.
- All 79 browser tests passed on desktop and mobile Chromium.
- Full Hub suite: 1,255 passed, 18 skipped, and one test raced creation against separate prompt delivery. Corrected the assertion to wait for actual delivery; the affected routing/materialization journeys passed in three consecutive runs.
- Typecheck, repository lint, formatting, database drift check, production build, and Docker smoke passed.
- This exercised isolated processes and controlled providers, not a live Discord account or billable model.

### Risk surface

Check mixed daemon versions, recovery after lost acknowledgements, and archive/completion ordering. Deploy after existing Hub runs settle: this change does not migrate executions started through the old RPC. Recovery preserves existing agents; if temporary environment credentials no longer have a live lease, it fails with `execution_credentials_unavailable` rather than reminting credentials that cannot reach an existing process environment. Pending cleanup stays pending until its resource identity and acknowledgement are known.

### Related work

Closes https://github.com/getpaseo/paseo/issues/4569.

Refs #127 for the separate configured-startup-deadline work. Workspace affinity in #86 and the broader app retry work in https://github.com/getpaseo/paseo/pull/4442 retain distinct goals.

### Supersedes

- [getpaseo/paseo#4568 — derive Hub agent title from prompt](https://github.com/getpaseo/paseo/pull/4568) — This PR takes over long-prompt Hub workflows through ordinary daemon requests, making the adapter-specific daemon title patch unnecessary for updated Hub.


### Joint deployment

Deploy together with #126. Its combined branch includes this change, the reconciled browser fixture, and a reproduced overlapping-reconnect recovery correction. Combined verification and rollout evidence are tracked in #126. Finish old-path executions and pending cleanup before deployment.


### Deployment and live verification

Both #126 and #128 are merged and deployed at `a60ec6f28a037ee7aea57866268f2a810f7dab47`; the deployed image revision matches the verified combined tree. All nine main CI checks and deployment passed. Production health passed.

A [653-character GitHub QA request](https://github.com/getpaseo/hub/pull/128#issuecomment-5608825500) triggered exactly one workflow and one agent on the existing instance. Hub persisted the 9,462-character rendered prompt; the provider transcript contains the entire QA request and final marker. The [bot reply](https://github.com/getpaseo/hub/pull/128#issuecomment-5608831072) reproduced that marker. Authenticated completion succeeded, archive cleanup was acknowledged, and the bot reply was filtered without spawning a second workflow. No daemon source changes or restart were needed.
