### PR TITLE
Make the two-minute startup timeout configurable

### DIFF
--- a/src/agent-sessions/index.ts
+++ b/src/agent-sessions/index.ts
@@ -1,7 +1,10 @@
 import { parseConnectionTemplate } from "../config/connection-template.js";
 import { createHash } from "node:crypto";
 import type { Database, AgentExecutionRecord } from "../db/types.js";
-import type { LaunchMachineIntent } from "../dispatcher/launch-machine-intent.js";
+import {
+  DEFAULT_STARTUP_TIMEOUT_MS,
+  type LaunchMachineIntent,
+} from "../dispatcher/launch-machine-intent.js";
 import type { DaemonCreateAgentOptions } from "../daemons/protocol.js";
 import type { AgentConnection, AgentEvent } from "../daemons/agents/index.js";
 import {
@@ -38,6 +41,7 @@ export class AgentSessions {
     action: "created" | "continued" | "restored";
   }> {
     const policy = input.intent.continuation;
+    const startupTimeoutMs = input.intent.startupTimeoutMs ?? DEFAULT_STARTUP_TIMEOUT_MS;
     const continuationKey = policy?.key ?? null;
     if (
       continuationKey !== null &&
@@ -102,7 +106,7 @@ export class AgentSessions {
       await this.database.attachExecutionToSession(input.executionId, id);
       let action: "created" | "continued" | "restored" = "continued";
       if (session.agentId === null) {
-        const agent = await input.connection.create(id, session.creationOptions);
+        const agent = await input.connection.create(id, session.creationOptions, startupTimeoutMs);
         session = { ...session, agentId: agent.id, workspaceId: agent.workspaceId };
         await this.database.saveAgentSession(session);
         action = "created";
@@ -119,7 +123,7 @@ export class AgentSessions {
         throw new AgentSessionError("agent_interrupted");
       }
       if (agent.archivedAt) {
-        await input.connection.restore(session.workspaceId);
+        await input.connection.restore(session.workspaceId, startupTimeoutMs);
         action = "restored";
       }
       await this.database.attachExecutionToSession(input.executionId, id, action);
@@ -135,6 +139,7 @@ export class AgentSessions {
           policy === undefined
             ? input.intent.prompt
             : `Hub execution: ${input.executionId}\nUse this executionId for Hub tool calls for this request.\n\n${input.intent.prompt}`,
+          startupTimeoutMs,
         );
       } catch (error) {
         unsubscribe();

--- a/src/config/compiler.test.ts
+++ b/src/config/compiler.test.ts
@@ -56,6 +56,14 @@ function legacyCompiledConfiguration(compiled: CompiledHubConfig): unknown {
 }
 
 describe("workflow compiler", () => {
+  it("preserves an authored startup timeout in stored compiled configurations", () => {
+    const authored = configuration();
+    Reflect.set(authored.triggers[0]!.steps[0]!, "startup_timeout", "3m");
+    const compiled = compileHubConfig(authored);
+    assert.equal(compiled.triggers[0]?.steps[0]?.startupTimeoutMs, 180_000);
+    assert.deepEqual(parseCompiledHubConfig(compiled), compiled);
+  });
+
   it.each([
     "paseo.event.github.delivery_id",
     "paseo.prompt",

--- a/src/config/compiler.ts
+++ b/src/config/compiler.ts
@@ -168,6 +168,7 @@ const StepSchema = z
     environment: z.string().min(1),
     max_runtime: z.string().min(1),
     idle_timeout: z.string().min(1),
+    startup_timeout: z.string().min(1).optional(),
     agent: AuthoredAgentSelectionSchema,
     prompt: z.array(PromptBlockSchema).min(1),
     env: z.record(z.string().min(1), z.string()).optional(),
@@ -243,6 +244,7 @@ export interface CompiledStep {
   environment: string;
   maxRuntimeMs: number;
   idleTimeoutMs: number;
+  startupTimeoutMs?: number | undefined;
   agent: CompiledAgentSelection;
   prompt: readonly CompiledPromptBlock[];
   env?: Readonly<Record<string, string>> | undefined;
@@ -391,6 +393,7 @@ const CompiledStepSchema: z.ZodType<CompiledStep> = z
     environment: z.string().min(1),
     maxRuntimeMs: z.number().int().positive().max(MAX_DURATION_MS),
     idleTimeoutMs: z.number().int().positive().max(MAX_DURATION_MS),
+    startupTimeoutMs: z.number().int().positive().max(MAX_DURATION_MS).optional(),
     agent: CompiledAgentSelectionSchema,
     prompt: z.array(CompiledPromptBlockSchema).min(1),
     env: z.record(z.string(), z.string()).optional(),
@@ -591,6 +594,16 @@ function compileStep(
     environment: step.environment,
     maxRuntimeMs,
     idleTimeoutMs,
+    ...(step.startup_timeout === undefined
+      ? {}
+      : {
+          startupTimeoutMs: compileAt([...stepPath, "startup_timeout"], () =>
+            parseDurationMs(
+              step.startup_timeout!,
+              `trigger ${trigger.name} step ${step.id} startup_timeout`,
+            ),
+          ),
+        }),
     agent,
     prompt: compilePromptBlocks(trigger.name, step.id, step.prompt, resolvedPromptPartials),
     ...(env === undefined ? {} : { env }),

--- a/src/daemons/agents/index.test.ts
+++ b/src/daemons/agents/index.test.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
 import { DaemonAgents } from "./index.js";
 import { DaemonResponseLostError, type DaemonCreateAgentOptions } from "../protocol.js";
 
@@ -81,3 +81,55 @@ function enable(agents: DaemonAgents): void {
     },
   });
 }
+
+test.each(["create", "restore", "send"] as const)(
+  "%s honors the supplied startup wait without changing the RPC",
+  async (operation) => {
+    vi.useFakeTimers();
+    let respond: (() => void) | undefined;
+    const agents = new DaemonAgents((frame) => {
+      const { message } = z
+        .object({ message: z.record(z.string(), z.unknown()) })
+        .parse(JSON.parse(frame));
+      const reply = () =>
+        agents.receive({
+          type: "session",
+          message: {
+            type: "response",
+            payload: {
+              requestId: message["requestId"],
+              state: { kind: "recoverable" },
+              accepted: true,
+              agent: { id: "agent", workspaceId: "workspace", status: "idle" },
+            },
+          },
+        });
+      if (message["type"] === "workspace.recovery.inspect.request") reply();
+      else respond = reply;
+      expect(message).not.toHaveProperty("timeoutMs");
+    });
+    try {
+      enable(agents);
+      const start = () => {
+        if (operation === "create") return agents.create("key", options, 180_000);
+        if (operation === "restore") return agents.restore("workspace", 180_000);
+        return agents.send("agent", "message-key", "hello", 180_000);
+      };
+      const outcome = start().then(
+        () => "accepted",
+        (error: unknown) => error,
+      );
+      await vi.advanceTimersByTimeAsync(150_000);
+      expect(respond).toBeDefined();
+      respond!();
+      expect(await outcome).toBe("accepted");
+
+      const expired = start().catch((error: unknown) => error);
+      await vi.advanceTimersByTimeAsync(180_000);
+      expect(await expired).toBeInstanceOf(DaemonResponseLostError);
+    } finally {
+      agents.close();
+      vi.useRealTimers();
+    }
+  },
+);

--- a/src/daemons/agents/index.ts
+++ b/src/daemons/agents/index.ts
@@ -18,10 +18,14 @@ export type AgentEvent =
   | { type: "agent_update"; agent: AgentSnapshot; timestamp: string }
   | { type: "agent_stream"; agentId: string; event: DaemonAgentStreamEvent; timestamp: string };
 export interface AgentConnection {
-  create(key: string, options: DaemonCreateAgentOptions): Promise<AgentSnapshot>;
+  create(
+    key: string,
+    options: DaemonCreateAgentOptions,
+    timeoutMs?: number,
+  ): Promise<AgentSnapshot>;
   get(agentId: string): Promise<AgentSnapshot>;
-  send(agentId: string, messageId: string, text: string): Promise<void>;
-  restore(workspaceId: string): Promise<boolean>;
+  send(agentId: string, messageId: string, text: string, timeoutMs?: number): Promise<void>;
+  restore(workspaceId: string, timeoutMs?: number): Promise<boolean>;
   control(agentId: string, workspaceId: string, action: "interrupt" | "archive"): Promise<void>;
   watch(agentId: string, listener: (event: AgentEvent) => void): Promise<() => void>;
 }
@@ -105,23 +109,30 @@ export class DaemonAgents implements AgentConnection {
     this.listeners.clear();
   }
 
-  async create(key: string, options: DaemonCreateAgentOptions): Promise<AgentSnapshot> {
-    const response = await this.request({
-      type: "create_agent_request",
-      idempotencyKey: key,
-      config: {
-        provider: options.provider,
-        cwd: options.cwd,
-        model: options.model,
-        modeId: options.mode,
-        thinkingOptionId: options.thinkingOptionId,
-        providerOptions: options.providerOptions,
-        mcpServers: options.mcpServers,
-        toolPolicy: options.toolPolicy,
+  async create(
+    key: string,
+    options: DaemonCreateAgentOptions,
+    timeoutMs?: number,
+  ): Promise<AgentSnapshot> {
+    const response = await this.request(
+      {
+        type: "create_agent_request",
+        idempotencyKey: key,
+        config: {
+          provider: options.provider,
+          cwd: options.cwd,
+          model: options.model,
+          modeId: options.mode,
+          thinkingOptionId: options.thinkingOptionId,
+          providerOptions: options.providerOptions,
+          mcpServers: options.mcpServers,
+          toolPolicy: options.toolPolicy,
+        },
+        env: options.env,
+        worktree: options.worktree,
       },
-      env: options.env,
-      worktree: options.worktree,
-    });
+      timeoutMs,
+    );
     return SnapshotSchema.parse(response["agent"]);
   }
   async get(agentId: string): Promise<AgentSnapshot> {
@@ -132,16 +143,19 @@ export class DaemonAgents implements AgentConnection {
       );
     return SnapshotSchema.parse(response["agent"]);
   }
-  async send(agentId: string, messageId: string, text: string): Promise<void> {
-    await this.request({
-      type: "send_agent_message_request",
-      agentId,
-      messageId,
-      text,
-      activeTurnBehavior: "steer",
-    });
+  async send(agentId: string, messageId: string, text: string, timeoutMs?: number): Promise<void> {
+    await this.request(
+      {
+        type: "send_agent_message_request",
+        agentId,
+        messageId,
+        text,
+        activeTurnBehavior: "steer",
+      },
+      timeoutMs,
+    );
   }
-  async restore(workspaceId: string): Promise<boolean> {
+  async restore(workspaceId: string, timeoutMs?: number): Promise<boolean> {
     const result = await this.request({ type: "workspace.recovery.inspect.request", workspaceId });
     const state = z
       .object({ kind: z.string(), reason: z.string().optional() })
@@ -151,7 +165,7 @@ export class DaemonAgents implements AgentConnection {
       throw new DaemonAgentError(
         "Workspace cannot be restored; inspect its recovery state in Paseo",
       );
-    await this.request({ type: "workspace.recovery.restore.request", workspaceId });
+    await this.request({ type: "workspace.recovery.restore.request", workspaceId }, timeoutMs);
     return true;
   }
   async control(
@@ -193,14 +207,17 @@ export class DaemonAgents implements AgentConnection {
   private emit(agentId: string, event: AgentEvent): void {
     for (const listener of this.listeners.get(agentId) ?? []) listener(event);
   }
-  private async request(message: Record<string, unknown>): Promise<Record<string, unknown>> {
+  private async request(
+    message: Record<string, unknown>,
+    timeoutMs = 30_000,
+  ): Promise<Record<string, unknown>> {
     if (!this.supported) throw new DaemonAgentError("Update the Paseo daemon to run Hub agents");
     const requestId = randomUUID();
     let timeout: ReturnType<typeof setTimeout> | undefined;
     try {
       const result = await new Promise<Record<string, unknown>>((resolve, reject) => {
         this.pending.set(requestId, { resolve, reject });
-        timeout = setTimeout(() => reject(new DaemonResponseLostError()), 30_000);
+        timeout = setTimeout(() => reject(new DaemonResponseLostError()), timeoutMs);
         this.sendFrame(JSON.stringify({ type: "session", message: { ...message, requestId } }));
       });
       const parsed = ResultSchema.parse(result);

--- a/src/daemons/daemons.test.ts
+++ b/src/daemons/daemons.test.ts
@@ -562,6 +562,7 @@ describe("daemon enrollment and execution", () => {
     hub.issueConnectionLeaseOnAuthorityMaterialization();
     hub.hangAuthorityMintPermanently();
     const dispatch = hub.beginDispatch({
+      startupTimeoutMs: 30_000,
       env: { TOKEN: "${{ paseo.connections.some-connection.token }}" },
       github: {
         connection: "getpaseo-github",
@@ -1844,19 +1845,63 @@ describe("daemon enrollment and execution", () => {
     },
   );
 
-  it("bounds spawn acknowledgement and execution deadlines with the deterministic clock", async () => {
+  it.each([
+    { name: "default", startupTimeoutMs: undefined, delayMs: 90_000 },
+    { name: "configured", startupTimeoutMs: 180_000, delayMs: 150_000 },
+  ])("allows slow startup within the $name budget", async ({ startupTimeoutMs, delayMs }) => {
     await hub.connectDaemon();
     hub.holdSpawnAcknowledgement();
-    const dispatch = hub.beginDispatch({ timeoutMs: 60_000 });
+    const dispatch = hub
+      .beginDispatch({
+        ...(startupTimeoutMs === undefined ? {} : { startupTimeoutMs }),
+        timeoutMs: 600_000,
+        idleTimeoutMs: 600_000,
+      })
+      .then(
+        (value) => ({ value }),
+        (error: unknown) => ({ error }),
+      );
     await hub.spawnBegins();
-    await hub.advanceDispatchTime(30_000);
-
-    await assert.rejects(
-      dispatch,
-      (error: unknown) =>
-        error instanceof DaemonDispatchFailure && error.reason === "daemon_timeout",
-    );
+    await hub.advanceDispatchTime(delayMs);
+    hub.acceptSpawn();
+    const outcome = await dispatch;
+    assert.ok("value" in outcome, "error" in outcome ? String(outcome.error) : "dispatch failed");
+    assert.equal((await hub.execution(outcome.value.execution.id)).status, "running");
+    assert.equal(hub.createdAgentCount(), 1);
   });
+
+  it.each([
+    { startupTimeoutMs: undefined, timeoutMs: 600_000, waitMs: 120_000, reason: "daemon_timeout" },
+    { startupTimeoutMs: 45_000, timeoutMs: 600_000, waitMs: 45_000, reason: "daemon_timeout" },
+    { startupTimeoutMs: 180_000, timeoutMs: 60_000, waitMs: 60_000, reason: "timeout" },
+  ])(
+    "bounds startup at $waitMs ms with reason $reason",
+    async ({ startupTimeoutMs, timeoutMs, waitMs, reason }) => {
+      await hub.connectDaemon();
+      hub.holdSpawnAcknowledgement();
+      let settled = false;
+      const dispatch = hub
+        .beginDispatch({
+          timeoutMs,
+          ...(startupTimeoutMs === undefined ? {} : { startupTimeoutMs }),
+        })
+        .then(
+          () => undefined,
+          (error: unknown) => error,
+        )
+        .then((result) => {
+          settled = true;
+          return result;
+        });
+      await hub.spawnBegins();
+      await hub.advanceDispatchTime(waitMs - 1);
+      assert.equal(settled, false);
+      await hub.advanceDispatchTime(1);
+      const failure = await dispatch;
+      assert.ok(failure instanceof DaemonDispatchFailure);
+      assert.equal(failure.reason, reason);
+    },
+  );
 
   it("expires at the dispatch boundary before creating an agent", async () => {
     await hub.connectDaemon();

--- a/src/daemons/lifecycle.ts
+++ b/src/daemons/lifecycle.ts
@@ -21,7 +21,10 @@ import type {
   WorkflowDeadlineKind,
   WorkflowAgentCompletionInput,
 } from "../db/types.js";
-import type { LaunchMachineIntent } from "../dispatcher/launch-machine-intent.js";
+import {
+  DEFAULT_STARTUP_TIMEOUT_MS,
+  type LaunchMachineIntent,
+} from "../dispatcher/launch-machine-intent.js";
 import { logger as defaultLogger } from "../logger.js";
 import { reportFailure } from "../failures/index.js";
 import type { TriggerProvider } from "../triggers/index.js";
@@ -1479,7 +1482,10 @@ export class DaemonDispatchLifecycle {
     let canceled = false;
     const timeoutMs = Math.max(
       0,
-      Math.min(this.dispatchTimeoutMs, deadlineAt.getTime() - this.now()),
+      Math.min(
+        input.intent.startupTimeoutMs ?? DEFAULT_STARTUP_TIMEOUT_MS,
+        deadlineAt.getTime() - this.now(),
+      ),
     );
     try {
       return await withDispatchTimeout(

--- a/src/dispatcher/launch-machine-intent.ts
+++ b/src/dispatcher/launch-machine-intent.ts
@@ -4,6 +4,8 @@ import type { WorktreeTarget } from "../config/index.js";
 import type { JsonValue } from "../config/compiler.js";
 import type { CompiledGitHubAuthority } from "../config/github-authority.js";
 
+export const DEFAULT_STARTUP_TIMEOUT_MS = 120_000;
+
 export interface DaemonEnvironmentTarget {
   kind: "daemon";
   daemonId: string;
@@ -29,6 +31,7 @@ export interface LaunchMachineIntent {
   agent: TriggerAgentConfig;
   allowOutputs: readonly AllowedOutput[];
   timeoutMs?: number;
+  startupTimeoutMs?: number;
   idleTimeoutMs?: number;
   autoArchive: boolean;
   triggerContext: unknown;
@@ -53,6 +56,7 @@ export function buildLaunchMachineIntent(input: {
   agent: TriggerAgentConfig;
   allowOutputs: readonly AllowedOutput[];
   timeoutMs?: number;
+  startupTimeoutMs?: number;
   idleTimeoutMs?: number;
   autoArchive: boolean;
   triggerContext: unknown;
@@ -73,6 +77,7 @@ export function buildLaunchMachineIntent(input: {
     agent: input.agent,
     allowOutputs: input.allowOutputs,
     ...(input.timeoutMs === undefined ? {} : { timeoutMs: input.timeoutMs }),
+    ...(input.startupTimeoutMs === undefined ? {} : { startupTimeoutMs: input.startupTimeoutMs }),
     ...(input.idleTimeoutMs === undefined ? {} : { idleTimeoutMs: input.idleTimeoutMs }),
     autoArchive: input.autoArchive,
     triggerContext: input.triggerContext,

--- a/src/triggers/configuration/editor.test.ts
+++ b/src/triggers/configuration/editor.test.ts
@@ -49,6 +49,7 @@ run:
   prompt: Handle it.
   max_runtime: 3h
   idle_timeout: 15m
+  startup_timeout: 3m
   env:
     TEAM: core
   github:
@@ -97,6 +98,7 @@ describe("trigger form YAML bridge", () => {
     });
     expect(value.inputs).toBeDefined();
     expect(value.max_runtime).toBe("4h");
+    expect(value.run.startup_timeout).toBe("3m");
     expect(value.run.env).toEqual({ TEAM: "core" });
     expect(value.run.github).toEqual({
       connection: "company-github",

--- a/src/triggers/configuration/index.test.ts
+++ b/src/triggers/configuration/index.test.ts
@@ -67,6 +67,29 @@ run:
 `;
 
 describe("self-contained trigger documents", () => {
+  it("compiles and preserves a configurable startup timeout", () => {
+    const yaml = trigger.replace("  max_runtime: 90m", "  max_runtime: 90m\n  startup_timeout: 3m");
+    const compiled = compileTriggerDocument(yaml);
+    assert.equal(compiled.events[0]?.steps[0]?.startupTimeoutMs, 180_000);
+    assert.equal(
+      parseTriggerDocument(serializeTriggerDocument(compiled.authored)).run.startup_timeout,
+      "3m",
+    );
+  });
+
+  it.each(["0s", "25h", "invalid"])("rejects invalid startup timeout %s", (duration) => {
+    assert.throws(
+      () =>
+        compileTriggerDocument(
+          trigger.replace(
+            "  max_runtime: 90m",
+            `  max_runtime: 90m\n  startup_timeout: ${duration}`,
+          ),
+        ),
+      /startup_timeout/,
+    );
+  });
+
   it("compiles every input event to one launch against the inline target and agent choices", () => {
     const compiled = compileTriggerDocument(trigger);
 

--- a/src/triggers/configuration/index.ts
+++ b/src/triggers/configuration/index.ts
@@ -64,6 +64,9 @@ export function compileTriggerDocument(yaml: string): CompiledTriggerDocument {
           environment: "target",
           max_runtime: authored.run.max_runtime,
           idle_timeout: authored.run.idle_timeout,
+          ...(authored.run.startup_timeout === undefined
+            ? {}
+            : { startup_timeout: authored.run.startup_timeout }),
           agent,
           prompt: [{ text: authored.run.prompt }],
           ...(authored.run.env === undefined ? {} : { env: authored.run.env }),

--- a/src/triggers/configuration/legacy-migration.ts
+++ b/src/triggers/configuration/legacy-migration.ts
@@ -155,6 +155,9 @@ function singleRunDocument(
         .join("\n"),
       max_runtime: duration(step.maxRuntimeMs),
       idle_timeout: duration(step.idleTimeoutMs),
+      ...(step.startupTimeoutMs === undefined
+        ? {}
+        : { startup_timeout: duration(step.startupTimeoutMs) }),
       ...(step.env === undefined ? {} : { env: { ...step.env } }),
       ...(step.github === undefined
         ? {}

--- a/src/triggers/configuration/schema.ts
+++ b/src/triggers/configuration/schema.ts
@@ -102,6 +102,7 @@ export const TriggerRunSchema = z
     prompt: z.string().min(1),
     max_runtime: z.string().min(1).default("2h"),
     idle_timeout: z.string().min(1).default("10m"),
+    startup_timeout: z.string().min(1).optional(),
     env: z.record(z.string().min(1), z.string()).optional(),
     github: AuthoredGitHubAuthoritySchema.optional(),
     output: z

--- a/src/workflows/engine.test.ts
+++ b/src/workflows/engine.test.ts
@@ -164,7 +164,7 @@ describe("durable multi-step workflow engine", () => {
     assert.equal(steps[0]?.failureReason, "trigger_context_materializer_unavailable");
   });
 
-  it("carries provider options unchanged into persisted and dispatched launch intent", async () => {
+  it("carries provider options and startup timeout into persisted and dispatched launch intent", async () => {
     const rawConfiguration = deadlineConfiguration();
     const options = {
       sandbox_workspace_write: {
@@ -183,6 +183,7 @@ describe("durable multi-step workflow engine", () => {
     const agent = authoredStep["agent"];
     if (!isRecord(agent)) throw new Error("test agent unavailable");
     Reflect.set(agent, "options", options);
+    Reflect.set(authoredStep, "startup_timeout", "3m");
     const fixture = await workflowFixture({ rawConfiguration });
     let dispatched: LaunchMachineIntent | undefined;
     const { handler, engine } = engineFor(fixture, [], async (intent) => {
@@ -193,11 +194,13 @@ describe("durable multi-step workflow engine", () => {
     await engine.processAvailable();
 
     assert.deepEqual(dispatched?.agent, { provider: "codex", options });
+    assert.equal(dispatched?.startupTimeoutMs, 180_000);
     const run = (
       await fixture.database.findTriggerRunsByProviderEventReceiptId(fixture.providerEventReceiptId)
     )[0]!;
     const persistedStep = (await fixture.database.listWorkflowStepRunsForTriggerRun(run.id))[0]!;
     assert.deepEqual(persistedStep.dispatchIntent?.agent, { provider: "codex", options });
+    assert.equal(persistedStep.dispatchIntent?.startupTimeoutMs, 180_000);
   });
 
   it("logs an initial recovery rejection and retries on the next interval", async () => {

--- a/src/workflows/engine.ts
+++ b/src/workflows/engine.ts
@@ -957,6 +957,7 @@ function buildStepIntent(
       allowOutputs: step.allowOutputs,
       timeoutMs: step.maxRuntimeMs,
       idleTimeoutMs: step.idleTimeoutMs,
+      ...(step.startupTimeoutMs === undefined ? {} : { startupTimeoutMs: step.startupTimeoutMs }),
       autoArchive: step.autoArchive,
       triggerContext: run.triggerContext,
       outputContext: run.outputContext,


### PR DESCRIPTION
Hub now waits up to two minutes for agent startup by default. Set `run.startup_timeout: 5m` in a trigger YAML file (or `startup_timeout` on a workflow step) when a machine needs longer.

The setting controls Hub's overall startup wait and its existing create, restore, and initial-message RPC waits. It accepts the existing positive duration syntax, up to 24 hours. Runtime and idle deadlines still apply; control and read RPCs retain their existing limits. The value survives configuration storage, migration, and form edits.

Public documentation: [Paseo #4601](https://github.com/getpaseo/paseo/pull/4601), documentation only.

## Goals

- Increase the default startup wait from 30 seconds to two minutes.
- Let trigger authors configure the wait through YAML.
- Use the current standard daemon RPCs and existing idempotency receipts.

## Non-goals

Daemon protocol changes, cancellation/recovery redesign, provider timeout changes, or a new form control.

## Verification

- Failing-first socket regression: a delayed create response failed with `daemon_timeout` on the baseline. The same test succeeds after 90 seconds by default and 150 seconds with a three-minute setting.
- Startup expires at the two-minute default or a shorter configured value; remaining runtime caps it. Existing create/restore/send RPCs accept slow responses and still expire at the supplied budget.
- 147 compiler, form, workflow, session, and RPC tests passed; five socket deadline cases passed.
- All eight source-built Hub integration tests passed against the existing pinned daemon, including continuation, archive/restore, and lost creation response recovery. No daemon upgrade or pin change.
- Typecheck, lint, formatting, build, migration drift, and Docker smoke passed. All 80 browser tests passed.
- Full local unit/integration run: 1,322 passed, 18 skipped, one timeout in `HubHarness.start()` before the test body. That test passed unchanged on a focused retry (4.2 seconds). The complete current-head CI run passed: 1,323 tests passed, 18 skipped, plus 13 script tests, 80 browser tests, and eight source-built Hub integration tests.

Risk surface: Hub waits longer before reporting a stalled startup. Existing runtime/idle limits, daemon behavior, and handling of ambiguous responses remain in effect.

## Supersedes

- [Hub #127](https://github.com/getpaseo/hub/pull/127) and [Paseo #4588](https://github.com/getpaseo/paseo/pull/4588), both closed — this Hub-only timeout setting replaces the proposed startup protocol changes.

All nine Hub checks passed at `9de042e4595cf66779c5df1808bd1794d10743cd`; no unresolved review threads. The documentation PR is also green at `a1a03e8eb3ea47f37b62158819cccbfe9772c508`, with its review finding resolved. Both PRs remain unmerged.
