### PR TITLE
Steer active agents with scoped credentials

### DIFF
--- a/src/agent-sessions/index.test.ts
+++ b/src/agent-sessions/index.test.ts
@@ -51,7 +51,7 @@ class TestAgents implements AgentConnection {
   }
 }
 
-async function fixture() {
+async function fixture(now = Date.now) {
   const database = createMemoryDatabase();
   const connection = new TestAgents();
   const outputs = new OutputExecutorRegistry();
@@ -63,7 +63,7 @@ async function fixture() {
       replies.push({ executionId: input.agentExecutionId, context: input.outputContext });
     },
   });
-  const sessions = new AgentSessions(database, "secret", "https://hub.test", outputs);
+  const sessions = new AgentSessions(database, "secret", "https://hub.test", outputs, now);
   const capabilities = createExecutionCapabilityServer({
     database,
     outputs,
@@ -76,6 +76,7 @@ async function fixture() {
     target = "daemon",
     env: Record<string, string> = {},
     prompt = "hello",
+    overrides: Partial<LaunchMachineIntent> = {},
   ) {
     const executionId = randomUUID();
     const intent: LaunchMachineIntent = {
@@ -96,6 +97,7 @@ async function fixture() {
       configurationRevisionId: randomUUID(),
       hubConfig: {},
       ...(key === false ? {} : { continuation: { key, compatibility: { target } } }),
+      ...overrides,
     };
     await database.insertAgentExecution({
       id: executionId,
@@ -106,6 +108,7 @@ async function fixture() {
       outputContext: intent.outputContext,
       configurationRevisionId: intent.configurationRevisionId,
       launchIntent: intent,
+      ...(intent.deadlineAt === undefined ? {} : { deadlineAt: intent.deadlineAt }),
     });
     return {
       executionId,
@@ -118,7 +121,7 @@ async function fixture() {
           createOptions: async () => ({
             provider: "codex",
             cwd: "/repo",
-            env: {},
+            env: intent.github === undefined ? {} : { GH_TOKEN: "scoped-github-token" },
             toolPolicy: { preapproved: [] },
           }),
         }),
@@ -238,15 +241,69 @@ test("ordinary launches use agent sessions and preserve long prompts without ena
   ]);
 });
 
-test("temporary environment credentials require a new agent instead of being reused", async () => {
+test("steering keeps the active agent's scoped credentials instead of requiring a new agent", async () => {
   const f = await fixture();
   const env = { TOKEN: "${{ paseo.connections.support.token }}" };
-  const continuing = await f.arrival("conversation", "daemon", env);
-  await expect(continuing.dispatch()).rejects.toThrow(
-    "Temporary environment credentials require New agent",
-  );
-  expect(f.connection.creates).toHaveLength(0);
-  const fresh = await f.arrival(null, "daemon", env);
-  await fresh.dispatch();
+  const github = {
+    connection: "getpaseo-github",
+    repositories: ["getpaseo/paseo"],
+    permissions: { contents: "write" as const },
+    durationMs: 60 * 60 * 1000,
+  };
+  const first = await f.arrival("conversation", "daemon", env, "first request", { github });
+  const original = await first.dispatch();
+  const next = await f.arrival("conversation", "daemon", env, "follow-up", { github });
+  expect(await next.dispatch()).toMatchObject({ agentId: original.agentId, action: "continued" });
   expect(f.connection.creates).toHaveLength(1);
+  expect(f.connection.creates[0]?.env).toEqual({ GH_TOKEN: "scoped-github-token" });
+  expect(f.connection.deliveries).toHaveLength(2);
+});
+
+test("steering cannot extend the active agent's original max-runtime deadline", async () => {
+  const f = await fixture();
+  const deadlineAt = new Date("2030-01-01T01:00:00Z");
+  const first = await f.arrival("conversation", "daemon", {}, "first request", { deadlineAt });
+  await first.dispatch();
+  const next = await f.arrival("conversation", "daemon", {}, "follow-up", {
+    deadlineAt: new Date("2030-01-01T01:30:00Z"),
+  });
+  await next.dispatch();
+  expect((await f.execution(first.executionId)).deadlineAt).toEqual(deadlineAt);
+  expect((await f.execution(next.executionId)).deadlineAt).toEqual(deadlineAt);
+});
+
+test("a completed credentialed task gets a fresh agent and isolates the previous agent's tools", async () => {
+  const f = await fixture();
+  const github = {
+    connection: "getpaseo-github",
+    repositories: ["getpaseo/paseo"],
+    permissions: { contents: "write" as const },
+    durationMs: 60 * 60 * 1000,
+  };
+  const first = await f.arrival("conversation", "daemon", {}, "first", { github });
+  const original = await first.dispatch();
+  await f.database.transitionAgentExecution(first.executionId, "succeeded");
+  await f.sessions.releaseAuthority(await f.execution(first.executionId), async () => {});
+  const next = await f.arrival("conversation", "daemon", {}, "next task", { github });
+  const fresh = await next.dispatch();
+  expect(fresh.agentId).not.toBe(original.agentId);
+  expect(f.connection.creates).toHaveLength(2);
+  expect(await f.call(next.executionId, "finish_execution", {}, first.executionId)).toMatchObject({
+    result: { isError: true },
+  });
+});
+
+test("a ping cannot send more work after the inherited deadline while timeout cleanup is pending", async () => {
+  let now = Date.parse("2030-01-01T00:00:00Z");
+  const f = await fixture(() => now);
+  const first = await f.arrival("conversation", "daemon", {}, "first", {
+    deadlineAt: new Date(now + 1000),
+  });
+  await first.dispatch();
+  now += 1000;
+  const next = await f.arrival("conversation", "daemon", {}, "too late", {
+    deadlineAt: new Date(now + 1000),
+  });
+  await expect(next.dispatch()).rejects.toThrow("execution_deadline_exceeded");
+  expect(f.connection.deliveries).toHaveLength(1);
 });

--- a/src/agent-sessions/index.ts
+++ b/src/agent-sessions/index.ts
@@ -27,6 +27,7 @@ export class AgentSessions {
     private readonly secret: string,
     private readonly publicBaseUrl: string,
     private readonly outputs: OutputExecutorRegistry,
+    private readonly now: () => number = Date.now,
   ) {}
 
   async dispatch(input: {
@@ -40,40 +41,61 @@ export class AgentSessions {
     unsubscribe: () => void;
     action: "created" | "continued" | "restored";
   }> {
+    const incoming = await this.database.findAgentExecutionById(input.executionId);
+    if (!incoming || !isActive(incoming)) throw new AgentSessionError("execution_terminal");
     const policy = input.intent.continuation;
     const startupTimeoutMs = input.intent.startupTimeoutMs ?? DEFAULT_STARTUP_TIMEOUT_MS;
     const continuationKey = policy?.key ?? null;
-    if (
-      continuationKey !== null &&
-      (input.intent.github !== undefined ||
-        Object.values({ ...input.intent.environment.env, ...input.intent.env }).some(
-          (value) => parseConnectionTemplate(value).length > 0,
-        ))
-    ) {
-      throw new AgentSessionError(
-        "Temporary environment credentials require New agent continuity. Existing agents cannot refresh their environment.",
+    const projectId = input.intent.projectId;
+    const lockId = deriveSessionId(projectId, continuationKey ?? `execution:${input.executionId}`);
+    const findSession = async () => {
+      const execution = await this.database.findAgentExecutionById(input.executionId);
+      if (execution?.agentSessionId)
+        return this.database.findAgentSession(execution.agentSessionId);
+      return continuationKey === null
+        ? this.database.findAgentSession(
+            deriveSessionId(projectId, `execution:${input.executionId}`),
+          )
+        : this.database.findAgentSessionByKey(projectId, continuationKey);
+    };
+    const isFinishedCredentialedSession = async (session: AgentSessionRecord) => {
+      const executions = await this.database.listAgentSessionExecutions(session.id);
+      return (
+        executions.length > 0 &&
+        !executions.some(isActive) &&
+        executions.some(
+          (execution) =>
+            execution.launchIntent !== null && hasTemporaryCredentials(execution.launchIntent),
+        )
       );
-    }
-    const id = sessionId(
-      input.intent.projectId,
-      continuationKey ?? `execution:${input.executionId}`,
-    );
+    };
     // External credential minting must not hold a database connection open during shutdown.
-    const storedSession = await this.database.findAgentSession(id);
-    const options = storedSession?.creationOptions ?? (await input.createOptions());
-    return this.database.withAdvisoryLock(`agent-session:${id}`, async () => {
+    const storedSession = await findSession();
+    const options =
+      !storedSession || (await isFinishedCredentialedSession(storedSession))
+        ? await input.createOptions()
+        : undefined;
+    const dispatched = await this.database.withAdvisoryLock(`agent-session:${lockId}`, async () => {
       const tools = executionToolDefinitions(
         input.intent.outputSchema,
         this.outputs.materialize(input.intent.allowOutputs, input.intent.outputContext),
       );
       const compatibility = fingerprint({ settings: policy?.compatibility, tools });
-      let session = await this.database.findAgentSession(id);
+      let session = await findSession();
+      if (session && (await isFinishedCredentialedSession(session))) {
+        // Completion may have raced credential preparation. Retry outside the lock.
+        if (!options) return undefined;
+        await this.database.saveAgentSession({ ...session, continuationKey: null });
+        session = undefined;
+      }
+      const id = session?.id ?? deriveSessionId(projectId, `execution:${input.executionId}`);
       if (session && session.compatibility !== compatibility) {
         throw new AgentSessionError(
           "Continuation settings differ from the existing agent; use a different key or choose a new agent",
         );
       }
       if (!session) {
+        if (!options) return undefined;
         const token = deriveAgentExecutionCompletionToken(this.secret, `session:${id}`);
         session = {
           id,
@@ -103,6 +125,16 @@ export class AgentSessions {
         };
         await this.database.saveAgentSession(session);
       }
+      const activeExecutions = (await this.database.listAgentSessionExecutions(id)).filter(
+        (execution) => execution.status === "spawning" || execution.status === "running",
+      );
+      const deadline = activeExecutions.reduce<number>(
+        (earliest, execution) =>
+          Math.min(earliest, execution.deadlineAt?.getTime() ?? Number.POSITIVE_INFINITY),
+        Number.POSITIVE_INFINITY,
+      );
+      if (Number.isFinite(deadline))
+        await this.database.limitAgentExecutionDeadline(input.executionId, new Date(deadline));
       await this.database.attachExecutionToSession(input.executionId, id);
       let action: "created" | "continued" | "restored" = "continued";
       if (session.agentId === null) {
@@ -127,26 +159,42 @@ export class AgentSessions {
         action = "restored";
       }
       await this.database.attachExecutionToSession(input.executionId, id, action);
-      const unsubscribe = await input.connection.watch(session.agentId, input.onEvent);
-      try {
-        const execution = await this.database.findAgentExecutionById(input.executionId);
-        if (!execution || execution.status === "failed" || execution.status === "succeeded") {
-          throw new AgentSessionError("execution_terminal");
-        }
-        await input.connection.send(
-          session.agentId,
-          input.executionId,
-          policy === undefined
-            ? input.intent.prompt
-            : `Hub execution: ${input.executionId}\nUse this executionId for Hub tool calls for this request.\n\n${input.intent.prompt}`,
-          startupTimeoutMs,
-        );
-      } catch (error) {
-        unsubscribe();
-        throw error;
-      }
+      const unsubscribe = await this.deliver(input, session.agentId, startupTimeoutMs);
       return { agentId: session.agentId, unsubscribe, action };
     });
+    return dispatched ?? this.dispatch(input);
+  }
+
+  private async deliver(
+    input: {
+      executionId: string;
+      intent: LaunchMachineIntent;
+      connection: AgentConnection;
+      onEvent: (event: AgentEvent) => void;
+    },
+    agentId: string,
+    startupTimeoutMs: number,
+  ): Promise<() => void> {
+    const unsubscribe = await input.connection.watch(agentId, input.onEvent);
+    try {
+      const execution = await this.database.findAgentExecutionById(input.executionId);
+      if (!execution || !isActive(execution)) throw new AgentSessionError("execution_terminal");
+      if (execution.deadlineAt !== null && execution.deadlineAt.getTime() <= this.now()) {
+        throw new AgentSessionError("execution_deadline_exceeded");
+      }
+      await input.connection.send(
+        agentId,
+        input.executionId,
+        input.intent.continuation === undefined
+          ? input.intent.prompt
+          : `Hub execution: ${input.executionId}\nUse this executionId for Hub tool calls for this request.\n\n${input.intent.prompt}`,
+        startupTimeoutMs,
+      );
+      return unsubscribe;
+    } catch (error) {
+      unsubscribe();
+      throw error;
+    }
   }
 
   async control(
@@ -159,7 +207,7 @@ export class AgentSessions {
     const session = await this.database.findAgentSession(id);
     if (!session?.agentId || !session.workspaceId) return false;
     const { agentId, workspaceId } = session;
-    return this.database.withAdvisoryLock(`agent-session:${id}`, async () => {
+    return this.database.withAdvisoryLock(sessionLock(session), async () => {
       const executions = await this.database.listAgentSessionExecutions(id);
       // A completed arrival cannot stop work belonging to a newer arrival.
       if (executions.some((item) => item.status === "spawning" || item.status === "running"))
@@ -168,9 +216,38 @@ export class AgentSessions {
       return true;
     });
   }
+
+  async releaseAuthority(
+    execution: AgentExecutionRecord,
+    release: (executionId: string) => Promise<void>,
+  ): Promise<void> {
+    const sessionId = execution.agentSessionId;
+    const session =
+      sessionId === null ? undefined : await this.database.findAgentSession(sessionId);
+    const owners =
+      sessionId === null || !session
+        ? [execution.id]
+        : await this.database.withAdvisoryLock(sessionLock(session), async () => {
+            const executions = await this.database.listAgentSessionExecutions(sessionId);
+            if (executions.some((item) => item.status === "spawning" || item.status === "running"))
+              return [];
+            return executions.map((item) => item.id);
+          });
+    // Revocation can call upstream services; do not keep a database lock while it runs.
+    await Promise.all(owners.map(release));
+  }
+
+  async canResumeAuthority(
+    execution: AgentExecutionRecord,
+    available: (executionId: string) => boolean,
+  ): Promise<boolean> {
+    if (execution.agentSessionId === null) return available(execution.id);
+    const owners = await this.database.listAgentSessionExecutions(execution.agentSessionId);
+    return owners.some((owner) => available(owner.id));
+  }
 }
 
-function sessionId(projectId: string, key: string): string {
+function deriveSessionId(projectId: string, key: string): string {
   const hex = createHash("sha256")
     .update(JSON.stringify(["agent-session", projectId, key]))
     .digest("hex");
@@ -186,4 +263,19 @@ function fingerprint(value: unknown): string {
       ),
     )
     .digest("hex");
+}
+
+function isActive(execution: AgentExecutionRecord): boolean {
+  return execution.status === "spawning" || execution.status === "running";
+}
+function hasTemporaryCredentials(intent: LaunchMachineIntent): boolean {
+  return (
+    intent.github !== undefined ||
+    Object.values({ ...intent.environment.env, ...intent.env }).some(
+      (value) => parseConnectionTemplate(value).length > 0,
+    )
+  );
+}
+function sessionLock(session: AgentSessionRecord): string {
+  return `agent-session:${session.continuationKey === null ? session.id : deriveSessionId(session.projectId, session.continuationKey)}`;
 }

--- a/src/daemons/daemons.test.ts
+++ b/src/daemons/daemons.test.ts
@@ -532,6 +532,88 @@ describe("daemon enrollment and execution", () => {
     assert.deepEqual(hub.authorityRevokedTokens(), ["durable-scoped-token-1"]);
   });
 
+  it("keeps scoped credentials until all requests steering the active agent finish", async () => {
+    await hub.connectDaemon();
+    const settings = {
+      continuation: { key: "same-thread", compatibility: { target: "same-repository" } },
+      github: {
+        connection: "getpaseo-github",
+        repositories: ["getpaseo/paseo"],
+        permissions: { contents: "write" as const },
+        durationMs: 60 * 60 * 1000,
+      },
+    };
+    const first = await hub.handoff(settings);
+    await hub.waitForCreatedAgentLaunch();
+    await hub.advanceDispatchTime(1_000);
+    const next = await hub.handoff(settings);
+    await hub.waitForRecoveredExecution(next.execution.id);
+
+    assert.equal(hub.createdAgentRequestCount(), 1);
+    assert.equal(hub.authorityMintInputs().length, 1);
+    assert.equal(
+      (await hub.execution(next.execution.id)).deadlineAt?.getTime(),
+      (await hub.execution(first.execution.id)).deadlineAt?.getTime(),
+    );
+    assert.equal(
+      Reflect.get(Object(hub.createdAgentLaunch().env), "GH_TOKEN"),
+      "durable-scoped-token-1",
+    );
+    await hub.callSessionTool(first.execution.id, "finish_execution");
+    assert.equal((await hub.execution(first.execution.id)).status, "succeeded");
+    assert.deepEqual(hub.authorityRevokedTokens(), []);
+
+    await hub.disconnectDaemon();
+    await hub.reconnectDaemon();
+    await hub.waitForRecoveredExecution(next.execution.id);
+    assert.equal(hub.createdAgentRequestCount(), 1);
+    assert.equal(hub.authorityMintInputs().length, 1);
+
+    await hub.callSessionTool(next.execution.id, "finish_execution");
+    assert.equal((await hub.execution(next.execution.id)).status, "succeeded");
+    assert.deepEqual(hub.authorityRevokedTokens(), ["durable-scoped-token-1"]);
+
+    const later = await hub.handoff(settings);
+    await hub.waitForRecoveredExecution(later.execution.id);
+    assert.equal(hub.createdAgentRequestCount(), 2);
+    assert.equal(hub.authorityMintInputs().length, 2);
+    assert.notEqual(
+      (await hub.execution(later.execution.id)).agentSessionId,
+      (await hub.execution(first.execution.id)).agentSessionId,
+    );
+    await hub.callSessionTool(later.execution.id, "finish_execution");
+    assert.equal((await hub.execution(later.execution.id)).status, "succeeded");
+    assert.deepEqual(hub.authorityRevokedTokens(), [
+      "durable-scoped-token-1",
+      "durable-scoped-token-2",
+    ]);
+  });
+
+  it("stops all steered requests and revokes their scoped credentials at the original hard deadline", async () => {
+    await hub.connectDaemon();
+    const settings = {
+      timeoutMs: 10_000,
+      continuation: { key: "bounded-thread", compatibility: { target: "same-repository" } },
+      github: {
+        connection: "getpaseo-github",
+        repositories: ["getpaseo/paseo"],
+        permissions: { contents: "write" as const },
+        durationMs: 60 * 60 * 1000,
+      },
+    };
+    const first = await hub.handoff(settings);
+    await hub.waitForCreatedAgentLaunch();
+    await hub.advanceDispatchTime(5_000);
+    const next = await hub.handoff(settings);
+    await hub.waitForRecoveredExecution(next.execution.id);
+
+    await hub.advanceDispatchTime(5_000);
+    assert.equal((await hub.execution(first.execution.id)).status, "failed");
+    assert.equal((await hub.execution(next.execution.id)).status, "failed");
+    assert.ok(hub.controlActions().includes("interrupt"));
+    assert.deepEqual(hub.authorityRevokedTokens(), ["durable-scoped-token-1"]);
+  });
+
   it("fails recovery of revoked scoped credentials without recreating the agent or reminting", async () => {
     await hub.connectDaemon();
     const handedOff = await hub.handoff({

--- a/src/daemons/daemons.test.ts
+++ b/src/daemons/daemons.test.ts
@@ -589,30 +589,39 @@ describe("daemon enrollment and execution", () => {
     ]);
   });
 
-  it("stops all steered requests and revokes their scoped credentials at the original hard deadline", async () => {
-    await hub.connectDaemon();
-    const settings = {
-      timeoutMs: 10_000,
-      continuation: { key: "bounded-thread", compatibility: { target: "same-repository" } },
-      github: {
-        connection: "getpaseo-github",
-        repositories: ["getpaseo/paseo"],
-        permissions: { contents: "write" as const },
-        durationMs: 60 * 60 * 1000,
-      },
-    };
-    const first = await hub.handoff(settings);
-    await hub.waitForCreatedAgentLaunch();
-    await hub.advanceDispatchTime(5_000);
-    const next = await hub.handoff(settings);
-    await hub.waitForRecoveredExecution(next.execution.id);
+  it.each(["agent", "workflow"])(
+    "stops steered requests and revokes credentials at the hard deadline via %s",
+    async (deadlineOwner) => {
+      await hub.connectDaemon();
+      const settings = {
+        timeoutMs: 10_000,
+        continuation: { key: "bounded-thread", compatibility: { target: "same-repository" } },
+        github: {
+          connection: "getpaseo-github",
+          repositories: ["getpaseo/paseo"],
+          permissions: { contents: "write" as const },
+          durationMs: 60 * 60 * 1000,
+        },
+      };
+      const first = await hub.handoff(settings);
+      await hub.waitForCreatedAgentLaunch();
+      await hub.advanceDispatchTime(5_000);
+      const next = await hub.handoff(settings);
+      await hub.waitForRecoveredExecution(next.execution.id, "running");
 
-    await hub.advanceDispatchTime(5_000);
-    assert.equal((await hub.execution(first.execution.id)).status, "failed");
-    assert.equal((await hub.execution(next.execution.id)).status, "failed");
-    assert.ok(hub.controlActions().includes("interrupt"));
-    assert.deepEqual(hub.authorityRevokedTokens(), ["durable-scoped-token-1"]);
-  });
+      if (deadlineOwner === "workflow") {
+        hub.advanceDispatchClock(5_000);
+        await hub.drainWorkflowOutbox();
+      } else {
+        await hub.advanceDispatchTime(5_000);
+      }
+      await hub.waitForExecutionStatus(first.execution.id, "failed");
+      await hub.waitForExecutionStatus(next.execution.id, "failed");
+      await hub.waitForControlAction("interrupt");
+      await hub.waitForAuthorityRevocation();
+      assert.deepEqual(hub.authorityRevokedTokens(), ["durable-scoped-token-1"]);
+    },
+  );
 
   it("fails recovery of revoked scoped credentials without recreating the agent or reminting", async () => {
     await hub.connectDaemon();

--- a/src/daemons/lifecycle.ts
+++ b/src/daemons/lifecycle.ts
@@ -929,6 +929,10 @@ export class DaemonDispatchLifecycle {
       this.clearExecutionDeadline(executionId);
       this.releaseExecutionResources(executionId);
       this.startedExecutions.delete(executionId);
+      const execution = await this.options.database.findAgentExecutionById(executionId);
+      if (execution && isTerminalExecutionStatus(execution.status)) {
+        await this.notifyExecutionTerminal(execution);
+      }
     }
     await this.recoverPendingHubActions();
   }

--- a/src/daemons/lifecycle.ts
+++ b/src/daemons/lifecycle.ts
@@ -1010,13 +1010,15 @@ export class DaemonDispatchLifecycle {
     if (
       current.agentSessionId !== null &&
       this.options.executionAuthority &&
-      !this.options.executionAuthority.canResume({
-        executionId: current.id,
-        projectId: intent.projectId,
-        triggerContext: intent.triggerContext,
-        env: { ...intent.environment.env, ...intent.env },
-        ...(intent.github === undefined ? {} : { github: intent.github }),
-      })
+      !(await this.sessionOwner().canResumeAuthority(current, (executionId) =>
+        this.options.executionAuthority!.canResume({
+          executionId,
+          projectId: intent.projectId,
+          triggerContext: intent.triggerContext,
+          env: { ...intent.environment.env, ...intent.env },
+          ...(intent.github === undefined ? {} : { github: intent.github }),
+        }),
+      ))
     ) {
       await this.failAgentExecution(current.id, "execution_credentials_unavailable");
       return;
@@ -1381,19 +1383,18 @@ export class DaemonDispatchLifecycle {
         this.report(error, "daemon.provider.terminal-cleanup", { executionId: execution.id });
       });
     }
-    await Promise.all(
-      this.options.executionAuthority === undefined
-        ? []
-        : [
-            this.options.executionAuthority
-              .onExecutionTerminal(execution.id)
-              .catch((error: unknown) => {
-                this.report(error, "daemon.execution-authority.terminal-cleanup", {
-                  executionId: execution.id,
-                });
-              }),
-          ],
-    );
+    const authority = this.options.executionAuthority;
+    if (authority === undefined) return;
+    const release = (executionId: string) => authority.onExecutionTerminal(executionId);
+    await (
+      execution.agentSessionId === null
+        ? release(execution.id)
+        : this.sessionOwner().releaseAuthority(execution, release)
+    ).catch((error: unknown) => {
+      this.report(error, "daemon.execution-authority.terminal-cleanup", {
+        executionId: execution.id,
+      });
+    });
   }
 
   private async notifyMachineTerminatedForExecution(
@@ -1513,6 +1514,7 @@ export class DaemonDispatchLifecycle {
       this.options.completionTokenSecret,
       this.options.publicBaseUrl,
       this.executionCapabilities,
+      () => this.now(),
     );
   }
 

--- a/src/daemons/test-utils/hub-harness.ts
+++ b/src/daemons/test-utils/hub-harness.ts
@@ -135,6 +135,7 @@ const ExecutionSessionRequestSchema = z.object({
       agentId: z.string(),
       messageId: z.string(),
       text: z.string(),
+      activeTurnBehavior: z.literal("steer"),
     }),
     z.object({
       type: z.literal("cancel_agent_request"),
@@ -1160,6 +1161,36 @@ export class HubHarness {
         id: 1,
         method: "tools/call",
         params: { name, arguments: args },
+      }),
+    });
+    assert.equal(response.status, 200);
+    const body: unknown = await response.json();
+    assert.ok(isRecord(body));
+    return body;
+  }
+
+  async callSessionTool(
+    executionId: string,
+    name: "finish_execution" | "reply",
+    args: Record<string, unknown> = {},
+  ): Promise<Record<string, unknown>> {
+    const execution = await this.execution(executionId);
+    assert.ok(execution.agentSessionId);
+    const session = await this.requireDatabase().findAgentSession(execution.agentSessionId);
+    const mcp = session?.creationOptions.mcpServers?.["hub"];
+    assert.ok(mcp);
+    const response = await fetch(mcp.url, {
+      method: "POST",
+      headers: {
+        ...mcp.headers,
+        accept: "application/json, text/event-stream",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name, arguments: { ...args, executionId } },
       }),
     });
     assert.equal(response.status, 200);

--- a/src/daemons/test-utils/hub-harness.ts
+++ b/src/daemons/test-utils/hub-harness.ts
@@ -837,6 +837,9 @@ export class HubHarness {
   controlActions(): readonly HubExecutionControlAction[] {
     return this.requireDaemon().controlActions();
   }
+  async waitForControlAction(action: HubExecutionControlAction): Promise<void> {
+    await waitFor(async () => this.controlActions().includes(action));
+  }
   originUrl(): string {
     return this.origin;
   }

--- a/src/db/memory.ts
+++ b/src/db/memory.ts
@@ -1625,6 +1625,29 @@ class MemoryDatabase implements Database {
     return updated;
   }
 
+  async limitAgentExecutionDeadline(executionId: string, deadlineAt: Date) {
+    const execution = this.readAgentExecution(executionId);
+    if (isTerminalAgentExecutionStatus(execution.status)) return;
+    const boundedDeadline = new Date(
+      Math.min(deadlineAt.getTime(), execution.deadlineAt?.getTime() ?? Number.POSITIVE_INFINITY),
+    );
+    const idleDeadlineAt = capIdleDeadline(execution.idleDeadlineAt, boundedDeadline);
+    this.agentExecutions.set(executionId, {
+      ...execution,
+      deadlineAt: boundedDeadline,
+      idleDeadlineAt,
+    });
+    if (execution.workflowStepRunId !== null) {
+      const step = this.workflowStepRuns.get(execution.workflowStepRunId);
+      if (step !== undefined)
+        this.workflowStepRuns.set(step.id, {
+          ...step,
+          deadlineAt: boundedDeadline,
+          idleDeadlineAt,
+        });
+    }
+  }
+
   async setAgentExecutionIdleDeadline(
     executionId: string,
     idleDeadlineAt: Date | null,
@@ -2238,6 +2261,13 @@ class MemoryDatabase implements Database {
   >();
   async findAgentSession(id: string) {
     return structuredClone(this.agentSessions.get(id));
+  }
+  async findAgentSessionByKey(projectId: string, key: string) {
+    return structuredClone(
+      [...this.agentSessions.values()].find(
+        (session) => session.projectId === projectId && session.continuationKey === key,
+      ),
+    );
   }
   async saveAgentSession(
     session: import("../agent-sessions/index.js").AgentSessionRecord,

--- a/src/db/pg.ts
+++ b/src/db/pg.ts
@@ -1739,8 +1739,22 @@ class PgDatabase implements Database {
   }
 
   async limitAgentExecutionDeadline(executionId: string, deadlineAt: Date): Promise<void> {
-    await this.pool.query(
-      `with bounded as (
+    await this.pool.transaction(async (client) => {
+      // Match completion and deadline recovery: lock the run, then step, then execution.
+      const association = await client.query<{ id: string; trigger_run_id: string }>(
+        `select s.id, s.trigger_run_id from workflow_step_runs s
+         join agent_executions e on e.workflow_step_run_id = s.id where e.id = $1`,
+        [executionId],
+      );
+      const step = association.rows[0];
+      if (step) {
+        await client.query("select id from trigger_runs where id = $1 for update", [
+          step.trigger_run_id,
+        ]);
+        await client.query("select id from workflow_step_runs where id = $1 for update", [step.id]);
+      }
+      await client.query(
+        `with bounded as (
          update agent_executions
          set deadline_at = least(deadline_at, $2::timestamptz),
              idle_deadline_at = case when idle_deadline_at is null then null
@@ -1751,8 +1765,9 @@ class PgDatabase implements Database {
        update workflow_step_runs s
        set deadline_at = bounded.deadline_at, idle_deadline_at = bounded.idle_deadline_at
        from bounded where s.id = bounded.workflow_step_run_id`,
-      [executionId, deadlineAt],
-    );
+        [executionId, deadlineAt],
+      );
+    });
   }
 
   async setAgentExecutionIdleDeadline(

--- a/src/db/pg.ts
+++ b/src/db/pg.ts
@@ -1738,6 +1738,23 @@ class PgDatabase implements Database {
     return toAgentExecutionRecord(rows.rows[0]);
   }
 
+  async limitAgentExecutionDeadline(executionId: string, deadlineAt: Date): Promise<void> {
+    await this.pool.query(
+      `with bounded as (
+         update agent_executions
+         set deadline_at = least(deadline_at, $2::timestamptz),
+             idle_deadline_at = case when idle_deadline_at is null then null
+               else least(idle_deadline_at, deadline_at, $2::timestamptz) end
+         where id = $1 and status in ('spawning', 'running')
+         returning workflow_step_run_id, deadline_at, idle_deadline_at
+       )
+       update workflow_step_runs s
+       set deadline_at = bounded.deadline_at, idle_deadline_at = bounded.idle_deadline_at
+       from bounded where s.id = bounded.workflow_step_run_id`,
+      [executionId, deadlineAt],
+    );
+  }
+
   async setAgentExecutionIdleDeadline(
     executionId: string,
     idleDeadlineAt: Date | null,
@@ -2717,9 +2734,19 @@ class PgDatabase implements Database {
   ): Promise<void> {
     await this.pool.query(
       `insert into agent_sessions (id, organization_id, project_id, continuation_key, data)
-       values ($1, $2, $3, $4, $5) on conflict (id) do update set data = excluded.data`,
+       values ($1, $2, $3, $4, $5) on conflict (id) do update set data = excluded.data, continuation_key = excluded.continuation_key`,
       [session.id, session.organizationId, session.projectId, session.continuationKey, session],
     );
+  }
+
+  async findAgentSessionByKey(projectId: string, key: string) {
+    const result = await this.pool.query<{
+      data: import("../agent-sessions/index.js").AgentSessionRecord;
+    }>("select data from agent_sessions where project_id = $1 and continuation_key = $2", [
+      projectId,
+      key,
+    ]);
+    return result.rows[0]?.data;
   }
 
   async attachExecutionToSession(

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -1151,6 +1151,10 @@ export interface TerminateMachineFields {
 
 export interface Database {
   readonly schedules: import("../triggers/schedule/index.js").ScheduleStore;
+  findAgentSessionByKey(
+    projectId: string,
+    key: string,
+  ): Promise<import("../agent-sessions/index.js").AgentSessionRecord | undefined>;
   findAgentSession(
     id: string,
   ): Promise<import("../agent-sessions/index.js").AgentSessionRecord | undefined>;
@@ -1333,6 +1337,7 @@ export interface Database {
     observedAt: Date,
     processedAt: Date,
   ): Promise<AgentExecutionRecord>;
+  limitAgentExecutionDeadline(executionId: string, deadlineAt: Date): Promise<void>;
   prepareAgentExecutionForDispatch(
     executionId: string,
     daemonId: string,


### PR DESCRIPTION
Repeated messages in a conversation can steer the active agent while retaining its scoped credentials. Steering keeps the original credential expiry and hard runtime deadline. Once all requests finish, the next credentialed task starts with a fresh agent and freshly materialized credentials.

## Goals

- Allow active continuation with GitHub grants and connection-derived environment credentials.
- Keep shared credentials available until all overlapping requests finish, including across daemon reconnects.
- Enforce the original hard deadline and isolate later tasks from a completed session's tools and credentials.

## Non-goals

- Credential renewal, broader permissions, or changing configured token lifetimes.
- Trigger configuration migration or deployment.

## Why

The continuation guard rejected temporary credentials before checking whether an agent was still active. Removing that guard alone would let an earlier request revoke credentials still needed by a follow-up, and would reuse revoked credentials after completion. Session selection and terminal cleanup now account for the lifetime of overlapping requests. Follow-ups also inherit the active session's earliest hard deadline instead of extending continuous runtime.

## Verification

Failing-first regressions cover credentialed steering, premature revocation, reconnect recovery, hard deadlines, and isolation after completion. The PostgreSQL/HTTP/WebSocket integration checks one worker and one token across active follow-ups, then a fresh worker/token for a later task.

Before rebasing onto the startup-timeout fix, the full suite passed: 1,316 tests, 8 source-daemon E2Es, and 79 browser cases (one browser test was rerun with the required source-checkout setting; one case was skipped). Typecheck, lint, formatting, database drift, production build, and Docker smoke checks passed.

After rebasing onto #130, all 148 tests across the agent-session, daemon lifecycle, daemon transport, daemon integration, and execution-authority files passed. Typecheck, lint, formatting, the production build, and all 8 source-daemon E2Es also passed again.

## Risk surface

Review concurrent arrivals, completion versus delivery, and cleanup/reconnect behavior. Credentialed sessions now start fresh after all requests become terminal; sessions without temporary environment credentials retain their existing restore behavior. The configured startup timeout remains independent of the hard runtime deadline. No database schema or daemon protocol change is required.

Refs #118 and #36.

Companion public documentation: https://github.com/getpaseo/paseo/pull/4607.


## Deadline verification

Deadline updates now follow the existing run → step → execution database lock order. Workflow deadline recovery invokes terminal credential cleanup, matching the agent deadline path. The integration regression covers both paths and waits for observed request failure, interruption, and token revocation.
