### PR TITLE
Keep dashboard navigation aligned with the visible page

### DIFF
--- a/e2e/helpers/pending-navigation.ts
+++ b/e2e/helpers/pending-navigation.ts
@@ -1,0 +1,51 @@
+import { expect, type Page } from "@playwright/test";
+
+/** Hold real responses; the built route code and application services remain unchanged. */
+export async function holdPageScripts(page: Page) {
+  const pausedAt = new Date();
+  // Install before the pause target so browser RPC latency cannot put that target in the past.
+  await page.clock.install({ time: new Date(pausedAt.getTime() - 60_000) });
+  await page.clock.pauseAt(pausedAt);
+  const requests = await holdRequests(page, /\/assets\/.*\.js(?:\?.*)?$/u);
+  return {
+    requested: requests.requested,
+    showPendingPage: async () => {
+      // Advance Router's pending threshold without a wall-clock race.
+      await page.clock.runFor(1000);
+      await expect(page.getByRole("region", { name: "Loading page", exact: true })).toBeVisible();
+    },
+    release: async () => {
+      await page.clock.resume();
+      await requests.release();
+    },
+  };
+}
+
+export function holdPageData(page: Page) {
+  return holdRequests(page, /\/_serverFn\//u);
+}
+
+async function holdRequests(page: Page, pattern: RegExp) {
+  let requestReceived = () => {};
+  const requested = new Promise<void>((resolve) => {
+    requestReceived = resolve;
+  });
+  let releaseRequests = () => {};
+  const released = new Promise<void>((resolve) => {
+    releaseRequests = resolve;
+  });
+  await page.route(pattern, async (route) => {
+    requestReceived();
+    await released;
+    await route.continue();
+  });
+  return {
+    requested,
+    release: async () => {
+      releaseRequests();
+      await page.unrouteAll({ behavior: "wait" });
+      // Observe the result after the held downloads arrive, including a superseded route's code.
+      await page.waitForLoadState("networkidle");
+    },
+  };
+}

--- a/e2e/navigation-pending.spec.ts
+++ b/e2e/navigation-pending.spec.ts
@@ -1,0 +1,182 @@
+import { expect, type Page } from "@playwright/test";
+import { test } from "./app.js";
+import type { PaseoHub } from "./helpers/hub.js";
+import { projectApp } from "./helpers/projects/index.js";
+import { holdPageScripts, holdPageData } from "./helpers/pending-navigation.js";
+import { OrganizationTriggers } from "./helpers/triggers.js";
+
+const owner = {
+  name: "Alice",
+  email: "alice-navigation-pending@example.com",
+  password: "alice-navigation-pending-password",
+};
+
+test("keeps shell and body together through a slow download and cached navigation", async ({
+  hub,
+  page,
+}) => {
+  await openOrganization(hub, page);
+  const download = await holdPageScripts(page);
+  try {
+    await projectApp(page).navigation.openOrganizationSection("Daemons");
+    await download.requested;
+    await expectOrganizationPage(page, "Triggers");
+    await download.showPendingPage();
+    await expectOrganizationDestination(page, "Daemons");
+    await expect(page.getByRole("heading", { name: "Triggers", exact: true })).toBeHidden();
+  } finally {
+    await download.release();
+  }
+  await expectOrganizationPage(page, "Daemons");
+  await projectApp(page).navigation.openOrganizationSection("Triggers");
+  await expectOrganizationPage(page, "Triggers");
+  await projectApp(page).navigation.openOrganizationSection("Daemons");
+  await expectOrganizationPage(page, "Daemons");
+  await page.goBack();
+  await expectOrganizationPage(page, "Triggers");
+});
+
+test("a later navigation wins while an earlier download is pending", async ({ hub, page }) => {
+  await openOrganization(hub, page);
+  const download = await holdPageScripts(page);
+  try {
+    await projectApp(page).navigation.openOrganizationSection("Daemons");
+    await download.requested;
+    await download.showPendingPage();
+    await projectApp(page).navigation.openOrganizationSection("Triggers");
+    await expectOrganizationPage(page, "Triggers");
+  } finally {
+    await download.release();
+  }
+  await expectOrganizationPage(page, "Triggers");
+  await expect(page.getByRole("heading", { name: "Daemons", exact: true })).toBeHidden();
+});
+
+test("keeps settings tabs aligned through pending navigation and Back", async ({ hub, page }) => {
+  await openOrganization(hub, page);
+  await projectApp(page).navigation.openOrganizationSection("Settings");
+  await expectSettingsPage(page, "Team");
+  const download = await holdPageScripts(page);
+  try {
+    await openSettingsTab(page, "Usage");
+    await download.requested;
+    await expectSettingsPage(page, "Team");
+    await download.showPendingPage();
+    await expectSettingsDestination(page, "Usage");
+    await expect(page.getByRole("heading", { name: "Team", exact: true })).toBeHidden();
+    await page.goBack();
+    await expectSettingsPage(page, "Team");
+  } finally {
+    await download.release();
+  }
+  await expectSettingsPage(page, "Team");
+});
+
+test("switches organization and instance context with the presented page", async ({
+  hub,
+  page,
+}) => {
+  await openOrganization(hub, page);
+  await hub.grantOperator("owner");
+  await expectOrganizationPage(page, "Triggers");
+  const download = await holdPageScripts(page);
+  try {
+    await enterInstance(page);
+    await download.requested;
+    await expectOrganizationPage(page, "Triggers");
+    await download.showPendingPage();
+    await projectApp(page).navigation.expectBreadcrumb("Instance", "Apps");
+    await expect(page.getByRole("navigation", { name: "Instance", exact: true })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Triggers", exact: true })).toBeHidden();
+  } finally {
+    await download.release();
+  }
+  await expect(page.getByRole("heading", { name: "Apps", exact: true })).toBeVisible();
+  await projectApp(page).navigation.leaveInstance();
+  await expectOrganizationPage(page, "Triggers");
+});
+
+test("removes the previous page's header actions when its replacement is presented", async ({
+  hub,
+  page,
+}) => {
+  await openOrganization(hub, page);
+  await new OrganizationTriggers(page).startNew();
+  const download = await holdPageScripts(page);
+  try {
+    await projectApp(page).navigation.openOrganizationSection("Daemons");
+    await download.requested;
+    await projectApp(page).navigation.expectBreadcrumb("Acme", "Triggers", "Trigger editor");
+    await expect(page.getByRole("radio", { name: "Form", exact: true })).toBeVisible();
+    await download.showPendingPage();
+    await expectOrganizationDestination(page, "Daemons");
+    await expect(page.getByRole("radio", { name: "Form", exact: true })).toBeHidden();
+  } finally {
+    await download.release();
+  }
+  await expectOrganizationPage(page, "Daemons");
+});
+
+test("replaces the old body while destination data is delayed", async ({ hub, page }) => {
+  await openOrganization(hub, page);
+  const data = await holdPageData(page);
+  try {
+    await projectApp(page).navigation.openOrganizationSection("Daemons");
+    await data.requested;
+    await expectOrganizationPage(page, "Daemons");
+    await expect(page.getByRole("heading", { name: "Triggers", exact: true })).toBeHidden();
+  } finally {
+    await data.release();
+  }
+  await expectOrganizationPage(page, "Daemons");
+});
+
+async function openOrganization(hub: PaseoHub, page: Page) {
+  await hub.signUpAs("owner", owner);
+  await hub.createOrganization("owner", "Acme");
+  await expectOrganizationPage(page, "Triggers");
+}
+
+async function expectOrganizationDestination(page: Page, name: string) {
+  await projectApp(page).navigation.expectBreadcrumb("Acme", name);
+  await expect(
+    page
+      .getByRole("navigation", { name: "Organization", exact: true })
+      .getByRole("link", { name, exact: true }),
+  ).toHaveAttribute("aria-current", "page");
+  await expect(page.getByRole("button", { name: "Organization", exact: true })).toContainText(
+    "Acme",
+  );
+}
+
+async function expectOrganizationPage(page: Page, name: string) {
+  await expectOrganizationDestination(page, name);
+  await expect(page.getByRole("heading", { name, exact: true, level: 1 })).toBeVisible();
+  await expect(page.getByRole("region", { name: "Loading page", exact: true })).toBeHidden();
+}
+
+async function openSettingsTab(page: Page, name: string) {
+  await page
+    .getByRole("navigation", { name: "Organization settings" })
+    .getByRole("link", { name, exact: true })
+    .click();
+}
+
+async function expectSettingsDestination(page: Page, name: string) {
+  await projectApp(page).navigation.expectBreadcrumb("Acme", "Settings", name);
+  await expect(
+    page
+      .getByRole("navigation", { name: "Organization settings" })
+      .getByRole("link", { name, exact: true }),
+  ).toHaveAttribute("aria-current", "page");
+}
+
+async function expectSettingsPage(page: Page, name: string) {
+  await expectSettingsDestination(page, name);
+  await expect(page.getByRole("heading", { name, exact: true, level: 1 })).toBeVisible();
+}
+
+async function enterInstance(page: Page) {
+  const menu = await projectApp(page).navigation.openAccountMenu(owner.email);
+  await menu.getByRole("menuitem", { name: "Instance administration" }).click();
+}

--- a/src/components/app/tab-nav.tsx
+++ b/src/components/app/tab-nav.tsx
@@ -1,7 +1,6 @@
 /* oxlint-disable typescript-eslint/no-unsafe-type-assertion -- tenant-scoped paths are assembled from server-resolved route metadata */
-import { Link } from "@tanstack/react-router";
+import { Link, trimPathRight, useMatches } from "@tanstack/react-router";
 
-import { usePresentedPathname } from "../../navigation/index.js";
 import { cn } from "../../lib/utils.js";
 import { Skeleton } from "../ui/skeleton.js";
 
@@ -19,7 +18,7 @@ export interface TabNavItem {
  * These are routes. A control that swaps state without changing the URL is `SegmentedControl`.
  */
 export function TabNav({ label, items }: { label: string; items: readonly TabNavItem[] }) {
-  const pathname = usePresentedPathname();
+  const pathname = useMatches({ select: (matches) => trimPathRight(matches.at(-1)!.pathname) });
   return (
     <nav aria-label={label} className="mb-6 flex flex-wrap gap-4 border-b">
       {items.map((item) => {

--- a/src/components/app/tab-nav.tsx
+++ b/src/components/app/tab-nav.tsx
@@ -1,6 +1,7 @@
 /* oxlint-disable typescript-eslint/no-unsafe-type-assertion -- tenant-scoped paths are assembled from server-resolved route metadata */
-import { Link, useRouterState } from "@tanstack/react-router";
+import { Link } from "@tanstack/react-router";
 
+import { usePresentedPathname } from "../../navigation/index.js";
 import { cn } from "../../lib/utils.js";
 import { Skeleton } from "../ui/skeleton.js";
 
@@ -18,7 +19,7 @@ export interface TabNavItem {
  * These are routes. A control that swaps state without changing the URL is `SegmentedControl`.
  */
 export function TabNav({ label, items }: { label: string; items: readonly TabNavItem[] }) {
-  const pathname = useRouterState({ select: (state) => state.location.pathname });
+  const pathname = usePresentedPathname();
   return (
     <nav aria-label={label} className="mb-6 flex flex-wrap gap-4 border-b">
       {items.map((item) => {

--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -1,0 +1,10 @@
+import { trimPathRight, useMatches } from "@tanstack/react-router";
+
+/**
+ * The route the outlet is presenting, including its pending state. The browser's location
+ * advances before that presentation changes; using it for page context mislabels the old page.
+ */
+export function usePresentedPathname(): string {
+  // Index matches end in a slash even when their public URL does not.
+  return useMatches({ select: (matches) => trimPathRight(matches.at(-1)!.pathname) });
+}

--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -1,10 +1,55 @@
 import { trimPathRight, useMatches } from "@tanstack/react-router";
 
-/**
- * The route the outlet is presenting, including its pending state. The browser's location
- * advances before that presentation changes; using it for page context mislabels the old page.
- */
-export function usePresentedPathname(): string {
-  // Index matches end in a slash even when their public URL does not.
-  return useMatches({ select: (matches) => trimPathRight(matches.at(-1)!.pathname) });
+declare module "@tanstack/react-router" {
+  interface StaticDataRouteOption {
+    breadcrumb?: string;
+    instance?: boolean;
+    tabs?: boolean;
+    projectSection?: "overview" | "configuration" | "activity" | "settings";
+  }
+}
+
+/** Shared layout context comes from the routes TanStack is presenting, including pending UI. */
+export function usePageContext() {
+  return useMatches({
+    select: (matches) => ({
+      breadcrumbs: matches.flatMap(({ staticData }) =>
+        staticData.breadcrumb === undefined ? [] : [staticData.breadcrumb],
+      ),
+      instance: matches.some(({ staticData }) => staticData.instance === true),
+      tabs: matches.some(({ staticData }) => staticData.tabs === true),
+      projectSection:
+        matches
+          .flatMap(({ staticData }) =>
+            staticData.projectSection === undefined ? [] : [staticData.projectSection],
+          )
+          .at(-1) ?? "overview",
+    }),
+    structuralSharing: true,
+  });
+}
+
+/** Parameters are already decoded by the router; never reconstruct tenant identity from a URL. */
+export function usePresentedTenantScope():
+  | { organizationSlug: string; projectSlug?: string }
+  | undefined {
+  return useMatches({
+    select: (matches) => {
+      const params = matches.at(-1)!.params;
+      return "organizationSlug" in params
+        ? { organizationSlug: params.organizationSlug }
+        : undefined;
+    },
+    structuralSharing: true,
+  });
+}
+
+/** Links reflect the presented route tree, rather than the URL of an unfinished navigation. */
+export function usePresentedDestination(to: string, subtree = false): boolean {
+  return useMatches({
+    select: (matches) =>
+      (subtree ? matches : matches.slice(-1)).some(
+        (match) => trimPathRight(match.pathname) === trimPathRight(to),
+      ),
+  });
 }

--- a/src/projects/context.tsx
+++ b/src/projects/context.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
-import { useRouterState } from "@tanstack/react-router";
 import { useServerFn } from "@tanstack/react-start";
 import { createContext, useContext, useMemo, type ReactNode } from "react";
+import { usePresentedPathname } from "../navigation/index.js";
 import { tenantContext } from "./functions.js";
 import type { ProjectDashboard } from "./dashboard.js";
 
@@ -25,7 +25,7 @@ const ProjectTenantContext = createContext<TenantContextValue | null>(null);
 const RouteTenantStatusContext = createContext<RouteTenantStatus>({ state: "outside" });
 
 export function RouteTenantProvider({ children }: { children: ReactNode }) {
-  const pathname = useRouterState({ select: (state) => state.location.pathname });
+  const pathname = usePresentedPathname();
   const scope = routeScope(pathname);
   const load = useServerFn(tenantContext);
   const snapshot = useQuery({

--- a/src/projects/context.tsx
+++ b/src/projects/context.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { useServerFn } from "@tanstack/react-start";
 import { createContext, useContext, useMemo, type ReactNode } from "react";
-import { usePresentedPathname } from "../navigation/index.js";
+import { usePresentedTenantScope } from "../navigation/index.js";
 import { tenantContext } from "./functions.js";
 import type { ProjectDashboard } from "./dashboard.js";
 
@@ -25,8 +25,7 @@ const ProjectTenantContext = createContext<TenantContextValue | null>(null);
 const RouteTenantStatusContext = createContext<RouteTenantStatus>({ state: "outside" });
 
 export function RouteTenantProvider({ children }: { children: ReactNode }) {
-  const pathname = usePresentedPathname();
-  const scope = routeScope(pathname);
+  const scope = usePresentedTenantScope();
   const load = useServerFn(tenantContext);
   const snapshot = useQuery({
     queryKey: ["tenant", scope?.organizationSlug, scope?.projectSlug],
@@ -88,17 +87,4 @@ export function useOptionalRouteTenant(): TenantContextValue | null {
 
 export function useRouteTenantStatus(): RouteTenantStatus {
   return useContext(RouteTenantStatusContext);
-}
-
-export function routeScope(
-  pathname: string,
-): { organizationSlug: string; projectSlug?: string } | undefined {
-  const segments = pathname.split("/").filter(Boolean);
-  if (segments[0] !== "o" || segments[1] === undefined) return undefined;
-  const projectIndex = segments.indexOf("projects");
-  const projectSlug = projectIndex >= 0 ? segments[projectIndex + 1] : undefined;
-  return {
-    organizationSlug: decodeURIComponent(segments[1]),
-    ...(projectSlug === undefined ? {} : { projectSlug: decodeURIComponent(projectSlug) }),
-  };
 }

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,6 +1,7 @@
 import { createRouter } from "@tanstack/react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { routeTree } from "./routeTree.gen";
+import { PanelSkeleton } from "./components/app/loading.js";
 
 export function getRouter() {
   const queryClient = new QueryClient({
@@ -9,6 +10,7 @@ export function getRouter() {
   return createRouter({
     routeTree,
     scrollRestoration: true,
+    defaultPendingComponent: () => <PanelSkeleton label="Loading page" />,
     context: { queryClient },
     Wrap: ({ children }) => (
       <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>

--- a/src/routes/_shell/apps.tsx
+++ b/src/routes/_shell/apps.tsx
@@ -1,4 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { AppsPanel } from "../../provider-applications/panel.js";
 
-export const Route = createFileRoute("/_shell/apps")({ component: AppsPanel });
+export const Route = createFileRoute("/_shell/apps")({
+  staticData: { breadcrumb: "Apps", instance: true },
+  component: AppsPanel,
+});

--- a/src/routes/_shell/cli-login.tsx
+++ b/src/routes/_shell/cli-login.tsx
@@ -2,7 +2,10 @@ import { createFileRoute } from "@tanstack/react-router";
 import { useActiveAccount } from "../../auth/active-account.js";
 import { CliLoginApproval } from "../../cli-authorizations/approval.js";
 
-export const Route = createFileRoute("/_shell/cli-login")({ component: CliLogin });
+export const Route = createFileRoute("/_shell/cli-login")({
+  staticData: { breadcrumb: "CLI login" },
+  component: CliLogin,
+});
 
 function CliLogin() {
   const account = useActiveAccount();

--- a/src/routes/_shell/o/$organizationSlug/activity.tsx
+++ b/src/routes/_shell/o/$organizationSlug/activity.tsx
@@ -2,5 +2,6 @@ import { createFileRoute } from "@tanstack/react-router";
 import { TriggerActivityPanel } from "../../../../triggers/activity-panel.js";
 
 export const Route = createFileRoute("/_shell/o/$organizationSlug/activity")({
+  staticData: { breadcrumb: "Activity", projectSection: "activity" },
   component: TriggerActivityPanel,
 });

--- a/src/routes/_shell/o/$organizationSlug/connections.tsx
+++ b/src/routes/_shell/o/$organizationSlug/connections.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { OrganizationConnectionsPanel } from "../../../../projects/panels.js";
 export const Route = createFileRoute("/_shell/o/$organizationSlug/connections")({
+  staticData: { breadcrumb: "Connections" },
   component: OrganizationConnectionsPanel,
 });

--- a/src/routes/_shell/o/$organizationSlug/daemons.tsx
+++ b/src/routes/_shell/o/$organizationSlug/daemons.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { OrganizationDaemonsPanel } from "../../../../projects/panels.js";
 export const Route = createFileRoute("/_shell/o/$organizationSlug/daemons")({
+  staticData: { breadcrumb: "Daemons" },
   component: OrganizationDaemonsPanel,
 });

--- a/src/routes/_shell/o/$organizationSlug/settings.tsx
+++ b/src/routes/_shell/o/$organizationSlug/settings.tsx
@@ -5,5 +5,6 @@ import { OrganizationSettingsLayout } from "../../../../auth/organization-settin
 // occasionally, so they sit under one sidebar entry instead of competing with Projects, Daemons,
 // and Connections for attention.
 export const Route = createFileRoute("/_shell/o/$organizationSlug/settings")({
+  staticData: { breadcrumb: "Settings", tabs: true },
   component: OrganizationSettingsLayout,
 });

--- a/src/routes/_shell/o/$organizationSlug/settings/api-keys.tsx
+++ b/src/routes/_shell/o/$organizationSlug/settings/api-keys.tsx
@@ -2,5 +2,6 @@ import { createFileRoute } from "@tanstack/react-router";
 import { ApiKeys } from "../../../../../auth/api-key-panel.js";
 
 export const Route = createFileRoute("/_shell/o/$organizationSlug/settings/api-keys")({
+  staticData: { breadcrumb: "API keys" },
   component: ApiKeys,
 });

--- a/src/routes/_shell/o/$organizationSlug/settings/billing.tsx
+++ b/src/routes/_shell/o/$organizationSlug/settings/billing.tsx
@@ -11,6 +11,7 @@ import { billingConfigured } from "../../../../../server/capabilities.js";
 // so it is exempted from the src/billing/ import boundary in oxlint.json, which lets the whole
 // feature (server + UI) live under src/billing/ and be deleted as one directory.
 export const Route = createFileRoute("/_shell/o/$organizationSlug/settings/billing")({
+  staticData: { breadcrumb: "Billing" },
   // `?plans` arrives from surfaces that hit a plan limit — the locked invite control on Team — so
   // the picker is open on arrival instead of asking the customer to find it again.
   validateSearch: z.object({ plans: z.boolean().optional() }),

--- a/src/routes/_shell/o/$organizationSlug/settings/team.tsx
+++ b/src/routes/_shell/o/$organizationSlug/settings/team.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { Team } from "../../../../../auth/team.js";
 export const Route = createFileRoute("/_shell/o/$organizationSlug/settings/team")({
+  staticData: { breadcrumb: "Team" },
   component: Team,
 });

--- a/src/routes/_shell/o/$organizationSlug/settings/usage.tsx
+++ b/src/routes/_shell/o/$organizationSlug/settings/usage.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { OrganizationUsagePanel } from "../../../../../usage/panel.js";
 export const Route = createFileRoute("/_shell/o/$organizationSlug/settings/usage")({
+  staticData: { breadcrumb: "Usage" },
   component: OrganizationUsagePanel,
 });

--- a/src/routes/_shell/o/$organizationSlug/triggers.tsx
+++ b/src/routes/_shell/o/$organizationSlug/triggers.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/_shell/o/$organizationSlug/triggers")({
+  staticData: { breadcrumb: "Triggers" },
   component: Outlet,
 });

--- a/src/routes/_shell/o/$organizationSlug/triggers/$triggerId.tsx
+++ b/src/routes/_shell/o/$organizationSlug/triggers/$triggerId.tsx
@@ -2,6 +2,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import { TriggerEditorPanel } from "../../../../../triggers/panel.js";
 
 export const Route = createFileRoute("/_shell/o/$organizationSlug/triggers/$triggerId")({
+  staticData: { breadcrumb: "Trigger editor" },
   component: TriggerEditorRoute,
 });
 

--- a/src/routes/_shell/operator.tsx
+++ b/src/routes/_shell/operator.tsx
@@ -7,5 +7,6 @@ import { OperatorEntitlementsPage } from "../../operator/panel.js";
 // route sees only "You don't have operator access." The nav entry is gated separately as
 // presentation.
 export const Route = createFileRoute("/_shell/operator")({
+  staticData: { breadcrumb: "Operator", instance: true },
   component: OperatorEntitlementsPage,
 });

--- a/src/shell/dashboard-shell.tsx
+++ b/src/shell/dashboard-shell.tsx
@@ -15,7 +15,7 @@ import { Outlet } from "@tanstack/react-router";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useServerFn } from "@tanstack/react-start";
 import { useCallback } from "react";
-import { usePresentedPathname } from "../navigation/index.js";
+import { usePageContext } from "../navigation/index.js";
 import { Page } from "../components/app/page.js";
 import { FailureAlert } from "../components/app/failure-alert.js";
 import { PanelSkeleton } from "../components/app/loading.js";
@@ -52,7 +52,7 @@ import {
   ProjectSwitcher,
   type RouteTenant,
 } from "./switchers.js";
-import { routeSection, SiteHeader } from "./site-header.js";
+import { SiteHeader } from "./site-header.js";
 import { SiteHeaderActionsProvider } from "./site-header-actions.js";
 
 type ActiveAccount = ActiveAccountState;
@@ -208,16 +208,14 @@ function PageContent({
   transitioning: boolean;
 }) {
   const status = useRouteTenantStatus();
-  const pathname = usePresentedPathname();
+  const page = usePageContext();
   // One name for the slot, whichever read is in flight: switching organization and resolving the
   // tenant behind a URL are the same wait to someone listening to the page.
   if (transitioning || status.state === "pending") {
-    // The URL already says whether the page arriving here is one of the settings sections, and
+    // Route metadata says whether the page arriving here is one of the settings sections, and
     // those carry a tab strip above their own header. Holding that rail open is the difference
     // between a page that fills in and a page that drops when the tenant resolves.
-    const section = routeSection(pathname);
-    const tabs = section !== undefined && "group" in section;
-    return <PanelSkeleton label="Loading account context" tabs={tabs} />;
+    return <PanelSkeleton label="Loading account context" tabs={page.tabs} />;
   }
   if (status.state === "failed") {
     return <FailureAlert title={status.title} error={status.message} fallback={status.message} />;
@@ -381,8 +379,7 @@ const PROJECT_SECTIONS: readonly SectionDestination[] = [
   { section: "activity", label: "Activity", icon: History },
   { section: "settings", label: "Settings", icon: Settings },
 ];
-// The instance is the deployment, so its surfaces sit outside `/o/` and there is no tenant in
-// their paths. That also makes the path the only thing that can say you are on one.
+// Instance destinations sit outside the organization hierarchy.
 const INSTANCE_DESTINATIONS: readonly NavigationItem[] = [
   { to: "/apps", label: "Apps", icon: Blocks },
   { to: "/operator", label: "Operator", icon: ShieldCheck },
@@ -393,7 +390,6 @@ const INSTANCE_DESTINATIONS: readonly NavigationItem[] = [
  * route keeps the organization sidebar and their way back out — the route itself refuses them.
  */
 function useInstanceScope(operator: boolean): boolean {
-  const pathname = usePresentedPathname();
-  const onInstanceRoute = INSTANCE_DESTINATIONS.some((destination) => destination.to === pathname);
-  return operator && onInstanceRoute;
+  const page = usePageContext();
+  return operator && page.instance;
 }

--- a/src/shell/dashboard-shell.tsx
+++ b/src/shell/dashboard-shell.tsx
@@ -11,10 +11,11 @@ import {
   SlidersHorizontal,
   Zap,
 } from "lucide-react";
-import { Outlet, useRouterState } from "@tanstack/react-router";
+import { Outlet } from "@tanstack/react-router";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useServerFn } from "@tanstack/react-start";
 import { useCallback } from "react";
+import { usePresentedPathname } from "../navigation/index.js";
 import { Page } from "../components/app/page.js";
 import { FailureAlert } from "../components/app/failure-alert.js";
 import { PanelSkeleton } from "../components/app/loading.js";
@@ -207,7 +208,7 @@ function PageContent({
   transitioning: boolean;
 }) {
   const status = useRouteTenantStatus();
-  const pathname = useRouterState({ select: (state) => state.location.pathname });
+  const pathname = usePresentedPathname();
   // One name for the slot, whichever read is in flight: switching organization and resolving the
   // tenant behind a URL are the same wait to someone listening to the page.
   if (transitioning || status.state === "pending") {
@@ -392,9 +393,7 @@ const INSTANCE_DESTINATIONS: readonly NavigationItem[] = [
  * route keeps the organization sidebar and their way back out — the route itself refuses them.
  */
 function useInstanceScope(operator: boolean): boolean {
-  const onInstanceRoute = useRouterState({
-    select: (state) =>
-      INSTANCE_DESTINATIONS.some((destination) => destination.to === state.location.pathname),
-  });
+  const pathname = usePresentedPathname();
+  const onInstanceRoute = INSTANCE_DESTINATIONS.some((destination) => destination.to === pathname);
   return operator && onInstanceRoute;
 }

--- a/src/shell/navigation-group.tsx
+++ b/src/shell/navigation-group.tsx
@@ -1,8 +1,9 @@
 /* oxlint-disable typescript-eslint/no-unsafe-type-assertion -- dynamic tenant URLs are assembled from server-resolved route metadata */
-import { Link, useRouterState } from "@tanstack/react-router";
+import { Link } from "@tanstack/react-router";
 import type { LucideIcon } from "lucide-react";
 import { useCallback } from "react";
 
+import { usePresentedPathname } from "../navigation/index.js";
 import {
   SidebarGroup,
   SidebarGroupContent,
@@ -67,10 +68,8 @@ export function NavigationGroup({
  */
 function NavItem({ item }: { item: NavigationItem }) {
   const { to, label, icon: Icon, subtree = false } = item;
-  const active = useRouterState({
-    select: (state) =>
-      state.location.pathname === to || (subtree && state.location.pathname.startsWith(`${to}/`)),
-  });
+  const pathname = usePresentedPathname();
+  const active = pathname === to || (subtree && pathname.startsWith(`${to}/`));
   const { isMobile, setOpenMobile } = useSidebar();
   // On compact the sidebar is an overlay covering the destination. A document load used
   // to dismiss it; client-side navigation has to dismiss it deliberately.

--- a/src/shell/navigation-group.tsx
+++ b/src/shell/navigation-group.tsx
@@ -3,7 +3,7 @@ import { Link } from "@tanstack/react-router";
 import type { LucideIcon } from "lucide-react";
 import { useCallback } from "react";
 
-import { usePresentedPathname } from "../navigation/index.js";
+import { usePresentedDestination } from "../navigation/index.js";
 import {
   SidebarGroup,
   SidebarGroupContent,
@@ -68,8 +68,7 @@ export function NavigationGroup({
  */
 function NavItem({ item }: { item: NavigationItem }) {
   const { to, label, icon: Icon, subtree = false } = item;
-  const pathname = usePresentedPathname();
-  const active = pathname === to || (subtree && pathname.startsWith(`${to}/`));
+  const active = usePresentedDestination(to, subtree);
   const { isMobile, setOpenMobile } = useSidebar();
   // On compact the sidebar is an overlay covering the destination. A document load used
   // to dismiss it; client-side navigation has to dismiss it deliberately.

--- a/src/shell/site-header.tsx
+++ b/src/shell/site-header.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from "react";
 
-import { usePresentedPathname } from "../navigation/index.js";
+import { usePageContext } from "../navigation/index.js";
 import { cn } from "../lib/utils.js";
 import { Separator } from "../components/ui/separator.js";
 import { SidebarTrigger, useSidebar } from "../components/ui/sidebar.js";
@@ -13,7 +13,7 @@ import { SiteHeaderActionsTarget } from "./site-header-actions.js";
  * ends on the thing the reader is looking at.
  */
 export function SiteHeader({ scope, project }: { scope: string; project?: string }) {
-  const trail = viewTrail(usePresentedPathname());
+  const { breadcrumbs: trail } = usePageContext();
   return (
     <header className="sticky top-0 z-10 flex h-12 shrink-0 items-center gap-2 border-b bg-background px-4">
       <RestoringSidebarTrigger />
@@ -70,38 +70,4 @@ function RestoringSidebarTrigger() {
   }, [isMobile, openMobile]);
 
   return <SidebarTrigger ref={trigger} className="-ml-1" />;
-}
-
-// Longest suffix first: an organization settings path ends with `/settings/team`, a project
-// settings path ends with `/settings`, and only the first match may win.
-const ROUTE_SECTIONS = [
-  { suffix: "/settings/api-keys", label: "API keys", group: "Settings" },
-  { suffix: "/settings/team", label: "Team", group: "Settings" },
-  { suffix: "/settings/usage", label: "Usage", group: "Settings" },
-  { suffix: "/settings/billing", label: "Billing", group: "Settings" },
-  { suffix: "/settings", label: "Settings", projectSection: "settings" },
-  { suffix: "/configuration", label: "Configuration", projectSection: "configuration" },
-  { suffix: "/activity", label: "Activity", projectSection: "activity" },
-  { suffix: "/overview", label: "Overview", projectSection: "overview" },
-  { suffix: "/triggers", label: "Triggers" },
-  { suffix: "/projects", label: "Projects" },
-  { suffix: "/daemons", label: "Daemons" },
-  { suffix: "/connections", label: "Connections" },
-  { suffix: "/apps", label: "Apps" },
-  { suffix: "/operator", label: "Operator" },
-  { suffix: "/cli-login", label: "CLI login" },
-] as const;
-
-/** Which surface a pathname is, for the breadcrumb and for the project switcher's target. */
-export function routeSection(pathname: string) {
-  return ROUTE_SECTIONS.find((route) => pathname.endsWith(route.suffix));
-}
-
-function viewTrail(pathname: string): string[] {
-  if (/\/triggers\/[^/]+$/u.test(pathname)) return ["Triggers", "Trigger editor"];
-  const section = routeSection(pathname);
-  // A path this list does not know is a path with nothing true to say about it. The scope crumb
-  // still stands on its own, and the page's own `<h1>` says what the surface is.
-  if (section === undefined) return [];
-  return "group" in section ? [section.group, section.label] : [section.label];
 }

--- a/src/shell/site-header.tsx
+++ b/src/shell/site-header.tsx
@@ -1,6 +1,6 @@
-import { useRouterState } from "@tanstack/react-router";
 import { useEffect, useRef } from "react";
 
+import { usePresentedPathname } from "../navigation/index.js";
 import { cn } from "../lib/utils.js";
 import { Separator } from "../components/ui/separator.js";
 import { SidebarTrigger, useSidebar } from "../components/ui/sidebar.js";
@@ -13,7 +13,7 @@ import { SiteHeaderActionsTarget } from "./site-header-actions.js";
  * ends on the thing the reader is looking at.
  */
 export function SiteHeader({ scope, project }: { scope: string; project?: string }) {
-  const trail = useRouterState({ select: (state) => viewTrail(state.location.pathname) });
+  const trail = viewTrail(usePresentedPathname());
   return (
     <header className="sticky top-0 z-10 flex h-12 shrink-0 items-center gap-2 border-b bg-background px-4">
       <RestoringSidebarTrigger />

--- a/src/shell/switchers.tsx
+++ b/src/shell/switchers.tsx
@@ -1,8 +1,9 @@
 /* oxlint-disable typescript-eslint/no-unsafe-type-assertion -- dynamic tenant URLs are assembled from server-resolved route metadata */
 import { Check, FolderKanban, LogOut, Plus, ShieldCheck } from "lucide-react";
-import { Link, useRouterState } from "@tanstack/react-router";
+import { Link } from "@tanstack/react-router";
 import { useCallback, useState, type FormEvent } from "react";
 
+import { usePresentedPathname } from "../navigation/index.js";
 import { PaseoGlyph } from "../components/app/auth-layout.js";
 import { FormDialog } from "../components/app/form-dialog.js";
 import { FormField } from "../components/app/form-field.js";
@@ -151,7 +152,7 @@ function OrganizationItem({
 
 /** One line, and no organization on it: the switcher above already says which one. */
 export function ProjectSwitcher({ tenant }: { tenant: RouteTenant }) {
-  const pathname = useRouterState({ select: (state) => state.location.pathname });
+  const pathname = usePresentedPathname();
   const route = routeSection(pathname);
   const section =
     route !== undefined && "projectSection" in route ? route.projectSection : "overview";

--- a/src/shell/switchers.tsx
+++ b/src/shell/switchers.tsx
@@ -3,7 +3,7 @@ import { Check, FolderKanban, LogOut, Plus, ShieldCheck } from "lucide-react";
 import { Link } from "@tanstack/react-router";
 import { useCallback, useState, type FormEvent } from "react";
 
-import { usePresentedPathname } from "../navigation/index.js";
+import { usePageContext } from "../navigation/index.js";
 import { PaseoGlyph } from "../components/app/auth-layout.js";
 import { FormDialog } from "../components/app/form-dialog.js";
 import { FormField } from "../components/app/form-field.js";
@@ -17,7 +17,6 @@ import { formValue } from "../auth/account-actions.js";
 import type { ActiveAccountState } from "../auth/organization-contract.js";
 import type { useOptionalRouteTenant } from "../projects/context.js";
 import { SidebarSwitcher } from "./sidebar-switcher.js";
-import { routeSection } from "./site-header.js";
 
 /** The organization, project, and membership behind the URL, once the shell has resolved it. */
 export type RouteTenant = NonNullable<ReturnType<typeof useOptionalRouteTenant>>;
@@ -152,10 +151,7 @@ function OrganizationItem({
 
 /** One line, and no organization on it: the switcher above already says which one. */
 export function ProjectSwitcher({ tenant }: { tenant: RouteTenant }) {
-  const pathname = usePresentedPathname();
-  const route = routeSection(pathname);
-  const section =
-    route !== undefined && "projectSection" in route ? route.projectSection : "overview";
+  const { projectSection: section } = usePageContext();
   const activeProjects = tenant.projects.filter((project) => project.status === "active");
   return (
     <SidebarSwitcher


### PR DESCRIPTION
When a destination’s JavaScript loads slowly, Hub updates the sidebar and breadcrumb before replacing the old body. Keep shell context and navigation selection tied to TanStack’s presented matches, and show the destination’s loading skeleton after the router’s normal pending threshold.

Route definitions now own breadcrumb labels, instance scope, and settings layout hints through typed staticData. The shell reads TanStack’s decoded route parameters for tenant identity instead of splitting URL strings. Nested route matches compose breadcrumbs; the shell no longer maintains a parallel route-name table. TanStack owns pending timing and navigation cancellation, with no additional navigation state.

Browser regressions cover short and long downloads, completion, cached navigation, Back, superseding navigation, nested settings tabs, organization/instance context, header actions, and delayed data. They hold real application requests rather than substituting responses. The original mismatch was reproduced against the production build before the fix.

Validation on the latest refactor:
- Typecheck, lint, formatting, migration drift, production build, and Docker smoke passed.
- Six navigation regressions passed twice with two workers (12 passes).
- Full browser suite: 86 passed, including desktop and mobile. Source-built Hub integration suite: 8 passed.
- Full unit suite: 1,323 passed, 18 skipped (177 passed test files, 5 skipped). All local verification ran against the source committed as 6ec982f.

Risk surface: dashboard navigation and tenant context. Query fetching and preloading policy are unchanged.

Companion public documentation: https://github.com/getpaseo/paseo/pull/4608
