### PR TITLE
fix(executions): survive Hub restarts with active credentials

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ runbooks for privately operated instances must not live here.
 
 The optional billing integration in `src/billing/` is inert without `STRIPE_SECRET_KEY`; instances without billing configuration expose no billing surface. See `docs/entitlements.md` and `docs/billing.md`.
 
-The public docs (served at https://paseo.sh/docs/hub) live in the main Paseo repository under `public-docs/`, keep it up to date with any relevant externallly observable changes. Update via PR.
+Public docs live in `getpaseo/paseo` under `public-docs/`. Follow the documentation criteria in `MAINTAINERS.md` before opening a companion PR.
 
 Repository verification, release, cross-repository compatibility, and documentation procedures
 live in `MAINTAINERS.md`.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -61,6 +61,10 @@ Later changes to the current changelog section update the existing release notes
 
 ## Update public documentation
 
-Public Hub documentation lives in `getpaseo/paseo` under `public-docs/`. Externally visible Hub
-changes require a companion Paseo pull request. Keep task guides progressive and examples
-complete; keep exhaustive field documentation in reference pages.
+Public Hub documentation lives in `getpaseo/paseo` under `public-docs/`. Open a companion PR
+when an API, interface, or user-facing workflow change affects what users need to know or do.
+Internal changes and fixes that restore expected behavior do not require new public docs.
+If existing documentation becomes inaccurate, correct it with the smallest necessary edit.
+
+Document the intended public experience, not internal architecture or maintainer process.
+Keep each addition tied to a reader’s task; omit details that do not help them complete it.

--- a/docs/workflow-authority.md
+++ b/docs/workflow-authority.md
@@ -76,11 +76,21 @@ activation fails instead of making precedence order observable. Authority is
 materialized independently for each running step. Classifier and skipped steps do
 not receive it, and no Git-specific RPC field is sent to Paseo.
 
-Graceful Hub shutdown stops the authority owner and retries active lease revocation
-within a bounded shutdown grace period. If upstream revocation remains unavailable,
-shutdown reports token-free residual-exposure diagnostics and returns; unreferenced
-retries may continue while the process remains alive. A hard process crash cannot run
-revocation, so GitHub's upstream one-hour token expiry remains the unavoidable exposure
-boundary until a future persisted lease policy can provide stronger crash recovery.
+Hub persists materialized authority and credential leases before delivering credentials to
+an agent. A Hub restart preserves active executions and their original credentials; recovery
+reattaches the same agent and restores lease deadlines and pending revocation work. Stopping
+the Hub process does not end an execution or revoke its credentials.
+
+Completion, cancellation, and the original lease deadline still require revocation. Recovery
+does not mint replacement credentials or extend deadlines. If Hub is unavailable at a shorter
+lease deadline, it reconciles overdue revocation when it returns; upstream expiry remains the
+maximum token lifetime. Revocation failures remain durable and retry until upstream expiry.
+
+Resolved credentials are private runtime data in the Hub database, separate from authored
+configuration. Authority records are removed at execution termination; lease records remain
+only until revocation succeeds or the token expires.
+
+When upgrading from a version with process-owned credentials, let active credentialed runs
+finish before restarting Hub. That version cannot hand its in-memory leases to the replacement.
 
 Public workflow-authority guidance lives in the Paseo repository under `public-docs/`.

--- a/drizzle/0048_execution_authority.sql
+++ b/drizzle/0048_execution_authority.sql
@@ -1,0 +1,14 @@
+CREATE TABLE "execution_authorities" (
+	"execution_id" uuid PRIMARY KEY NOT NULL,
+	"data" jsonb NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "execution_credential_leases" (
+	"id" uuid PRIMARY KEY NOT NULL,
+	"execution_id" uuid NOT NULL,
+	"data" jsonb NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "execution_authorities" ADD CONSTRAINT "execution_authorities_execution_id_agent_executions_id_fk" FOREIGN KEY ("execution_id") REFERENCES "public"."agent_executions"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "execution_credential_leases" ADD CONSTRAINT "execution_credential_leases_execution_id_agent_executions_id_fk" FOREIGN KEY ("execution_id") REFERENCES "public"."agent_executions"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "execution_credential_leases_execution_idx" ON "execution_credential_leases" USING btree ("execution_id");

--- a/drizzle/meta/0048_snapshot.json
+++ b/drizzle/meta/0048_snapshot.json
@@ -1,0 +1,6239 @@
+{
+  "id": "5d38ccc3-86d8-40ad-8f9c-9d1c04669de2",
+  "prevId": "a40c2929-41aa-40ed-bb2d-b5135b84061b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_executions": {
+      "name": "agent_executions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_session_action": {
+          "name": "agent_session_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "machine_id": {
+          "name": "machine_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_execution_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_by_agent_at": {
+          "name": "completed_by_agent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deadline_at": {
+          "name": "deadline_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idle_deadline_at": {
+          "name": "idle_deadline_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_context": {
+          "name": "trigger_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_context": {
+          "name": "output_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reaction_state": {
+          "name": "reaction_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "configuration_revision_id": {
+          "name": "configuration_revision_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completion_token_hash": {
+          "name": "completion_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_claimed_at": {
+          "name": "reply_claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_claim_count": {
+          "name": "reply_claim_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_emissions": {
+          "name": "output_emissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "output_delivery_attempts": {
+          "name": "output_delivery_attempts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "launch_intent": {
+          "name": "launch_intent",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daemon_id": {
+          "name": "daemon_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daemon_agent_id": {
+          "name": "daemon_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_step_run_id": {
+          "name": "workflow_step_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hub_action": {
+          "name": "hub_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hub_action_completed_at": {
+          "name": "hub_action_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hub_action_ready_at": {
+          "name": "hub_action_ready_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hub_action_acknowledgements": {
+          "name": "hub_action_acknowledgements",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"terminal_at\":null,\"idle_at\":null,\"finish_execution_call\":null}'::jsonb"
+        }
+      },
+      "indexes": {
+        "agent_executions_session_idx": {
+          "name": "agent_executions_session_idx",
+          "columns": [
+            {
+              "expression": "agent_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_executions_machine_id_idx": {
+          "name": "agent_executions_machine_id_idx",
+          "columns": [
+            {
+              "expression": "machine_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_executions_project_started_at_idx": {
+          "name": "agent_executions_project_started_at_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_executions_status_idx": {
+          "name": "agent_executions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_executions_agent_session_id_agent_sessions_id_fk": {
+          "name": "agent_executions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "agent_executions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agent_executions_project_organization_fk": {
+          "name": "agent_executions_project_organization_fk",
+          "tableFrom": "agent_executions",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id", "organization_id"],
+          "columnsTo": ["id", "organization_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agent_executions_revision_project_organization_fk": {
+          "name": "agent_executions_revision_project_organization_fk",
+          "tableFrom": "agent_executions",
+          "tableTo": "project_configuration_revisions",
+          "columnsFrom": ["configuration_revision_id", "project_id", "organization_id"],
+          "columnsTo": ["id", "project_id", "organization_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agent_executions_machine_organization_fk": {
+          "name": "agent_executions_machine_organization_fk",
+          "tableFrom": "agent_executions",
+          "tableTo": "machines",
+          "columnsFrom": ["machine_id", "organization_id"],
+          "columnsTo": ["id", "org_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agent_executions_daemon_organization_fk": {
+          "name": "agent_executions_daemon_organization_fk",
+          "tableFrom": "agent_executions",
+          "tableTo": "daemons",
+          "columnsFrom": ["daemon_id", "organization_id"],
+          "columnsTo": ["id", "organization_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agent_executions_workflow_step_run_fk": {
+          "name": "agent_executions_workflow_step_run_fk",
+          "tableFrom": "agent_executions",
+          "tableTo": "workflow_step_runs",
+          "columnsFrom": ["workflow_step_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agent_executions_hub_action_check": {
+          "name": "agent_executions_hub_action_check",
+          "value": "\"agent_executions\".\"hub_action\" is null or \"agent_executions\".\"hub_action\" in ('interrupt', 'archive')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_sessions": {
+      "name": "agent_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "continuation_key": {
+          "name": "continuation_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_sessions_project_key_unique": {
+          "name": "agent_sessions_project_key_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "continuation_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_sessions_project_id_projects_id_fk": {
+          "name": "agent_sessions_project_id_projects_id_fk",
+          "tableFrom": "agent_sessions",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attachment_capabilities": {
+      "name": "attachment_capabilities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider_event_receipt_id": {
+          "name": "provider_event_receipt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locator": {
+          "name": "locator",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "attachment_capabilities_receipt_provider_source_unique": {
+          "name": "attachment_capabilities_receipt_provider_source_unique",
+          "columns": [
+            {
+              "expression": "provider_event_receipt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attachment_capabilities_receipt_idx": {
+          "name": "attachment_capabilities_receipt_idx",
+          "columns": [
+            {
+              "expression": "provider_event_receipt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "attachment_capabilities_organization_id_organization_id_fk": {
+          "name": "attachment_capabilities_organization_id_organization_id_fk",
+          "tableFrom": "attachment_capabilities",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attachment_capabilities_receipt_organization_fk": {
+          "name": "attachment_capabilities_receipt_organization_fk",
+          "tableFrom": "attachment_capabilities",
+          "tableTo": "provider_event_receipts",
+          "columnsFrom": ["provider_event_receipt_id", "organization_id"],
+          "columnsTo": ["id", "organization_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "attachment_capabilities_provider_check": {
+          "name": "attachment_capabilities_provider_check",
+          "value": "\"attachment_capabilities\".\"provider\" in ('slack', 'discord')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_kind": {
+          "name": "actor_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_identity": {
+          "name": "actor_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_events_organization_created_idx": {
+          "name": "audit_events_organization_created_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_events_project_created_idx": {
+          "name": "audit_events_project_created_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_events_organization_id_organization_id_fk": {
+          "name": "audit_events_organization_id_organization_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audit_events_project_id_projects_id_fk": {
+          "name": "audit_events_project_id_projects_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audit_events_project_organization_fk": {
+          "name": "audit_events_project_organization_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id", "organization_id"],
+          "columnsTo": ["id", "organization_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "audit_events_actor_kind_check": {
+          "name": "audit_events_actor_kind_check",
+          "value": "\"audit_events\".\"actor_kind\" in ('user', 'github', 'system')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.billing_plan_prices": {
+      "name": "billing_plan_prices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lookup_key": {
+          "name": "lookup_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interval": {
+          "name": "interval",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_amount": {
+          "name": "unit_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "billing_plan_prices_plan_id_idx": {
+          "name": "billing_plan_prices_plan_id_idx",
+          "columns": [
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "billing_plan_prices_plan_id_billing_plans_id_fk": {
+          "name": "billing_plan_prices_plan_id_billing_plans_id_fk",
+          "tableFrom": "billing_plan_prices",
+          "tableTo": "billing_plans",
+          "columnsFrom": ["plan_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "billing_plan_prices_interval_check": {
+          "name": "billing_plan_prices_interval_check",
+          "value": "\"billing_plan_prices\".\"interval\" in ('monthly', 'annual')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.billing_plans": {
+      "name": "billing_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template": {
+          "name": "template",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_hash": {
+          "name": "template_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "marketing": {
+          "name": "marketing",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "billing_plans_slug_unique": {
+          "name": "billing_plans_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cli_authorizations": {
+      "name": "cli_authorizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_verifier": {
+          "name": "device_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code_verifier": {
+          "name": "user_code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint_verifier": {
+          "name": "fingerprint_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "poll_interval_seconds": {
+          "name": "poll_interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_poll_at": {
+          "name": "next_poll_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_organization_id": {
+          "name": "approved_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by_user_id": {
+          "name": "approved_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "cli_authorizations_fingerprint_idx": {
+          "name": "cli_authorizations_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "fingerprint_verifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cli_authorizations_status_expiry_idx": {
+          "name": "cli_authorizations_status_expiry_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cli_authorizations_device_verifier_unique": {
+          "name": "cli_authorizations_device_verifier_unique",
+          "nullsNotDistinct": false,
+          "columns": ["device_verifier"]
+        },
+        "cli_authorizations_user_code_verifier_unique": {
+          "name": "cli_authorizations_user_code_verifier_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_code_verifier"]
+        },
+        "cli_authorizations_credential_id_unique": {
+          "name": "cli_authorizations_credential_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["credential_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "cli_authorizations_status_check": {
+          "name": "cli_authorizations_status_check",
+          "value": "\"cli_authorizations\".\"status\" in ('pending', 'approved', 'denied', 'expired', 'disclosed')"
+        },
+        "cli_authorizations_poll_interval_check": {
+          "name": "cli_authorizations_poll_interval_check",
+          "value": "\"cli_authorizations\".\"poll_interval_seconds\" >= 5"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.configuration_sync_attempts": {
+      "name": "configuration_sync_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_connection_id": {
+          "name": "github_connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_repository_id": {
+          "name": "github_repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_delivery_id": {
+          "name": "webhook_delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "configuration_sync_attempts_project_created_idx": {
+          "name": "configuration_sync_attempts_project_created_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "configuration_sync_attempts_project_organization_fk": {
+          "name": "configuration_sync_attempts_project_organization_fk",
+          "tableFrom": "configuration_sync_attempts",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id", "organization_id"],
+          "columnsTo": ["id", "organization_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "configuration_sync_attempts_github_connection_organization_fk": {
+          "name": "configuration_sync_attempts_github_connection_organization_fk",
+          "tableFrom": "configuration_sync_attempts",
+          "tableTo": "github_connections",
+          "columnsFrom": ["github_connection_id", "organization_id"],
+          "columnsTo": ["id", "organization_id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daemon_enrollment_tokens": {
+      "name": "daemon_enrollment_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "verifier": {
+          "name": "verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_by_api_key_id": {
+          "name": "issued_by_api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_by_cli_credential_id": {
+          "name": "issued_by_cli_credential_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "daemon_enrollment_tokens_issued_by_cli_credential_id_organization_cli_credentials_id_fk": {
+          "name": "daemon_enrollment_tokens_issued_by_cli_credential_id_organization_cli_credentials_id_fk",
+          "tableFrom": "daemon_enrollment_tokens",
+          "tableTo": "organization_cli_credentials",
+          "columnsFrom": ["issued_by_cli_credential_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "daemon_enrollment_tokens_verifier_unique": {
+          "name": "daemon_enrollment_tokens_verifier_unique",
+          "nullsNotDistinct": false,
+          "columns": ["verifier"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daemons": {
+      "name": "daemons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enrollment_verifier": {
+          "name": "enrollment_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "machine_id": {
+          "name": "machine_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "daemon_public_key": {
+          "name": "daemon_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_verifier": {
+          "name": "credential_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registered_by_api_key_id": {
+          "name": "registered_by_api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registered_by_cli_credential_id": {
+          "name": "registered_by_cli_credential_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "presence": {
+          "name": "presence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'offline'"
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disconnected_at": {
+          "name": "disconnected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "daemons_machine_id_unique": {
+          "name": "daemons_machine_id_unique",
+          "columns": [
+            {
+              "expression": "machine_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "daemons_id_organization_unique": {
+          "name": "daemons_id_organization_unique",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "daemons_organization_slug_unique": {
+          "name": "daemons_organization_slug_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daemons_registered_by_cli_credential_id_organization_cli_credentials_id_fk": {
+          "name": "daemons_registered_by_cli_credential_id_organization_cli_credentials_id_fk",
+          "tableFrom": "daemons",
+          "tableTo": "organization_cli_credentials",
+          "columnsFrom": ["registered_by_cli_credential_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "daemons_machine_organization_fk": {
+          "name": "daemons_machine_organization_fk",
+          "tableFrom": "daemons",
+          "tableTo": "machines",
+          "columnsFrom": ["machine_id", "organization_id"],
+          "columnsTo": ["id", "org_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "daemons_idempotency_key_unique": {
+          "name": "daemons_idempotency_key_unique",
+          "nullsNotDistinct": false,
+          "columns": ["idempotency_key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "daemons_status_check": {
+          "name": "daemons_status_check",
+          "value": "\"daemons\".\"status\" in ('active', 'revoked')"
+        },
+        "daemons_presence_check": {
+          "name": "daemons_presence_check",
+          "value": "\"daemons\".\"presence\" in ('offline', 'connected')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.discord_connections": {
+      "name": "discord_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_application_id": {
+          "name": "provider_application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guild_name": {
+          "name": "guild_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connected_by_user_id": {
+          "name": "connected_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discord_connections_id_organization_unique": {
+          "name": "discord_connections_id_organization_unique",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discord_connections_organization_slug_unique": {
+          "name": "discord_connections_organization_slug_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_connections_organization_id_organization_id_fk": {
+          "name": "discord_connections_organization_id_organization_id_fk",
+          "tableFrom": "discord_connections",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "discord_connections_connected_by_user_id_user_id_fk": {
+          "name": "discord_connections_connected_by_user_id_user_id_fk",
+          "tableFrom": "discord_connections",
+          "tableTo": "user",
+          "columnsFrom": ["connected_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discord_connections_guild_id_unique": {
+          "name": "discord_connections_guild_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["guild_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entitlement_changes": {
+      "name": "entitlement_changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "before": {
+          "name": "before",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after": {
+          "name": "after",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "entitlement_changes_organization_created_idx": {
+          "name": "entitlement_changes_organization_created_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entitlement_changes_organization_id_organization_id_fk": {
+          "name": "entitlement_changes_organization_id_organization_id_fk",
+          "tableFrom": "entitlement_changes",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "entitlement_changes_source_check": {
+          "name": "entitlement_changes_source_check",
+          "value": "\"entitlement_changes\".\"source\" in ('provisioning', 'plan_stamp', 'override')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.execution_authorities": {
+      "name": "execution_authorities",
+      "schema": "",
+      "columns": {
+        "execution_id": {
+          "name": "execution_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "execution_authorities_execution_id_agent_executions_id_fk": {
+          "name": "execution_authorities_execution_id_agent_executions_id_fk",
+          "tableFrom": "execution_authorities",
+          "tableTo": "agent_executions",
+          "columnsFrom": ["execution_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.execution_credential_leases": {
+      "name": "execution_credential_leases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "execution_id": {
+          "name": "execution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "execution_credential_leases_execution_idx": {
+          "name": "execution_credential_leases_execution_idx",
+          "columns": [
+            {
+              "expression": "execution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "execution_credential_leases_execution_id_agent_executions_id_fk": {
+          "name": "execution_credential_leases_execution_id_agent_executions_id_fk",
+          "tableFrom": "execution_credential_leases",
+          "tableTo": "agent_executions",
+          "columnsFrom": ["execution_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_connections": {
+      "name": "github_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_application_id": {
+          "name": "provider_application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connected_by_user_id": {
+          "name": "connected_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "github_connections_installation_unique": {
+          "name": "github_connections_installation_unique",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_connections_organization_slug_unique": {
+          "name": "github_connections_organization_slug_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_connections_id_organization_unique": {
+          "name": "github_connections_id_organization_unique",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_connections_organization_idx": {
+          "name": "github_connections_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_connections_organization_id_organization_id_fk": {
+          "name": "github_connections_organization_id_organization_id_fk",
+          "tableFrom": "github_connections",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_connections_connected_by_user_id_user_id_fk": {
+          "name": "github_connections_connected_by_user_id_user_id_fk",
+          "tableFrom": "github_connections",
+          "tableTo": "user",
+          "columnsFrom": ["connected_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "github_connections_installation_id_unique": {
+          "name": "github_connections_installation_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["installation_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "github_connections_status_check": {
+          "name": "github_connections_status_check",
+          "value": "\"github_connections\".\"status\" in ('active', 'suspended')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.github_repositories": {
+      "name": "github_repositories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discovered_at": {
+          "name": "discovered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_repositories_connection_repository_unique": {
+          "name": "github_repositories_connection_repository_unique",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_repositories_organization_idx": {
+          "name": "github_repositories_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_repositories_connection_organization_fk": {
+          "name": "github_repositories_connection_organization_fk",
+          "tableFrom": "github_repositories",
+          "tableTo": "github_connections",
+          "columnsFrom": ["connection_id", "organization_id"],
+          "columnsTo": ["id", "organization_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instance_bootstrap": {
+      "name": "instance_bootstrap",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "app_onboarding_completed_at": {
+          "name": "app_onboarding_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "instance_bootstrap_organization_id_organization_id_fk": {
+          "name": "instance_bootstrap_organization_id_organization_id_fk",
+          "tableFrom": "instance_bootstrap",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "instance_bootstrap_owner_user_id_user_id_fk": {
+          "name": "instance_bootstrap_owner_user_id_user_id_fk",
+          "tableFrom": "instance_bootstrap",
+          "tableTo": "user",
+          "columnsFrom": ["owner_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "instance_bootstrap_completion_check": {
+          "name": "instance_bootstrap_completion_check",
+          "value": "\"instance_bootstrap\".\"completed_at\" is null or (\"instance_bootstrap\".\"organization_id\" is not null and \"instance_bootstrap\".\"owner_user_id\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitations_organization_status_idx": {
+          "name": "invitations_organization_status_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitations_pending_organization_email_unique": {
+          "name": "invitations_pending_organization_email_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invitation\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": ["inviter_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "invitations_role_check": {
+          "name": "invitations_role_check",
+          "value": "\"invitation\".\"role\" in ('admin', 'member')"
+        },
+        "invitations_status_check": {
+          "name": "invitations_status_check",
+          "value": "\"invitation\".\"status\" in ('pending', 'accepted', 'rejected', 'canceled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.linear_connections": {
+      "name": "linear_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linear_organization_id": {
+          "name": "linear_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_application_id": {
+          "name": "provider_application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linear_organization_name": {
+          "name": "linear_organization_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_user_id": {
+          "name": "app_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "connected_by_user_id": {
+          "name": "connected_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "linear_connections_id_organization_unique": {
+          "name": "linear_connections_id_organization_unique",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "linear_connections_organization_slug_unique": {
+          "name": "linear_connections_organization_slug_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "linear_connections_organization_external_unique": {
+          "name": "linear_connections_organization_external_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "linear_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "linear_connections_organization_id_organization_id_fk": {
+          "name": "linear_connections_organization_id_organization_id_fk",
+          "tableFrom": "linear_connections",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "linear_connections_connected_by_user_id_user_id_fk": {
+          "name": "linear_connections_connected_by_user_id_user_id_fk",
+          "tableFrom": "linear_connections",
+          "tableTo": "user",
+          "columnsFrom": ["connected_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "linear_connections_linear_organization_id_unique": {
+          "name": "linear_connections_linear_organization_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["linear_organization_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.machines": {
+      "name": "machines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "machine_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "terminated_at": {
+          "name": "terminated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shutdown_reason": {
+          "name": "shutdown_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_name": {
+          "name": "trigger_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_context": {
+          "name": "trigger_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "specs": {
+          "name": "specs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "machines_id_org_id_unique": {
+          "name": "machines_id_org_id_unique",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "machines_org_id_idx": {
+          "name": "machines_org_id_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "machines_status_idx": {
+          "name": "machines_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "members_organization_user_unique": {
+          "name": "members_organization_user_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "members_user_id_idx": {
+          "name": "members_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "members_organization_id_idx": {
+          "name": "members_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "members_role_check": {
+          "name": "members_role_check",
+          "value": "\"member\".\"role\" in ('owner', 'admin', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_api_keys": {
+      "name": "organization_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verifier": {
+          "name": "verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "organization_api_keys_prefix_unique": {
+          "name": "organization_api_keys_prefix_unique",
+          "columns": [
+            {
+              "expression": "prefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organization_api_keys_organization_created_idx": {
+          "name": "organization_api_keys_organization_created_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_api_keys_organization_id_organization_id_fk": {
+          "name": "organization_api_keys_organization_id_organization_id_fk",
+          "tableFrom": "organization_api_keys",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_api_keys_created_by_user_id_user_id_fk": {
+          "name": "organization_api_keys_created_by_user_id_user_id_fk",
+          "tableFrom": "organization_api_keys",
+          "tableTo": "user",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "organization_api_keys_scopes_check": {
+          "name": "organization_api_keys_scopes_check",
+          "value": "\"organization_api_keys\".\"scopes\" <@ ARRAY['projects:read', 'configuration:validate', 'configuration:install', 'runs:dispatch', 'daemons:enroll']::text[] and cardinality(\"organization_api_keys\".\"scopes\") > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_billing_customers": {
+      "name": "organization_billing_customers",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_billing_customers_organization_id_organization_id_fk": {
+          "name": "organization_billing_customers_organization_id_organization_id_fk",
+          "tableFrom": "organization_billing_customers",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_cli_credentials": {
+      "name": "organization_cli_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verifier": {
+          "name": "verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "organization_cli_credentials_prefix_unique": {
+          "name": "organization_cli_credentials_prefix_unique",
+          "columns": [
+            {
+              "expression": "prefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organization_cli_credentials_organization_created_idx": {
+          "name": "organization_cli_credentials_organization_created_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_cli_credentials_organization_id_organization_id_fk": {
+          "name": "organization_cli_credentials_organization_id_organization_id_fk",
+          "tableFrom": "organization_cli_credentials",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_cli_credentials_created_by_user_id_user_id_fk": {
+          "name": "organization_cli_credentials_created_by_user_id_user_id_fk",
+          "tableFrom": "organization_cli_credentials",
+          "tableTo": "user",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_connection_attempts": {
+      "name": "organization_connection_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_verifier": {
+          "name": "state_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "return_route": {
+          "name": "return_route",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_external_id": {
+          "name": "candidate_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pkce_verifier": {
+          "name": "pkce_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "configuration_version": {
+          "name": "configuration_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_application_id": {
+          "name": "provider_application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "callback_origin": {
+          "name": "callback_origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configuration_snapshot": {
+          "name": "configuration_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_configuration_version": {
+          "name": "expected_configuration_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activate_configuration": {
+          "name": "activate_configuration",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "organization_connection_attempts_expiry_idx": {
+          "name": "organization_connection_attempts_expiry_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_connection_attempts_organization_id_organization_id_fk": {
+          "name": "organization_connection_attempts_organization_id_organization_id_fk",
+          "tableFrom": "organization_connection_attempts",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_connection_attempts_user_id_user_id_fk": {
+          "name": "organization_connection_attempts_user_id_user_id_fk",
+          "tableFrom": "organization_connection_attempts",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_connection_attempts_session_id_session_id_fk": {
+          "name": "organization_connection_attempts_session_id_session_id_fk",
+          "tableFrom": "organization_connection_attempts",
+          "tableTo": "session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_connection_attempts_state_verifier_unique": {
+          "name": "organization_connection_attempts_state_verifier_unique",
+          "nullsNotDistinct": false,
+          "columns": ["state_verifier"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "organization_connection_attempts_provider_check": {
+          "name": "organization_connection_attempts_provider_check",
+          "value": "\"organization_connection_attempts\".\"provider\" in ('github', 'discord', 'slack', 'linear')"
+        },
+        "organization_connection_attempts_phase_check": {
+          "name": "organization_connection_attempts_phase_check",
+          "value": "\"organization_connection_attempts\".\"phase\" in ('github_setup', 'github_user_authorization', 'discord_authorization', 'slack_authorization', 'linear_authorization')"
+        },
+        "organization_connection_attempts_shape_check": {
+          "name": "organization_connection_attempts_shape_check",
+          "value": "(\"organization_connection_attempts\".\"phase\" = 'github_setup' and \"organization_connection_attempts\".\"provider\" = 'github' and \"organization_connection_attempts\".\"candidate_external_id\" is null and \"organization_connection_attempts\".\"pkce_verifier\" is null)\n        or (\"organization_connection_attempts\".\"phase\" = 'github_user_authorization' and \"organization_connection_attempts\".\"provider\" = 'github' and \"organization_connection_attempts\".\"candidate_external_id\" is not null and (\"organization_connection_attempts\".\"pkce_verifier\" is not null or \"organization_connection_attempts\".\"consumed_at\" is not null))\n        or (\"organization_connection_attempts\".\"phase\" = 'discord_authorization' and \"organization_connection_attempts\".\"provider\" = 'discord' and \"organization_connection_attempts\".\"candidate_external_id\" is null and \"organization_connection_attempts\".\"pkce_verifier\" is null)\n        or (\"organization_connection_attempts\".\"phase\" = 'slack_authorization' and \"organization_connection_attempts\".\"provider\" = 'slack' and \"organization_connection_attempts\".\"candidate_external_id\" is null and \"organization_connection_attempts\".\"pkce_verifier\" is null)\n        or (\"organization_connection_attempts\".\"phase\" = 'linear_authorization' and \"organization_connection_attempts\".\"provider\" = 'linear' and \"organization_connection_attempts\".\"candidate_external_id\" is null and \"organization_connection_attempts\".\"pkce_verifier\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_entitlements": {
+      "name": "organization_entitlements",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "granted": {
+          "name": "granted",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overrides": {
+          "name": "overrides",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_version": {
+          "name": "plan_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stamped_at": {
+          "name": "stamped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_entitlements_organization_id_organization_id_fk": {
+          "name": "organization_entitlements_organization_id_organization_id_fk",
+          "tableFrom": "organization_entitlements",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_trigger_revisions": {
+      "name": "organization_trigger_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trigger_id": {
+          "name": "trigger_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "yaml": {
+          "name": "yaml",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_configuration": {
+          "name": "normalized_configuration",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_evidence": {
+          "name": "source_evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organization_trigger_revisions_trigger_version_unique": {
+          "name": "organization_trigger_revisions_trigger_version_unique",
+          "columns": [
+            {
+              "expression": "trigger_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organization_trigger_revisions_id_trigger_organization_unique": {
+          "name": "organization_trigger_revisions_id_trigger_organization_unique",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trigger_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organization_trigger_revisions_trigger_created_idx": {
+          "name": "organization_trigger_revisions_trigger_created_idx",
+          "columns": [
+            {
+              "expression": "trigger_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_trigger_revisions_created_by_user_id_user_id_fk": {
+          "name": "organization_trigger_revisions_created_by_user_id_user_id_fk",
+          "tableFrom": "organization_trigger_revisions",
+          "tableTo": "user",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "organization_trigger_revisions_trigger_organization_fk": {
+          "name": "organization_trigger_revisions_trigger_organization_fk",
+          "tableFrom": "organization_trigger_revisions",
+          "tableTo": "organization_triggers",
+          "columnsFrom": ["trigger_id", "organization_id"],
+          "columnsTo": ["id", "organization_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "organization_trigger_revisions_source_kind_check": {
+          "name": "organization_trigger_revisions_source_kind_check",
+          "value": "\"organization_trigger_revisions\".\"source_kind\" in ('manual', 'github', 'project_migration')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_trigger_routes": {
+      "name": "organization_trigger_routes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_id": {
+          "name": "trigger_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_revision_id": {
+          "name": "trigger_revision_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "configured_event_name": {
+          "name": "configured_event_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "organization_trigger_routes_shape_unique": {
+          "name": "organization_trigger_routes_shape_unique",
+          "columns": [
+            {
+              "expression": "trigger_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trigger_revision_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "configured_event_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organization_trigger_routes_resource_idx": {
+          "name": "organization_trigger_routes_resource_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_trigger_routes_trigger_organization_fk": {
+          "name": "organization_trigger_routes_trigger_organization_fk",
+          "tableFrom": "organization_trigger_routes",
+          "tableTo": "organization_triggers",
+          "columnsFrom": ["trigger_id", "organization_id"],
+          "columnsTo": ["id", "organization_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_trigger_routes_revision_trigger_organization_fk": {
+          "name": "organization_trigger_routes_revision_trigger_organization_fk",
+          "tableFrom": "organization_trigger_routes",
+          "tableTo": "organization_trigger_revisions",
+          "columnsFrom": ["trigger_revision_id", "trigger_id", "organization_id"],
+          "columnsTo": ["id", "trigger_id", "organization_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_triggers": {
+      "name": "organization_triggers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_project_id": {
+          "name": "runtime_project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_revision_id": {
+          "name": "active_revision_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organization_triggers_organization_name_unique": {
+          "name": "organization_triggers_organization_name_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organization_triggers_id_organization_unique": {
+          "name": "organization_triggers_id_organization_unique",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organization_triggers_organization_updated_idx": {
+          "name": "organization_triggers_organization_updated_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_triggers_organization_id_organization_id_fk": {
+          "name": "organization_triggers_organization_id_organization_id_fk",
+          "tableFrom": "organization_triggers",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_triggers_runtime_project_id_projects_id_fk": {
+          "name": "organization_triggers_runtime_project_id_projects_id_fk",
+          "tableFrom": "organization_triggers",
+          "tableTo": "projects",
+          "columnsFrom": ["runtime_project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organization_triggers_active_revision_id_organization_trigger_revisions_id_fk": {
+          "name": "organization_triggers_active_revision_id_organization_trigger_revisions_id_fk",
+          "tableFrom": "organization_triggers",
+          "tableTo": "organization_trigger_revisions",
+          "columnsFrom": ["active_revision_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "organization_triggers_format_check": {
+          "name": "organization_triggers_format_check",
+          "value": "\"organization_triggers\".\"format\" in ('single_run', 'legacy_multistep')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_usage": {
+      "name": "organization_usage",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meter": {
+          "name": "meter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used": {
+          "name": "used",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "organization_usage_organization_meter_idx": {
+          "name": "organization_usage_organization_meter_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "meter",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_usage_organization_id_organization_id_fk": {
+          "name": "organization_usage_organization_id_organization_id_fk",
+          "tableFrom": "organization_usage",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "organization_usage_organization_id_meter_period_start_pk": {
+          "name": "organization_usage_organization_id_meter_period_start_pk",
+          "columns": ["organization_id", "meter", "period_start"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "organization_usage_used_non_negative": {
+          "name": "organization_usage_used_non_negative",
+          "value": "\"organization_usage\".\"used\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_configuration_revisions": {
+      "name": "project_configuration_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_evidence": {
+          "name": "source_evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_yaml": {
+          "name": "raw_yaml",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "normalized_configuration": {
+          "name": "normalized_configuration",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "validation_errors": {
+          "name": "validation_errors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_repository_id": {
+          "name": "github_repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_repository_full_name": {
+          "name": "github_repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_commit_sha": {
+          "name": "github_commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_commit_url": {
+          "name": "github_commit_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_ref": {
+          "name": "github_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_webhook_delivery_id": {
+          "name": "github_webhook_delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_sender": {
+          "name": "github_sender",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_author": {
+          "name": "github_author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_committer": {
+          "name": "github_committer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "validated_at": {
+          "name": "validated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "project_configuration_revisions_project_version_unique": {
+          "name": "project_configuration_revisions_project_version_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_configuration_revisions_id_project_organization_unique": {
+          "name": "project_configuration_revisions_id_project_organization_unique",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_configuration_revisions_project_created_idx": {
+          "name": "project_configuration_revisions_project_created_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_configuration_revisions_created_by_user_id_user_id_fk": {
+          "name": "project_configuration_revisions_created_by_user_id_user_id_fk",
+          "tableFrom": "project_configuration_revisions",
+          "tableTo": "user",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "project_configuration_revisions_project_organization_fk": {
+          "name": "project_configuration_revisions_project_organization_fk",
+          "tableFrom": "project_configuration_revisions",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id", "organization_id"],
+          "columnsTo": ["id", "organization_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "project_configuration_revisions_source_kind_check": {
+          "name": "project_configuration_revisions_source_kind_check",
+          "value": "\"project_configuration_revisions\".\"source_kind\" in ('github', 'manual')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_configuration_sources": {
+      "name": "project_configuration_sources",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_connection_id": {
+          "name": "github_connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_repository_id": {
+          "name": "github_repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_repository_full_name": {
+          "name": "github_repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_default_branch": {
+          "name": "github_default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "automatic_deployment_enabled": {
+          "name": "automatic_deployment_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "selected_by_user_id": {
+          "name": "selected_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_configuration_sources_selected_by_user_id_user_id_fk": {
+          "name": "project_configuration_sources_selected_by_user_id_user_id_fk",
+          "tableFrom": "project_configuration_sources",
+          "tableTo": "user",
+          "columnsFrom": ["selected_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "project_configuration_sources_project_organization_fk": {
+          "name": "project_configuration_sources_project_organization_fk",
+          "tableFrom": "project_configuration_sources",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id", "organization_id"],
+          "columnsTo": ["id", "organization_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_configuration_sources_github_connection_organization_fk": {
+          "name": "project_configuration_sources_github_connection_organization_fk",
+          "tableFrom": "project_configuration_sources",
+          "tableTo": "github_connections",
+          "columnsFrom": ["github_connection_id", "organization_id"],
+          "columnsTo": ["id", "organization_id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "project_configuration_sources_authority_shape_check": {
+          "name": "project_configuration_sources_authority_shape_check",
+          "value": "(\"project_configuration_sources\".\"kind\" = 'manual' and \"project_configuration_sources\".\"github_connection_id\" is null and \"project_configuration_sources\".\"github_repository_id\" is null and not \"project_configuration_sources\".\"automatic_deployment_enabled\") or (\"project_configuration_sources\".\"kind\" = 'github' and \"project_configuration_sources\".\"github_connection_id\" is not null and \"project_configuration_sources\".\"github_repository_id\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_trigger_migrations": {
+      "name": "project_trigger_migrations",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configuration_revision_id": {
+          "name": "configuration_revision_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "migrated_at": {
+          "name": "migrated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_trigger_migrations_organization_idx": {
+          "name": "project_trigger_migrations_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_trigger_migrations_project_id_projects_id_fk": {
+          "name": "project_trigger_migrations_project_id_projects_id_fk",
+          "tableFrom": "project_trigger_migrations",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_trigger_migrations_organization_id_organization_id_fk": {
+          "name": "project_trigger_migrations_organization_id_organization_id_fk",
+          "tableFrom": "project_trigger_migrations",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_trigger_migrations_revision_project_organization_fk": {
+          "name": "project_trigger_migrations_revision_project_organization_fk",
+          "tableFrom": "project_trigger_migrations",
+          "tableTo": "project_configuration_revisions",
+          "columnsFrom": ["configuration_revision_id", "project_id", "organization_id"],
+          "columnsTo": ["id", "project_id", "organization_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_trigger_routes": {
+      "name": "project_trigger_routes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configuration_revision_id": {
+          "name": "configuration_revision_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_name": {
+          "name": "trigger_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "project_trigger_routes_shape_unique": {
+          "name": "project_trigger_routes_shape_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "configuration_revision_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trigger_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_trigger_routes_resource_idx": {
+          "name": "project_trigger_routes_resource_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_trigger_routes_project_organization_fk": {
+          "name": "project_trigger_routes_project_organization_fk",
+          "tableFrom": "project_trigger_routes",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id", "organization_id"],
+          "columnsTo": ["id", "organization_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_trigger_routes_revision_project_organization_fk": {
+          "name": "project_trigger_routes_revision_project_organization_fk",
+          "tableFrom": "project_trigger_routes",
+          "tableTo": "project_configuration_revisions",
+          "columnsFrom": ["configuration_revision_id", "project_id", "organization_id"],
+          "columnsTo": ["id", "project_id", "organization_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "project_trigger_routes_provider_check": {
+          "name": "project_trigger_routes_provider_check",
+          "value": "\"project_trigger_routes\".\"provider\" in ('github', 'slack', 'discord', 'linear')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_configuration_revision_id": {
+          "name": "active_configuration_revision_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "projects_organization_slug_unique": {
+          "name": "projects_organization_slug_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_id_organization_unique": {
+          "name": "projects_id_organization_unique",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_organization_status_idx": {
+          "name": "projects_organization_status_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_organization_id_organization_id_fk": {
+          "name": "projects_organization_id_organization_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "projects_created_by_user_id_user_id_fk": {
+          "name": "projects_created_by_user_id_user_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "user",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "projects_active_configuration_revision_id_project_configuration_revisions_id_fk": {
+          "name": "projects_active_configuration_revision_id_project_configuration_revisions_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "project_configuration_revisions",
+          "columnsFrom": ["active_configuration_revision_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "projects_status_check": {
+          "name": "projects_status_check",
+          "value": "\"projects\".\"status\" in ('active', 'archived')"
+        },
+        "projects_archive_shape_check": {
+          "name": "projects_archive_shape_check",
+          "value": "(\"projects\".\"status\" = 'active' and \"projects\".\"archived_at\" is null) or (\"projects\".\"status\" = 'archived' and \"projects\".\"archived_at\" is not null and \"projects\".\"active_configuration_revision_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.provider_event_receipts": {
+      "name": "provider_event_receipts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signature_hash": {
+          "name": "signature_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_application_id": {
+          "name": "provider_application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_configuration_version": {
+          "name": "provider_configuration_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "dropped_reason": {
+          "name": "dropped_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_routes": {
+          "name": "accepted_routes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "provider_event_receipts_id_organization_unique": {
+          "name": "provider_event_receipts_id_organization_unique",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "provider_event_receipts_organization_delivery_unique": {
+          "name": "provider_event_receipts_organization_delivery_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "delivery_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "provider_event_receipts_signature_unique": {
+          "name": "provider_event_receipts_signature_unique",
+          "columns": [
+            {
+              "expression": "signature_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"provider_event_receipts\".\"signature_hash\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "provider_event_receipts_organization_received_idx": {
+          "name": "provider_event_receipts_organization_received_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "provider_event_receipts_resource_idx": {
+          "name": "provider_event_receipts_resource_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provider_event_receipts_organization_id_organization_id_fk": {
+          "name": "provider_event_receipts_organization_id_organization_id_fk",
+          "tableFrom": "provider_event_receipts",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "provider_event_receipts_provider_check": {
+          "name": "provider_event_receipts_provider_check",
+          "value": "\"provider_event_receipts\".\"provider\" in ('github', 'slack', 'discord', 'linear', 'manual', 'schedule')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.runtime_configuration": {
+      "name": "runtime_configuration",
+      "schema": "",
+      "columns": {
+        "singleton": {
+          "name": "singleton",
+          "type": "boolean",
+          "primaryKey": true,
+          "notNull": true,
+          "default": true
+        },
+        "auth_secret": {
+          "name": "auth_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "runtime_configuration_singleton_check": {
+          "name": "runtime_configuration_singleton_check",
+          "value": "\"runtime_configuration\".\"singleton\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.runtime_provider_activation": {
+      "name": "runtime_provider_activation",
+      "schema": "",
+      "columns": {
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_application_id": {
+          "name": "provider_application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configuration_version": {
+          "name": "configuration_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "runtime_provider_activation_provider_check": {
+          "name": "runtime_provider_activation_provider_check",
+          "value": "\"runtime_provider_activation\".\"provider\" in ('github', 'slack', 'discord', 'linear')"
+        },
+        "runtime_provider_activation_version_check": {
+          "name": "runtime_provider_activation_version_check",
+          "value": "\"runtime_provider_activation\".\"configuration_version\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.runtime_provider_configuration": {
+      "name": "runtime_provider_configuration",
+      "schema": "",
+      "columns": {
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "configuration": {
+          "name": "configuration",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified_external_identity": {
+          "name": "verified_external_identity",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "runtime_provider_configuration_updated_by_user_id_user_id_fk": {
+          "name": "runtime_provider_configuration_updated_by_user_id_user_id_fk",
+          "tableFrom": "runtime_provider_configuration",
+          "tableTo": "user",
+          "columnsFrom": ["updated_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "runtime_provider_configuration_provider_check": {
+          "name": "runtime_provider_configuration_provider_check",
+          "value": "\"runtime_provider_configuration\".\"provider\" in ('github', 'slack', 'discord', 'linear')"
+        },
+        "runtime_provider_configuration_version_check": {
+          "name": "runtime_provider_configuration_version_check",
+          "value": "\"runtime_provider_configuration\".\"version\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sessions_active_organization_id_idx": {
+          "name": "sessions_active_organization_id_idx",
+          "columns": [
+            {
+              "expression": "active_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_connections": {
+      "name": "slack_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_application_id": {
+          "name": "provider_application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_name": {
+          "name": "team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_access_token": {
+          "name": "bot_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "connected_by_user_id": {
+          "name": "connected_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "slack_connections_id_organization_unique": {
+          "name": "slack_connections_id_organization_unique",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "slack_connections_organization_slug_unique": {
+          "name": "slack_connections_organization_slug_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_connections_organization_id_organization_id_fk": {
+          "name": "slack_connections_organization_id_organization_id_fk",
+          "tableFrom": "slack_connections",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slack_connections_connected_by_user_id_user_id_fk": {
+          "name": "slack_connections_connected_by_user_id_user_id_fk",
+          "tableFrom": "slack_connections",
+          "tableTo": "user",
+          "columnsFrom": ["connected_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "slack_connections_team_id_unique": {
+          "name": "slack_connections_team_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["team_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trigger_runs": {
+      "name": "trigger_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configuration_revision_id": {
+          "name": "configuration_revision_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_event_receipt_id": {
+          "name": "provider_event_receipt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configured_trigger_name": {
+          "name": "configured_trigger_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation": {
+          "name": "conversation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'accepted'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inputs": {
+          "name": "inputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "values": {
+          "name": "values",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "trigger_context": {
+          "name": "trigger_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "output_context": {
+          "name": "output_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "deadline_at": {
+          "name": "deadline_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deadline_kind": {
+          "name": "deadline_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reaction_state": {
+          "name": "reaction_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_notification_pending_at": {
+          "name": "terminal_notification_pending_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_notification_delivered_at": {
+          "name": "terminal_notification_delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_notification_lease_expires_at": {
+          "name": "terminal_notification_lease_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection": {
+          "name": "rejection",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "trigger_runs_receipt_project_configured_unique": {
+          "name": "trigger_runs_receipt_project_configured_unique",
+          "columns": [
+            {
+              "expression": "provider_event_receipt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "configured_trigger_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trigger_runs_status_deadline_idx": {
+          "name": "trigger_runs_status_deadline_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deadline_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trigger_runs_project_created_idx": {
+          "name": "trigger_runs_project_created_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trigger_runs_terminal_notification_idx": {
+          "name": "trigger_runs_terminal_notification_idx",
+          "columns": [
+            {
+              "expression": "terminal_notification_delivered_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "terminal_notification_lease_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trigger_runs_organization_fk": {
+          "name": "trigger_runs_organization_fk",
+          "tableFrom": "trigger_runs",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trigger_runs_project_organization_fk": {
+          "name": "trigger_runs_project_organization_fk",
+          "tableFrom": "trigger_runs",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id", "organization_id"],
+          "columnsTo": ["id", "organization_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trigger_runs_revision_project_organization_fk": {
+          "name": "trigger_runs_revision_project_organization_fk",
+          "tableFrom": "trigger_runs",
+          "tableTo": "project_configuration_revisions",
+          "columnsFrom": ["configuration_revision_id", "project_id", "organization_id"],
+          "columnsTo": ["id", "project_id", "organization_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "trigger_runs_receipt_organization_fk": {
+          "name": "trigger_runs_receipt_organization_fk",
+          "tableFrom": "trigger_runs",
+          "tableTo": "provider_event_receipts",
+          "columnsFrom": ["provider_event_receipt_id", "organization_id"],
+          "columnsTo": ["id", "organization_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "trigger_runs_status_check": {
+          "name": "trigger_runs_status_check",
+          "value": "\"trigger_runs\".\"status\" in ('running', 'succeeded', 'failed', 'timed_out', 'rejected')"
+        },
+        "trigger_runs_outcome_check": {
+          "name": "trigger_runs_outcome_check",
+          "value": "(\"trigger_runs\".\"outcome\" = 'accepted' and \"trigger_runs\".\"status\" <> 'rejected' and \"trigger_runs\".\"rejection\" is null)\n        or (\"trigger_runs\".\"outcome\" = 'rejected' and \"trigger_runs\".\"status\" = 'rejected' and \"trigger_runs\".\"rejection\" is not null)"
+        },
+        "trigger_runs_deadline_kind_check": {
+          "name": "trigger_runs_deadline_kind_check",
+          "value": "\"trigger_runs\".\"deadline_kind\" is null or \"trigger_runs\".\"deadline_kind\" in ('step_hard', 'step_idle', 'whole_run')"
+        },
+        "trigger_runs_deadline_shape_check": {
+          "name": "trigger_runs_deadline_shape_check",
+          "value": "(\"trigger_runs\".\"outcome\" = 'accepted' and \"trigger_runs\".\"deadline_at\" is not null)\n        or (\"trigger_runs\".\"outcome\" = 'rejected' and \"trigger_runs\".\"deadline_at\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.trigger_schedules": {
+      "name": "trigger_schedules",
+      "schema": "",
+      "columns": {
+        "trigger_id": {
+          "name": "trigger_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recurrence": {
+          "name": "recurrence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_at": {
+          "name": "next_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_run_id": {
+          "name": "active_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "trigger_schedules_due_idx": {
+          "name": "trigger_schedules_due_idx",
+          "columns": [
+            {
+              "expression": "next_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trigger_schedules_trigger_id_organization_triggers_id_fk": {
+          "name": "trigger_schedules_trigger_id_organization_triggers_id_fk",
+          "tableFrom": "trigger_schedules",
+          "tableTo": "organization_triggers",
+          "columnsFrom": ["trigger_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trigger_schedules_active_run_id_trigger_runs_id_fk": {
+          "name": "trigger_schedules_active_run_id_trigger_runs_id_fk",
+          "tableFrom": "trigger_schedules",
+          "tableTo": "trigger_runs",
+          "columnsFrom": ["active_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "must_change_password": {
+          "name": "must_change_password",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_instance_operator": {
+          "name": "is_instance_operator",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_step_runs": {
+      "name": "workflow_step_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trigger_run_id": {
+          "name": "trigger_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_id": {
+          "name": "step_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_execution_id": {
+          "name": "agent_execution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deadline_kind": {
+          "name": "deadline_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deadline_at": {
+          "name": "deadline_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idle_deadline_at": {
+          "name": "idle_deadline_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatch_intent": {
+          "name": "dispatch_intent",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflow_step_runs_trigger_ordinal_unique": {
+          "name": "workflow_step_runs_trigger_ordinal_unique",
+          "columns": [
+            {
+              "expression": "trigger_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ordinal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_step_runs_trigger_step_unique": {
+          "name": "workflow_step_runs_trigger_step_unique",
+          "columns": [
+            {
+              "expression": "trigger_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "step_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_step_runs_agent_execution_unique": {
+          "name": "workflow_step_runs_agent_execution_unique",
+          "columns": [
+            {
+              "expression": "agent_execution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workflow_step_runs\".\"agent_execution_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_step_runs_trigger_status_idx": {
+          "name": "workflow_step_runs_trigger_status_idx",
+          "columns": [
+            {
+              "expression": "trigger_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_step_runs_trigger_run_fk": {
+          "name": "workflow_step_runs_trigger_run_fk",
+          "tableFrom": "workflow_step_runs",
+          "tableTo": "trigger_runs",
+          "columnsFrom": ["trigger_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_step_runs_status_check": {
+          "name": "workflow_step_runs_status_check",
+          "value": "\"workflow_step_runs\".\"status\" in ('pending', 'running', 'succeeded', 'skipped', 'failed', 'timed_out')"
+        },
+        "workflow_step_runs_deadline_kind_check": {
+          "name": "workflow_step_runs_deadline_kind_check",
+          "value": "\"workflow_step_runs\".\"deadline_kind\" is null or \"workflow_step_runs\".\"deadline_kind\" in ('step_hard', 'step_idle', 'whole_run')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_wakeups": {
+      "name": "workflow_wakeups",
+      "schema": "",
+      "columns": {
+        "trigger_run_id": {
+          "name": "trigger_run_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "available_at": {
+          "name": "available_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflow_wakeups_available_lease_idx": {
+          "name": "workflow_wakeups_available_lease_idx",
+          "columns": [
+            {
+              "expression": "available_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lease_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_wakeups_trigger_run_fk": {
+          "name": "workflow_wakeups_trigger_run_fk",
+          "tableFrom": "workflow_wakeups",
+          "tableTo": "trigger_runs",
+          "columnsFrom": ["trigger_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.agent_execution_status": {
+      "name": "agent_execution_status",
+      "schema": "public",
+      "values": ["spawning", "running", "succeeded", "failed"]
+    },
+    "public.machine_status": {
+      "name": "machine_status",
+      "schema": "public",
+      "values": ["spawning", "alive", "terminated"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -337,6 +337,13 @@
       "when": 1788961022620,
       "tag": "0047_loving_nuke",
       "breakpoints": true
+    },
+    {
+      "idx": 48,
+      "version": "7",
+      "when": 1788991675061,
+      "tag": "0048_execution_authority",
+      "breakpoints": true
     }
   ]
 }

--- a/src/agent-sessions/index.test.ts
+++ b/src/agent-sessions/index.test.ts
@@ -51,7 +51,7 @@ class TestAgents implements AgentConnection {
   }
 }
 
-async function fixture() {
+async function fixture(now = Date.now) {
   const database = createMemoryDatabase();
   const connection = new TestAgents();
   const outputs = new OutputExecutorRegistry();
@@ -63,7 +63,7 @@ async function fixture() {
       replies.push({ executionId: input.agentExecutionId, context: input.outputContext });
     },
   });
-  const sessions = new AgentSessions(database, "secret", "https://hub.test", outputs);
+  const sessions = new AgentSessions(database, "secret", "https://hub.test", outputs, now);
   const capabilities = createExecutionCapabilityServer({
     database,
     outputs,
@@ -76,6 +76,7 @@ async function fixture() {
     target = "daemon",
     env: Record<string, string> = {},
     prompt = "hello",
+    overrides: Partial<LaunchMachineIntent> = {},
   ) {
     const executionId = randomUUID();
     const intent: LaunchMachineIntent = {
@@ -96,6 +97,7 @@ async function fixture() {
       configurationRevisionId: randomUUID(),
       hubConfig: {},
       ...(key === false ? {} : { continuation: { key, compatibility: { target } } }),
+      ...overrides,
     };
     await database.insertAgentExecution({
       id: executionId,
@@ -106,6 +108,7 @@ async function fixture() {
       outputContext: intent.outputContext,
       configurationRevisionId: intent.configurationRevisionId,
       launchIntent: intent,
+      ...(intent.deadlineAt === undefined ? {} : { deadlineAt: intent.deadlineAt }),
     });
     return {
       executionId,
@@ -118,7 +121,7 @@ async function fixture() {
           createOptions: async () => ({
             provider: "codex",
             cwd: "/repo",
-            env: {},
+            env: intent.github === undefined ? {} : { GH_TOKEN: "scoped-github-token" },
             toolPolicy: { preapproved: [] },
           }),
         }),
@@ -238,15 +241,69 @@ test("ordinary launches use agent sessions and preserve long prompts without ena
   ]);
 });
 
-test("temporary environment credentials require a new agent instead of being reused", async () => {
+test("steering keeps the active agent's scoped credentials instead of requiring a new agent", async () => {
   const f = await fixture();
   const env = { TOKEN: "${{ paseo.connections.support.token }}" };
-  const continuing = await f.arrival("conversation", "daemon", env);
-  await expect(continuing.dispatch()).rejects.toThrow(
-    "Temporary environment credentials require New agent",
-  );
-  expect(f.connection.creates).toHaveLength(0);
-  const fresh = await f.arrival(null, "daemon", env);
-  await fresh.dispatch();
+  const github = {
+    connection: "getpaseo-github",
+    repositories: ["getpaseo/paseo"],
+    permissions: { contents: "write" as const },
+    durationMs: 60 * 60 * 1000,
+  };
+  const first = await f.arrival("conversation", "daemon", env, "first request", { github });
+  const original = await first.dispatch();
+  const next = await f.arrival("conversation", "daemon", env, "follow-up", { github });
+  expect(await next.dispatch()).toMatchObject({ agentId: original.agentId, action: "continued" });
   expect(f.connection.creates).toHaveLength(1);
+  expect(f.connection.creates[0]?.env).toEqual({ GH_TOKEN: "scoped-github-token" });
+  expect(f.connection.deliveries).toHaveLength(2);
+});
+
+test("steering cannot extend the active agent's original max-runtime deadline", async () => {
+  const f = await fixture();
+  const deadlineAt = new Date("2030-01-01T01:00:00Z");
+  const first = await f.arrival("conversation", "daemon", {}, "first request", { deadlineAt });
+  await first.dispatch();
+  const next = await f.arrival("conversation", "daemon", {}, "follow-up", {
+    deadlineAt: new Date("2030-01-01T01:30:00Z"),
+  });
+  await next.dispatch();
+  expect((await f.execution(first.executionId)).deadlineAt).toEqual(deadlineAt);
+  expect((await f.execution(next.executionId)).deadlineAt).toEqual(deadlineAt);
+});
+
+test("a completed credentialed task gets a fresh agent and isolates the previous agent's tools", async () => {
+  const f = await fixture();
+  const github = {
+    connection: "getpaseo-github",
+    repositories: ["getpaseo/paseo"],
+    permissions: { contents: "write" as const },
+    durationMs: 60 * 60 * 1000,
+  };
+  const first = await f.arrival("conversation", "daemon", {}, "first", { github });
+  const original = await first.dispatch();
+  await f.database.transitionAgentExecution(first.executionId, "succeeded");
+  await f.sessions.releaseAuthority(await f.execution(first.executionId), async () => {});
+  const next = await f.arrival("conversation", "daemon", {}, "next task", { github });
+  const fresh = await next.dispatch();
+  expect(fresh.agentId).not.toBe(original.agentId);
+  expect(f.connection.creates).toHaveLength(2);
+  expect(await f.call(next.executionId, "finish_execution", {}, first.executionId)).toMatchObject({
+    result: { isError: true },
+  });
+});
+
+test("a ping cannot send more work after the inherited deadline while timeout cleanup is pending", async () => {
+  let now = Date.parse("2030-01-01T00:00:00Z");
+  const f = await fixture(() => now);
+  const first = await f.arrival("conversation", "daemon", {}, "first", {
+    deadlineAt: new Date(now + 1000),
+  });
+  await first.dispatch();
+  now += 1000;
+  const next = await f.arrival("conversation", "daemon", {}, "too late", {
+    deadlineAt: new Date(now + 1000),
+  });
+  await expect(next.dispatch()).rejects.toThrow("execution_deadline_exceeded");
+  expect(f.connection.deliveries).toHaveLength(1);
 });

--- a/src/agent-sessions/index.ts
+++ b/src/agent-sessions/index.ts
@@ -27,6 +27,7 @@ export class AgentSessions {
     private readonly secret: string,
     private readonly publicBaseUrl: string,
     private readonly outputs: OutputExecutorRegistry,
+    private readonly now: () => number = Date.now,
   ) {}
 
   async dispatch(input: {
@@ -40,40 +41,61 @@ export class AgentSessions {
     unsubscribe: () => void;
     action: "created" | "continued" | "restored";
   }> {
+    const incoming = await this.database.findAgentExecutionById(input.executionId);
+    if (!incoming || !isActive(incoming)) throw new AgentSessionError("execution_terminal");
     const policy = input.intent.continuation;
     const startupTimeoutMs = input.intent.startupTimeoutMs ?? DEFAULT_STARTUP_TIMEOUT_MS;
     const continuationKey = policy?.key ?? null;
-    if (
-      continuationKey !== null &&
-      (input.intent.github !== undefined ||
-        Object.values({ ...input.intent.environment.env, ...input.intent.env }).some(
-          (value) => parseConnectionTemplate(value).length > 0,
-        ))
-    ) {
-      throw new AgentSessionError(
-        "Temporary environment credentials require New agent continuity. Existing agents cannot refresh their environment.",
+    const projectId = input.intent.projectId;
+    const lockId = deriveSessionId(projectId, continuationKey ?? `execution:${input.executionId}`);
+    const findSession = async () => {
+      const execution = await this.database.findAgentExecutionById(input.executionId);
+      if (execution?.agentSessionId)
+        return this.database.findAgentSession(execution.agentSessionId);
+      return continuationKey === null
+        ? this.database.findAgentSession(
+            deriveSessionId(projectId, `execution:${input.executionId}`),
+          )
+        : this.database.findAgentSessionByKey(projectId, continuationKey);
+    };
+    const isFinishedCredentialedSession = async (session: AgentSessionRecord) => {
+      const executions = await this.database.listAgentSessionExecutions(session.id);
+      return (
+        executions.length > 0 &&
+        !executions.some(isActive) &&
+        executions.some(
+          (execution) =>
+            execution.launchIntent !== null && hasTemporaryCredentials(execution.launchIntent),
+        )
       );
-    }
-    const id = sessionId(
-      input.intent.projectId,
-      continuationKey ?? `execution:${input.executionId}`,
-    );
+    };
     // External credential minting must not hold a database connection open during shutdown.
-    const storedSession = await this.database.findAgentSession(id);
-    const options = storedSession?.creationOptions ?? (await input.createOptions());
-    return this.database.withAdvisoryLock(`agent-session:${id}`, async () => {
+    const storedSession = await findSession();
+    const options =
+      !storedSession || (await isFinishedCredentialedSession(storedSession))
+        ? await input.createOptions()
+        : undefined;
+    const dispatched = await this.database.withAdvisoryLock(`agent-session:${lockId}`, async () => {
       const tools = executionToolDefinitions(
         input.intent.outputSchema,
         this.outputs.materialize(input.intent.allowOutputs, input.intent.outputContext),
       );
       const compatibility = fingerprint({ settings: policy?.compatibility, tools });
-      let session = await this.database.findAgentSession(id);
+      let session = await findSession();
+      if (session && (await isFinishedCredentialedSession(session))) {
+        // Completion may have raced credential preparation. Retry outside the lock.
+        if (!options) return undefined;
+        await this.database.saveAgentSession({ ...session, continuationKey: null });
+        session = undefined;
+      }
+      const id = session?.id ?? deriveSessionId(projectId, `execution:${input.executionId}`);
       if (session && session.compatibility !== compatibility) {
         throw new AgentSessionError(
           "Continuation settings differ from the existing agent; use a different key or choose a new agent",
         );
       }
       if (!session) {
+        if (!options) return undefined;
         const token = deriveAgentExecutionCompletionToken(this.secret, `session:${id}`);
         session = {
           id,
@@ -103,6 +125,16 @@ export class AgentSessions {
         };
         await this.database.saveAgentSession(session);
       }
+      const activeExecutions = (await this.database.listAgentSessionExecutions(id)).filter(
+        (execution) => execution.status === "spawning" || execution.status === "running",
+      );
+      const deadline = activeExecutions.reduce<number>(
+        (earliest, execution) =>
+          Math.min(earliest, execution.deadlineAt?.getTime() ?? Number.POSITIVE_INFINITY),
+        Number.POSITIVE_INFINITY,
+      );
+      if (Number.isFinite(deadline))
+        await this.database.limitAgentExecutionDeadline(input.executionId, new Date(deadline));
       await this.database.attachExecutionToSession(input.executionId, id);
       let action: "created" | "continued" | "restored" = "continued";
       if (session.agentId === null) {
@@ -127,26 +159,42 @@ export class AgentSessions {
         action = "restored";
       }
       await this.database.attachExecutionToSession(input.executionId, id, action);
-      const unsubscribe = await input.connection.watch(session.agentId, input.onEvent);
-      try {
-        const execution = await this.database.findAgentExecutionById(input.executionId);
-        if (!execution || execution.status === "failed" || execution.status === "succeeded") {
-          throw new AgentSessionError("execution_terminal");
-        }
-        await input.connection.send(
-          session.agentId,
-          input.executionId,
-          policy === undefined
-            ? input.intent.prompt
-            : `Hub execution: ${input.executionId}\nUse this executionId for Hub tool calls for this request.\n\n${input.intent.prompt}`,
-          startupTimeoutMs,
-        );
-      } catch (error) {
-        unsubscribe();
-        throw error;
-      }
+      const unsubscribe = await this.deliver(input, session.agentId, startupTimeoutMs);
       return { agentId: session.agentId, unsubscribe, action };
     });
+    return dispatched ?? this.dispatch(input);
+  }
+
+  private async deliver(
+    input: {
+      executionId: string;
+      intent: LaunchMachineIntent;
+      connection: AgentConnection;
+      onEvent: (event: AgentEvent) => void;
+    },
+    agentId: string,
+    startupTimeoutMs: number,
+  ): Promise<() => void> {
+    const unsubscribe = await input.connection.watch(agentId, input.onEvent);
+    try {
+      const execution = await this.database.findAgentExecutionById(input.executionId);
+      if (!execution || !isActive(execution)) throw new AgentSessionError("execution_terminal");
+      if (execution.deadlineAt !== null && execution.deadlineAt.getTime() <= this.now()) {
+        throw new AgentSessionError("execution_deadline_exceeded");
+      }
+      await input.connection.send(
+        agentId,
+        input.executionId,
+        input.intent.continuation === undefined
+          ? input.intent.prompt
+          : `Hub execution: ${input.executionId}\nUse this executionId for Hub tool calls for this request.\n\n${input.intent.prompt}`,
+        startupTimeoutMs,
+      );
+      return unsubscribe;
+    } catch (error) {
+      unsubscribe();
+      throw error;
+    }
   }
 
   async control(
@@ -159,7 +207,7 @@ export class AgentSessions {
     const session = await this.database.findAgentSession(id);
     if (!session?.agentId || !session.workspaceId) return false;
     const { agentId, workspaceId } = session;
-    return this.database.withAdvisoryLock(`agent-session:${id}`, async () => {
+    return this.database.withAdvisoryLock(sessionLock(session), async () => {
       const executions = await this.database.listAgentSessionExecutions(id);
       // A completed arrival cannot stop work belonging to a newer arrival.
       if (executions.some((item) => item.status === "spawning" || item.status === "running"))
@@ -168,9 +216,38 @@ export class AgentSessions {
       return true;
     });
   }
+
+  async releaseAuthority(
+    execution: AgentExecutionRecord,
+    release: (executionId: string) => Promise<void>,
+  ): Promise<void> {
+    const sessionId = execution.agentSessionId;
+    const session =
+      sessionId === null ? undefined : await this.database.findAgentSession(sessionId);
+    const owners =
+      sessionId === null || !session
+        ? [execution.id]
+        : await this.database.withAdvisoryLock(sessionLock(session), async () => {
+            const executions = await this.database.listAgentSessionExecutions(sessionId);
+            if (executions.some((item) => item.status === "spawning" || item.status === "running"))
+              return [];
+            return executions.map((item) => item.id);
+          });
+    // Revocation can call upstream services; do not keep a database lock while it runs.
+    await Promise.all(owners.map(release));
+  }
+
+  async canResumeAuthority(
+    execution: AgentExecutionRecord,
+    available: (executionId: string) => boolean,
+  ): Promise<boolean> {
+    if (execution.agentSessionId === null) return available(execution.id);
+    const owners = await this.database.listAgentSessionExecutions(execution.agentSessionId);
+    return owners.some((owner) => available(owner.id));
+  }
 }
 
-function sessionId(projectId: string, key: string): string {
+function deriveSessionId(projectId: string, key: string): string {
   const hex = createHash("sha256")
     .update(JSON.stringify(["agent-session", projectId, key]))
     .digest("hex");
@@ -186,4 +263,19 @@ function fingerprint(value: unknown): string {
       ),
     )
     .digest("hex");
+}
+
+function isActive(execution: AgentExecutionRecord): boolean {
+  return execution.status === "spawning" || execution.status === "running";
+}
+function hasTemporaryCredentials(intent: LaunchMachineIntent): boolean {
+  return (
+    intent.github !== undefined ||
+    Object.values({ ...intent.environment.env, ...intent.env }).some(
+      (value) => parseConnectionTemplate(value).length > 0,
+    )
+  );
+}
+function sessionLock(session: AgentSessionRecord): string {
+  return `agent-session:${session.continuationKey === null ? session.id : deriveSessionId(session.projectId, session.continuationKey)}`;
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -239,6 +239,7 @@ export function createHubApplication(options: HubRuntimeOptions): HubApplication
     handleUpgrade:
       options.database === null ? null : createDaemonUpgradeHandler(options.database, daemons!),
     async start(sources = []) {
+      await options.executionAuthority?.recover();
       await Promise.all([
         daemonModule?.lifecycle.recoverAgentExecutionDeadlines(),
         daemonModule?.lifecycle.recoverPendingHubActions(),

--- a/src/application-runtime.ts
+++ b/src/application-runtime.ts
@@ -420,6 +420,7 @@ function createRuntimeExecutionAuthority(
     (integration) => integration.githubAuthority !== undefined,
   )?.githubAuthority;
   return createExecutionAuthority({
+    database,
     connectionsForProject,
     ...(githubAuthority === undefined ? {} : { githubAuthority }),
     isExecutionActive: async (executionId) => {

--- a/src/auth/github.ts
+++ b/src/auth/github.ts
@@ -34,7 +34,7 @@ const GitHubAppBotIdentitySchema = z.object({ id: z.number().int().positive(), l
 export interface GitHubAuth {
   getInstallation(installationId: number): Promise<GitHubInstallation | undefined>;
   getInstallationToken(installationId: number): Promise<string>;
-  mintInstallationToken(installationId: number): Promise<string>;
+  mintInstallationToken(installationId: number): Promise<GitHubInstallationAccessToken>;
   mintInstallationAccessToken(input: {
     installationId: number;
     accountLogin: string;
@@ -91,10 +91,12 @@ export function createGitHubAuth(options: CreateGitHubAuthOptions): GitHubAuth {
     return data.token;
   }
 
-  async function mintInstallationToken(installationId: number): Promise<string> {
+  async function mintInstallationToken(
+    installationId: number,
+  ): Promise<GitHubInstallationAccessToken> {
     const data = await requestInstallationToken(installationId);
     logger.debug({ installationId, expiresAt: data.expires_at }, "minted installation token");
-    return data.token;
+    return { token: data.token, expiresAt: new Date(data.expires_at).getTime() };
   }
 
   async function mintInstallationAccessToken(input: {

--- a/src/config/connections.ts
+++ b/src/config/connections.ts
@@ -1,6 +1,12 @@
+export interface ConnectionTokenLease {
+  provider: "github";
+  token: string;
+  expiresAt: number;
+}
+
 export interface ConnectionResolutionContext {
   executionId?: string;
-  registerToken?: (token: string, revoke?: () => Promise<void> | void) => Promise<void> | void;
+  registerToken?: (lease: ConnectionTokenLease) => Promise<void> | void;
 }
 
 export type ConnectionResolver = (

--- a/src/daemons/daemons.test.ts
+++ b/src/daemons/daemons.test.ts
@@ -590,30 +590,39 @@ describe("daemon enrollment and execution", () => {
     ]);
   });
 
-  it("stops all steered requests and revokes their scoped credentials at the original hard deadline", async () => {
-    await hub.connectDaemon();
-    const settings = {
-      timeoutMs: 10_000,
-      continuation: { key: "bounded-thread", compatibility: { target: "same-repository" } },
-      github: {
-        connection: "getpaseo-github",
-        repositories: ["getpaseo/paseo"],
-        permissions: { contents: "write" as const },
-        durationMs: 60 * 60 * 1000,
-      },
-    };
-    const first = await hub.handoff(settings);
-    await hub.waitForCreatedAgentLaunch();
-    await hub.advanceDispatchTime(5_000);
-    const next = await hub.handoff(settings);
-    await hub.waitForRecoveredExecution(next.execution.id);
+  it.each(["agent", "workflow"])(
+    "stops steered requests and revokes credentials at the hard deadline via %s",
+    async (deadlineOwner) => {
+      await hub.connectDaemon();
+      const settings = {
+        timeoutMs: 10_000,
+        continuation: { key: "bounded-thread", compatibility: { target: "same-repository" } },
+        github: {
+          connection: "getpaseo-github",
+          repositories: ["getpaseo/paseo"],
+          permissions: { contents: "write" as const },
+          durationMs: 60 * 60 * 1000,
+        },
+      };
+      const first = await hub.handoff(settings);
+      await hub.waitForCreatedAgentLaunch();
+      await hub.advanceDispatchTime(5_000);
+      const next = await hub.handoff(settings);
+      await hub.waitForRecoveredExecution(next.execution.id, "running");
 
-    await hub.advanceDispatchTime(5_000);
-    assert.equal((await hub.execution(first.execution.id)).status, "failed");
-    assert.equal((await hub.execution(next.execution.id)).status, "failed");
-    assert.ok(hub.controlActions().includes("interrupt"));
-    assert.deepEqual(hub.authorityRevokedTokens(), ["durable-scoped-token-1"]);
-  });
+      if (deadlineOwner === "workflow") {
+        hub.advanceDispatchClock(5_000);
+        await hub.drainWorkflowOutbox();
+      } else {
+        await hub.advanceDispatchTime(5_000);
+      }
+      await hub.waitForExecutionStatus(first.execution.id, "failed");
+      await hub.waitForExecutionStatus(next.execution.id, "failed");
+      await hub.waitForControlAction("interrupt");
+      await hub.waitForAuthorityRevocation();
+      assert.deepEqual(hub.authorityRevokedTokens(), ["durable-scoped-token-1"]);
+    },
+  );
 
   it("resumes scoped credentials after restart without recreating the agent or reminting", async () => {
     await hub.connectDaemon();

--- a/src/daemons/daemons.test.ts
+++ b/src/daemons/daemons.test.ts
@@ -532,7 +532,7 @@ describe("daemon enrollment and execution", () => {
     assert.deepEqual(hub.authorityRevokedTokens(), ["durable-scoped-token-1"]);
   });
 
-  it("fails recovery of revoked scoped credentials without recreating the agent or reminting", async () => {
+  it("resumes scoped credentials after restart without recreating the agent or reminting", async () => {
     await hub.connectDaemon();
     const handedOff = await hub.handoff({
       github: {
@@ -546,15 +546,14 @@ describe("daemon enrollment and execution", () => {
     assert.deepEqual(hub.authorityRevokedTokens(), []);
 
     await hub.restartApp();
-    const failed = await hub.waitForExecutionStatus(handedOff.execution.id, "failed");
-
-    assert.deepEqual(hub.authorityRevokedTokens(), ["durable-scoped-token-1"]);
-    assert.deepEqual(failed.result, {
-      status: "failed",
-      reason: "execution_credentials_unavailable",
-    });
+    await hub.runtimeResources({ executionSubscriptions: 1 });
+    const recovered = await hub.execution(handedOff.execution.id);
+    assert.equal(recovered.status, "running");
+    assert.deepEqual(hub.authorityRevokedTokens(), []);
     assert.equal(hub.authorityMintInputs().length, 1);
     assert.equal(hub.createdAgentRequestCount(), 1);
+    assert.equal(await hub.completeExecution(handedOff.execution.id), 200);
+    assert.deepEqual(hub.authorityRevokedTokens(), ["durable-scoped-token-1"]);
   });
 
   it("bounds Hub shutdown when terminal cleanup follows a permanently unresolved authority mint", async () => {
@@ -575,7 +574,7 @@ describe("daemon enrollment and execution", () => {
       () => undefined,
       (error: unknown) => error,
     );
-    const execution = await hub.waitForPendingExecution();
+    await hub.waitForPendingExecution();
     await hub.waitForAuthorityMint();
 
     await hub.advanceDispatchTime(30_000);
@@ -585,22 +584,10 @@ describe("daemon enrollment and execution", () => {
     const shutdownStartedAt = Date.now();
     await hub.stopRuntimeResources();
     const shutdownElapsedMs = Date.now() - shutdownStartedAt;
-    const stopResult = await hub.authorityStopResult();
-
+    await hub.authorityStopResult();
     assert.ok(shutdownElapsedMs < 15_000, `Hub shutdown took ${shutdownElapsedMs}ms`);
     assert.ok((await dispatchOutcome) instanceof DaemonDispatchFailure);
     assert.equal(hub.createdAgentRequestCount(), 0);
-    assert.deepEqual(stopResult, {
-      residualExposures: [
-        {
-          executionId: execution.id,
-          leaseCount: 0,
-          pendingMaterializations: 1,
-        },
-      ],
-    });
-    assert.equal(JSON.stringify(stopResult).includes("durable-connection-token"), false);
-    assert.equal(JSON.stringify(stopResult).includes("durable-scoped-token"), false);
   }, 30_000);
 
   it("preserves literal worktree evidence during restart recovery", async () => {

--- a/src/daemons/daemons.test.ts
+++ b/src/daemons/daemons.test.ts
@@ -532,6 +532,88 @@ describe("daemon enrollment and execution", () => {
     assert.deepEqual(hub.authorityRevokedTokens(), ["durable-scoped-token-1"]);
   });
 
+  it("keeps scoped credentials until all requests steering the active agent finish", async () => {
+    await hub.connectDaemon();
+    const settings = {
+      continuation: { key: "same-thread", compatibility: { target: "same-repository" } },
+      github: {
+        connection: "getpaseo-github",
+        repositories: ["getpaseo/paseo"],
+        permissions: { contents: "write" as const },
+        durationMs: 60 * 60 * 1000,
+      },
+    };
+    const first = await hub.handoff(settings);
+    await hub.waitForCreatedAgentLaunch();
+    await hub.advanceDispatchTime(1_000);
+    const next = await hub.handoff(settings);
+    await hub.waitForRecoveredExecution(next.execution.id);
+
+    assert.equal(hub.createdAgentRequestCount(), 1);
+    assert.equal(hub.authorityMintInputs().length, 1);
+    assert.equal(
+      (await hub.execution(next.execution.id)).deadlineAt?.getTime(),
+      (await hub.execution(first.execution.id)).deadlineAt?.getTime(),
+    );
+    assert.equal(
+      Reflect.get(Object(hub.createdAgentLaunch().env), "GH_TOKEN"),
+      "durable-scoped-token-1",
+    );
+    await hub.callSessionTool(first.execution.id, "finish_execution");
+    assert.equal((await hub.execution(first.execution.id)).status, "succeeded");
+    assert.deepEqual(hub.authorityRevokedTokens(), []);
+
+    await hub.disconnectDaemon();
+    await hub.reconnectDaemon();
+    await hub.waitForRecoveredExecution(next.execution.id);
+    assert.equal(hub.createdAgentRequestCount(), 1);
+    assert.equal(hub.authorityMintInputs().length, 1);
+
+    await hub.callSessionTool(next.execution.id, "finish_execution");
+    assert.equal((await hub.execution(next.execution.id)).status, "succeeded");
+    assert.deepEqual(hub.authorityRevokedTokens(), ["durable-scoped-token-1"]);
+
+    const later = await hub.handoff(settings);
+    await hub.waitForRecoveredExecution(later.execution.id);
+    assert.equal(hub.createdAgentRequestCount(), 2);
+    assert.equal(hub.authorityMintInputs().length, 2);
+    assert.notEqual(
+      (await hub.execution(later.execution.id)).agentSessionId,
+      (await hub.execution(first.execution.id)).agentSessionId,
+    );
+    await hub.callSessionTool(later.execution.id, "finish_execution");
+    assert.equal((await hub.execution(later.execution.id)).status, "succeeded");
+    assert.deepEqual(hub.authorityRevokedTokens(), [
+      "durable-scoped-token-1",
+      "durable-scoped-token-2",
+    ]);
+  });
+
+  it("stops all steered requests and revokes their scoped credentials at the original hard deadline", async () => {
+    await hub.connectDaemon();
+    const settings = {
+      timeoutMs: 10_000,
+      continuation: { key: "bounded-thread", compatibility: { target: "same-repository" } },
+      github: {
+        connection: "getpaseo-github",
+        repositories: ["getpaseo/paseo"],
+        permissions: { contents: "write" as const },
+        durationMs: 60 * 60 * 1000,
+      },
+    };
+    const first = await hub.handoff(settings);
+    await hub.waitForCreatedAgentLaunch();
+    await hub.advanceDispatchTime(5_000);
+    const next = await hub.handoff(settings);
+    await hub.waitForRecoveredExecution(next.execution.id);
+
+    await hub.advanceDispatchTime(5_000);
+    assert.equal((await hub.execution(first.execution.id)).status, "failed");
+    assert.equal((await hub.execution(next.execution.id)).status, "failed");
+    assert.ok(hub.controlActions().includes("interrupt"));
+    assert.deepEqual(hub.authorityRevokedTokens(), ["durable-scoped-token-1"]);
+  });
+
   it("fails recovery of revoked scoped credentials without recreating the agent or reminting", async () => {
     await hub.connectDaemon();
     const handedOff = await hub.handoff({

--- a/src/daemons/daemons.test.ts
+++ b/src/daemons/daemons.test.ts
@@ -589,30 +589,39 @@ describe("daemon enrollment and execution", () => {
     ]);
   });
 
-  it("stops all steered requests and revokes their scoped credentials at the original hard deadline", async () => {
-    await hub.connectDaemon();
-    const settings = {
-      timeoutMs: 10_000,
-      continuation: { key: "bounded-thread", compatibility: { target: "same-repository" } },
-      github: {
-        connection: "getpaseo-github",
-        repositories: ["getpaseo/paseo"],
-        permissions: { contents: "write" as const },
-        durationMs: 60 * 60 * 1000,
-      },
-    };
-    const first = await hub.handoff(settings);
-    await hub.waitForCreatedAgentLaunch();
-    await hub.advanceDispatchTime(5_000);
-    const next = await hub.handoff(settings);
-    await hub.waitForRecoveredExecution(next.execution.id);
+  it.each(["agent", "workflow"])(
+    "stops steered requests and revokes credentials at the hard deadline via %s",
+    async (deadlineOwner) => {
+      await hub.connectDaemon();
+      const settings = {
+        timeoutMs: 10_000,
+        continuation: { key: "bounded-thread", compatibility: { target: "same-repository" } },
+        github: {
+          connection: "getpaseo-github",
+          repositories: ["getpaseo/paseo"],
+          permissions: { contents: "write" as const },
+          durationMs: 60 * 60 * 1000,
+        },
+      };
+      const first = await hub.handoff(settings);
+      await hub.waitForCreatedAgentLaunch();
+      await hub.advanceDispatchTime(5_000);
+      const next = await hub.handoff(settings);
+      await hub.waitForRecoveredExecution(next.execution.id, "running");
 
-    await hub.advanceDispatchTime(5_000);
-    assert.equal((await hub.execution(first.execution.id)).status, "failed");
-    assert.equal((await hub.execution(next.execution.id)).status, "failed");
-    assert.ok(hub.controlActions().includes("interrupt"));
-    assert.deepEqual(hub.authorityRevokedTokens(), ["durable-scoped-token-1"]);
-  });
+      if (deadlineOwner === "workflow") {
+        hub.advanceDispatchClock(5_000);
+        await hub.drainWorkflowOutbox();
+      } else {
+        await hub.advanceDispatchTime(5_000);
+      }
+      await hub.waitForExecutionStatus(first.execution.id, "failed");
+      await hub.waitForExecutionStatus(next.execution.id, "failed");
+      await hub.waitForControlAction("interrupt");
+      await hub.waitForAuthorityRevocation();
+      assert.deepEqual(hub.authorityRevokedTokens(), ["durable-scoped-token-1"]);
+    },
+  );
 
   it("fails recovery of revoked scoped credentials without recreating the agent or reminting", async () => {
     await hub.connectDaemon();

--- a/src/daemons/lifecycle.ts
+++ b/src/daemons/lifecycle.ts
@@ -929,6 +929,10 @@ export class DaemonDispatchLifecycle {
       this.clearExecutionDeadline(executionId);
       this.releaseExecutionResources(executionId);
       this.startedExecutions.delete(executionId);
+      const execution = await this.options.database.findAgentExecutionById(executionId);
+      if (execution && isTerminalExecutionStatus(execution.status)) {
+        await this.notifyExecutionTerminal(execution);
+      }
     }
     await this.recoverPendingHubActions();
   }

--- a/src/daemons/lifecycle.ts
+++ b/src/daemons/lifecycle.ts
@@ -1010,13 +1010,15 @@ export class DaemonDispatchLifecycle {
     if (
       current.agentSessionId !== null &&
       this.options.executionAuthority &&
-      !this.options.executionAuthority.canResume({
-        executionId: current.id,
-        projectId: intent.projectId,
-        triggerContext: intent.triggerContext,
-        env: { ...intent.environment.env, ...intent.env },
-        ...(intent.github === undefined ? {} : { github: intent.github }),
-      })
+      !(await this.sessionOwner().canResumeAuthority(current, (executionId) =>
+        this.options.executionAuthority!.canResume({
+          executionId,
+          projectId: intent.projectId,
+          triggerContext: intent.triggerContext,
+          env: { ...intent.environment.env, ...intent.env },
+          ...(intent.github === undefined ? {} : { github: intent.github }),
+        }),
+      ))
     ) {
       await this.failAgentExecution(current.id, "execution_credentials_unavailable");
       return;
@@ -1381,19 +1383,18 @@ export class DaemonDispatchLifecycle {
         this.report(error, "daemon.provider.terminal-cleanup", { executionId: execution.id });
       });
     }
-    await Promise.all(
-      this.options.executionAuthority === undefined
-        ? []
-        : [
-            this.options.executionAuthority
-              .onExecutionTerminal(execution.id)
-              .catch((error: unknown) => {
-                this.report(error, "daemon.execution-authority.terminal-cleanup", {
-                  executionId: execution.id,
-                });
-              }),
-          ],
-    );
+    const authority = this.options.executionAuthority;
+    if (authority === undefined) return;
+    const release = (executionId: string) => authority.onExecutionTerminal(executionId);
+    await (
+      execution.agentSessionId === null
+        ? release(execution.id)
+        : this.sessionOwner().releaseAuthority(execution, release)
+    ).catch((error: unknown) => {
+      this.report(error, "daemon.execution-authority.terminal-cleanup", {
+        executionId: execution.id,
+      });
+    });
   }
 
   private async notifyMachineTerminatedForExecution(
@@ -1513,6 +1514,7 @@ export class DaemonDispatchLifecycle {
       this.options.completionTokenSecret,
       this.options.publicBaseUrl,
       this.executionCapabilities,
+      () => this.now(),
     );
   }
 

--- a/src/daemons/lifecycle.ts
+++ b/src/daemons/lifecycle.ts
@@ -1010,13 +1010,13 @@ export class DaemonDispatchLifecycle {
     if (
       current.agentSessionId !== null &&
       this.options.executionAuthority &&
-      !this.options.executionAuthority.canResume({
+      !(await this.options.executionAuthority.canResume({
         executionId: current.id,
         projectId: intent.projectId,
         triggerContext: intent.triggerContext,
         env: { ...intent.environment.env, ...intent.env },
         ...(intent.github === undefined ? {} : { github: intent.github }),
-      })
+      }))
     ) {
       await this.failAgentExecution(current.id, "execution_credentials_unavailable");
       return;

--- a/src/daemons/test-utils/hub-harness.ts
+++ b/src/daemons/test-utils/hub-harness.ts
@@ -135,6 +135,7 @@ const ExecutionSessionRequestSchema = z.object({
       agentId: z.string(),
       messageId: z.string(),
       text: z.string(),
+      activeTurnBehavior: z.literal("steer"),
     }),
     z.object({
       type: z.literal("cancel_agent_request"),
@@ -1160,6 +1161,36 @@ export class HubHarness {
         id: 1,
         method: "tools/call",
         params: { name, arguments: args },
+      }),
+    });
+    assert.equal(response.status, 200);
+    const body: unknown = await response.json();
+    assert.ok(isRecord(body));
+    return body;
+  }
+
+  async callSessionTool(
+    executionId: string,
+    name: "finish_execution" | "reply",
+    args: Record<string, unknown> = {},
+  ): Promise<Record<string, unknown>> {
+    const execution = await this.execution(executionId);
+    assert.ok(execution.agentSessionId);
+    const session = await this.requireDatabase().findAgentSession(execution.agentSessionId);
+    const mcp = session?.creationOptions.mcpServers?.["hub"];
+    assert.ok(mcp);
+    const response = await fetch(mcp.url, {
+      method: "POST",
+      headers: {
+        ...mcp.headers,
+        accept: "application/json, text/event-stream",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name, arguments: { ...args, executionId } },
       }),
     });
     assert.equal(response.status, 200);

--- a/src/daemons/test-utils/hub-harness.ts
+++ b/src/daemons/test-utils/hub-harness.ts
@@ -1765,13 +1765,16 @@ export class HubHarness {
 
   private createExecutionAuthority(): ExecutionAuthority {
     return createExecutionAuthority({
+      database: this.requireDatabase(),
       connectionsForProject: () => async (connectionSlug, value, context) => {
         if (connectionSlug !== "some-connection" || value !== "token") {
           throw new Error(`unexpected test connection: ${connectionSlug}.${value}`);
         }
         if (this.issueAuthorityConnectionLease) {
-          await context?.registerToken?.("durable-connection-token", async () => {
-            this.authorityRevocations.push("durable-connection-token");
+          await context?.registerToken?.({
+            provider: "github",
+            token: "durable-connection-token",
+            expiresAt: Date.now() + 60 * 60_000,
           });
         }
         return "resolved-secret";

--- a/src/daemons/test-utils/hub-harness.ts
+++ b/src/daemons/test-utils/hub-harness.ts
@@ -837,6 +837,9 @@ export class HubHarness {
   controlActions(): readonly HubExecutionControlAction[] {
     return this.requireDaemon().controlActions();
   }
+  async waitForControlAction(action: HubExecutionControlAction): Promise<void> {
+    await waitFor(async () => this.controlActions().includes(action));
+  }
   originUrl(): string {
     return this.origin;
   }

--- a/src/db/memory.ts
+++ b/src/db/memory.ts
@@ -2232,6 +2232,39 @@ class MemoryDatabase implements Database {
     return record;
   }
 
+  private readonly authorityRecords = new Map<
+    string,
+    import("../execution-authority/index.js").ExecutionAuthorityRecord
+  >();
+  private readonly authorityLeases = new Map<
+    string,
+    import("../execution-authority/index.js").ExecutionCredentialLease
+  >();
+  readonly executionAuthority: import("../execution-authority/index.js").ExecutionAuthorityStore = {
+    executions: async () => [...this.authorityRecords.keys()],
+    read: async (id) => structuredClone(this.authorityRecords.get(id)),
+    commit: async (record) => {
+      if (!this.authorityRecords.has(record.executionId))
+        this.authorityRecords.set(record.executionId, structuredClone(record));
+      return structuredClone(this.authorityRecords.get(record.executionId)!);
+    },
+    remove: async (id) => {
+      this.authorityRecords.delete(id);
+    },
+    leases: async (executionId) =>
+      structuredClone(
+        [...this.authorityLeases.values()].filter(
+          (lease) => executionId === undefined || lease.executionId === executionId,
+        ),
+      ),
+    saveLease: async (lease) => {
+      this.authorityLeases.set(lease.id, structuredClone(lease));
+    },
+    removeLease: async (id) => {
+      this.authorityLeases.delete(id);
+    },
+  };
+
   private readonly agentSessions = new Map<
     string,
     import("../agent-sessions/index.js").AgentSessionRecord

--- a/src/db/memory.ts
+++ b/src/db/memory.ts
@@ -1625,6 +1625,29 @@ class MemoryDatabase implements Database {
     return updated;
   }
 
+  async limitAgentExecutionDeadline(executionId: string, deadlineAt: Date) {
+    const execution = this.readAgentExecution(executionId);
+    if (isTerminalAgentExecutionStatus(execution.status)) return;
+    const boundedDeadline = new Date(
+      Math.min(deadlineAt.getTime(), execution.deadlineAt?.getTime() ?? Number.POSITIVE_INFINITY),
+    );
+    const idleDeadlineAt = capIdleDeadline(execution.idleDeadlineAt, boundedDeadline);
+    this.agentExecutions.set(executionId, {
+      ...execution,
+      deadlineAt: boundedDeadline,
+      idleDeadlineAt,
+    });
+    if (execution.workflowStepRunId !== null) {
+      const step = this.workflowStepRuns.get(execution.workflowStepRunId);
+      if (step !== undefined)
+        this.workflowStepRuns.set(step.id, {
+          ...step,
+          deadlineAt: boundedDeadline,
+          idleDeadlineAt,
+        });
+    }
+  }
+
   async setAgentExecutionIdleDeadline(
     executionId: string,
     idleDeadlineAt: Date | null,
@@ -2238,6 +2261,13 @@ class MemoryDatabase implements Database {
   >();
   async findAgentSession(id: string) {
     return structuredClone(this.agentSessions.get(id));
+  }
+  async findAgentSessionByKey(projectId: string, key: string) {
+    return structuredClone(
+      [...this.agentSessions.values()].find(
+        (session) => session.projectId === projectId && session.continuationKey === key,
+      ),
+    );
   }
   async saveAgentSession(
     session: import("../agent-sessions/index.js").AgentSessionRecord,

--- a/src/db/migrations.integration.test.ts
+++ b/src/db/migrations.integration.test.ts
@@ -309,7 +309,7 @@ describe("database migration application", () => {
     assert.deepEqual(after, before);
     assert.deepEqual(await historicalShape(fixture.url), {
       authTables: 7,
-      drizzleMigrations: 48,
+      drizzleMigrations: 49,
       legacyArtifacts: null,
       legacyOperatorPrincipals: null,
       bootstrapOrganizationId: fixture.organizationId,

--- a/src/db/pg.ts
+++ b/src/db/pg.ts
@@ -1742,8 +1742,22 @@ class PgDatabase implements Database {
   }
 
   async limitAgentExecutionDeadline(executionId: string, deadlineAt: Date): Promise<void> {
-    await this.pool.query(
-      `with bounded as (
+    await this.pool.transaction(async (client) => {
+      // Match completion and deadline recovery: lock the run, then step, then execution.
+      const association = await client.query<{ id: string; trigger_run_id: string }>(
+        `select s.id, s.trigger_run_id from workflow_step_runs s
+         join agent_executions e on e.workflow_step_run_id = s.id where e.id = $1`,
+        [executionId],
+      );
+      const step = association.rows[0];
+      if (step) {
+        await client.query("select id from trigger_runs where id = $1 for update", [
+          step.trigger_run_id,
+        ]);
+        await client.query("select id from workflow_step_runs where id = $1 for update", [step.id]);
+      }
+      await client.query(
+        `with bounded as (
          update agent_executions
          set deadline_at = least(deadline_at, $2::timestamptz),
              idle_deadline_at = case when idle_deadline_at is null then null
@@ -1754,8 +1768,9 @@ class PgDatabase implements Database {
        update workflow_step_runs s
        set deadline_at = bounded.deadline_at, idle_deadline_at = bounded.idle_deadline_at
        from bounded where s.id = bounded.workflow_step_run_id`,
-      [executionId, deadlineAt],
-    );
+        [executionId, deadlineAt],
+      );
+    });
   }
 
   async setAgentExecutionIdleDeadline(

--- a/src/db/pg.ts
+++ b/src/db/pg.ts
@@ -1,3 +1,4 @@
+import { ExecutionAuthorityRepository } from "../execution-authority/index.js";
 import { ScheduleRepository } from "../triggers/schedule/index.js";
 import { acceptWorkflowRun } from "./workflow-intake.js";
 import { randomUUID } from "node:crypto";
@@ -134,6 +135,7 @@ export function createDatabase(runtime: DatabaseRuntime, locks: Locks): Database
 
 class PgDatabase implements Database {
   readonly schedules;
+  readonly executionAuthority;
   private readonly connections;
   private readonly triggerAcceptance;
 
@@ -142,6 +144,7 @@ class PgDatabase implements Database {
     private readonly locks: Locks,
   ) {
     this.schedules = new ScheduleRepository(this.pool);
+    this.executionAuthority = new ExecutionAuthorityRepository(this.pool);
     const database = this.pool.drizzle();
     this.connections = new ConnectionRepository(this.pool, locks);
     this.triggerAcceptance = new ProviderEventAcceptanceRepository(database, this.connections);

--- a/src/db/pg.ts
+++ b/src/db/pg.ts
@@ -1739,8 +1739,22 @@ class PgDatabase implements Database {
   }
 
   async limitAgentExecutionDeadline(executionId: string, deadlineAt: Date): Promise<void> {
-    await this.pool.query(
-      `with bounded as (
+    await this.pool.transaction(async (client) => {
+      // Match completion and deadline recovery: lock the run, then step, then execution.
+      const association = await client.query<{ id: string; trigger_run_id: string }>(
+        `select s.id, s.trigger_run_id from workflow_step_runs s
+         join agent_executions e on e.workflow_step_run_id = s.id where e.id = $1`,
+        [executionId],
+      );
+      const step = association.rows[0];
+      if (step) {
+        await client.query("select id from trigger_runs where id = $1 for update", [
+          step.trigger_run_id,
+        ]);
+        await client.query("select id from workflow_step_runs where id = $1 for update", [step.id]);
+      }
+      await client.query(
+        `with bounded as (
          update agent_executions
          set deadline_at = least(deadline_at, $2::timestamptz),
              idle_deadline_at = case when idle_deadline_at is null then null
@@ -1751,8 +1765,9 @@ class PgDatabase implements Database {
        update workflow_step_runs s
        set deadline_at = bounded.deadline_at, idle_deadline_at = bounded.idle_deadline_at
        from bounded where s.id = bounded.workflow_step_run_id`,
-      [executionId, deadlineAt],
-    );
+        [executionId, deadlineAt],
+      );
+    });
   }
 
   async setAgentExecutionIdleDeadline(

--- a/src/db/pg.ts
+++ b/src/db/pg.ts
@@ -1738,6 +1738,23 @@ class PgDatabase implements Database {
     return toAgentExecutionRecord(rows.rows[0]);
   }
 
+  async limitAgentExecutionDeadline(executionId: string, deadlineAt: Date): Promise<void> {
+    await this.pool.query(
+      `with bounded as (
+         update agent_executions
+         set deadline_at = least(deadline_at, $2::timestamptz),
+             idle_deadline_at = case when idle_deadline_at is null then null
+               else least(idle_deadline_at, deadline_at, $2::timestamptz) end
+         where id = $1 and status in ('spawning', 'running')
+         returning workflow_step_run_id, deadline_at, idle_deadline_at
+       )
+       update workflow_step_runs s
+       set deadline_at = bounded.deadline_at, idle_deadline_at = bounded.idle_deadline_at
+       from bounded where s.id = bounded.workflow_step_run_id`,
+      [executionId, deadlineAt],
+    );
+  }
+
   async setAgentExecutionIdleDeadline(
     executionId: string,
     idleDeadlineAt: Date | null,
@@ -2717,9 +2734,19 @@ class PgDatabase implements Database {
   ): Promise<void> {
     await this.pool.query(
       `insert into agent_sessions (id, organization_id, project_id, continuation_key, data)
-       values ($1, $2, $3, $4, $5) on conflict (id) do update set data = excluded.data`,
+       values ($1, $2, $3, $4, $5) on conflict (id) do update set data = excluded.data, continuation_key = excluded.continuation_key`,
       [session.id, session.organizationId, session.projectId, session.continuationKey, session],
     );
+  }
+
+  async findAgentSessionByKey(projectId: string, key: string) {
+    const result = await this.pool.query<{
+      data: import("../agent-sessions/index.js").AgentSessionRecord;
+    }>("select data from agent_sessions where project_id = $1 and continuation_key = $2", [
+      projectId,
+      key,
+    ]);
+    return result.rows[0]?.data;
   }
 
   async attachExecutionToSession(

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1436,3 +1436,22 @@ export const triggerSchedules = pgTable(
   },
   (table) => [index("trigger_schedules_due_idx").on(table.nextAt)],
 );
+
+export const executionAuthorities = pgTable("execution_authorities", {
+  executionId: uuid("execution_id")
+    .primaryKey()
+    .references(() => agentExecutions.id, { onDelete: "cascade" }),
+  data: jsonb("data").notNull(),
+});
+
+export const executionCredentialLeases = pgTable(
+  "execution_credential_leases",
+  {
+    id: uuid("id").primaryKey(),
+    executionId: uuid("execution_id")
+      .notNull()
+      .references(() => agentExecutions.id, { onDelete: "cascade" }),
+    data: jsonb("data").notNull(),
+  },
+  (table) => [index("execution_credential_leases_execution_idx").on(table.executionId)],
+);

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -1150,6 +1150,7 @@ export interface TerminateMachineFields {
 }
 
 export interface Database {
+  readonly executionAuthority: import("../execution-authority/index.js").ExecutionAuthorityStore;
   readonly schedules: import("../triggers/schedule/index.js").ScheduleStore;
   findAgentSession(
     id: string,

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -1151,6 +1151,10 @@ export interface TerminateMachineFields {
 
 export interface Database {
   readonly schedules: import("../triggers/schedule/index.js").ScheduleStore;
+  findAgentSessionByKey(
+    projectId: string,
+    key: string,
+  ): Promise<import("../agent-sessions/index.js").AgentSessionRecord | undefined>;
   findAgentSession(
     id: string,
   ): Promise<import("../agent-sessions/index.js").AgentSessionRecord | undefined>;
@@ -1333,6 +1337,7 @@ export interface Database {
     observedAt: Date,
     processedAt: Date,
   ): Promise<AgentExecutionRecord>;
+  limitAgentExecutionDeadline(executionId: string, deadlineAt: Date): Promise<void>;
   prepareAgentExecutionForDispatch(
     executionId: string,
     daemonId: string,

--- a/src/e2e/harness/acp-agent.mjs
+++ b/src/e2e/harness/acp-agent.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { appendFile, mkdir, rename, writeFile } from "node:fs/promises";
+import { access, appendFile, mkdir, rename, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { Readable, Writable } from "node:stream";
 import { pathToFileURL } from "node:url";
@@ -96,6 +96,17 @@ class PhaseFiveAgent {
         },
       },
     });
+    if (service === "credential-restart") {
+      const gate = requiredEnvironment("HUB_E2E_COMPLETE_GATE");
+      while (
+        !(await access(gate).then(
+          () => true,
+          () => false,
+        ))
+      ) {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+    }
     if (service === "daemon-restart" || prompt.includes("daemon-restart"))
       await runUntilInterrupted();
     if (this.hubMcp && sessionExecutionId) {

--- a/src/e2e/harness/browser-providers.ts
+++ b/src/e2e/harness/browser-providers.ts
@@ -72,7 +72,10 @@ export class BrowserGitHubAuth implements GitHubAuth {
   }
 
   mintInstallationToken(installationId: number) {
-    return Promise.resolve(`installation-token-${installationId}`);
+    return Promise.resolve({
+      token: `installation-token-${installationId}`,
+      expiresAt: Date.now() + 3600_000,
+    });
   }
 
   mintInstallationAccessToken(input: {

--- a/src/e2e/harness/hub-child.ts
+++ b/src/e2e/harness/hub-child.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+import { createExecutionAuthority } from "../../execution-authority/index.js";
 import { z } from "zod";
 import { appendFile, writeFile } from "node:fs/promises";
 import type { IncomingMessage } from "node:http";
@@ -144,8 +146,35 @@ async function main(): Promise<void> {
   });
   await configuration.activate(config.id);
   const resources = new OrganizationResources(database);
+  const executionAuthority = createExecutionAuthority({
+    database,
+    connectionsForProject: () => async () => {
+      throw new Error("Unexpected E2E connection value");
+    },
+    isExecutionActive: async (id) => {
+      const execution = await database.findAgentExecutionById(id);
+      return execution?.status === "running" || execution?.status === "spawning";
+    },
+    githubAuthority: {
+      mint: async () => {
+        const token = randomUUID();
+        await appendFile(
+          `${outputFile}.authority`,
+          `${JSON.stringify({ action: "mint", token })}\n`,
+        );
+        return { token, expiresAt: Date.now() + 3600_000, botUserId: 123, botLogin: "paseo[bot]" };
+      },
+      revoke: async (token) => {
+        await appendFile(
+          `${outputFile}.authority`,
+          `${JSON.stringify({ action: "revoke", token })}\n`,
+        );
+      },
+    },
+  });
   const application = createHubApplication({
     database,
+    executionAuthority,
     entitlements: entitlements.service,
     publicApi:
       auth.publicCredentials === undefined

--- a/src/e2e/harness/index.ts
+++ b/src/e2e/harness/index.ts
@@ -1050,6 +1050,13 @@ export class HubE2E {
     return readJsonLines(`${this.outputFile}.authority`);
   }
 
+  async credentialIsRevoked() {
+    await this.observe(
+      async () => (await this.credentialEvents()).some((event) => event["action"] === "revoke"),
+      "credential revocation",
+    );
+  }
+
   async beginAmbiguousManualRun(): Promise<AmbiguousRunEvidence> {
     await rm(this.completionGate, { force: true });
     this.requireProxy().loseNextCreateResponse();

--- a/src/e2e/harness/index.ts
+++ b/src/e2e/harness/index.ts
@@ -393,6 +393,24 @@ export class HubE2E {
       '        prompt: [{ text: "Deploy mcp-capability for phase-five-operator" }] ',
       "        allow_outputs:",
       "          - type: discord.reply",
+      "  - name: credential-restart",
+      "    on: manual.run",
+      "    max_runtime: 2h",
+      "    filters:",
+      "      from_users: [phase-five-operator]",
+      "    steps:",
+      "      - id: credential-step",
+      "        environment: phase-five",
+      "        max_runtime: 1h",
+      "        idle_timeout: 5m",
+      "        auto_archive: true",
+      "        github:",
+      "          connection: getpaseo-github",
+      "          repositories: [getpaseo/paseo]",
+      "          permissions: {contents: write}",
+      "        agent:",
+      "          provider: hub-e2e",
+      '        prompt: [{ text: "Deploy credential-restart for phase-five-operator" }]',
       "  - name: restart",
       "    on: manual.run",
       "    max_runtime: 2h",
@@ -1001,6 +1019,37 @@ export class HubE2E {
     await this.requireSource().disconnect();
   }
 
+  async beginCredentialRun() {
+    await rm(this.completionGate, { force: true });
+    const run = await this.runManual("credential-restart", "recovery", "credential-restart");
+    await this.observe(
+      async () =>
+        (await readJsonLines(this.acpRecordFile)).some(
+          (record) => record["executionId"] === run.executionId,
+        ),
+      "credentialed agent to execute its prompt",
+    );
+    await this.observe(
+      async () => (await this.persistedDaemonAgents(run.executionId))[0]?.lastStatus === "running",
+      "credentialed agent to be running",
+    );
+    return run;
+  }
+
+  async restartHubWithRunningAgent(executionId: string, crash: boolean) {
+    await this.restartHub(crash);
+    await this.daemonIsConnected();
+    await this.observe(
+      async () => this.requireProxy().hasReplacementConnection(),
+      "replacement Hub connection",
+    );
+    return this.sessionEvidence(executionId);
+  }
+
+  async credentialEvents() {
+    return readJsonLines(`${this.outputFile}.authority`);
+  }
+
   async beginAmbiguousManualRun(): Promise<AmbiguousRunEvidence> {
     await rm(this.completionGate, { force: true });
     this.requireProxy().loseNextCreateResponse();
@@ -1359,8 +1408,8 @@ export class HubE2E {
     });
   }
 
-  private async restartHub(): Promise<void> {
-    await stopChild(this.hub);
+  private async restartHub(crash = false): Promise<void> {
+    await stopChild(this.hub, undefined, crash ? "SIGKILL" : "SIGTERM");
     this.hub = await this.startHub();
     await this.observe(
       async () => (await fetch(`${this.proxy!.origin}/health`).catch(() => undefined))?.ok === true,
@@ -1702,17 +1751,21 @@ async function startChild(input: {
   return { name: input.name, process: child, logFile, output };
 }
 
-async function stopChild(child: ManagedChild | undefined, knownFamily?: number[]): Promise<void> {
+async function stopChild(
+  child: ManagedChild | undefined,
+  knownFamily?: number[],
+  signal: "SIGTERM" | "SIGKILL" = "SIGTERM",
+): Promise<void> {
   if (!child || child.process.exitCode !== null) return;
   const pid = child.process.pid;
   if (pid === undefined) throw new Error(`${child.name} has no process id`);
   const family = knownFamily ?? (await processFamily(pid));
-  child.process.kill("SIGTERM");
+  child.process.kill(signal);
   await withDiagnosticTimeout(
     new Promise<void>((done) => child.process.once("exit", () => done())),
     10_000,
     async () =>
-      new Error(`${child.name} did not exit after SIGTERM\n${await processDiagnostics(pid)}`),
+      new Error(`${child.name} did not exit after ${signal}\n${await processDiagnostics(pid)}`),
   );
   await withDiagnosticTimeout(
     waitForProcessExit(family),

--- a/src/e2e/hub-foundation.e2e.test.ts
+++ b/src/e2e/hub-foundation.e2e.test.ts
@@ -229,6 +229,32 @@ describeHubE2E("Paseo Hub cross-repository contract", () => {
     });
   }, 120_000);
 
+  it.each([false, true])(
+    "preserves a credentialed execution across a real Hub restart (crash=%s)",
+    async (crash) => {
+      await hub.connect();
+      await hub.daemonIsConnected();
+      await hub.installProductionConfiguration();
+      const run = await hub.beginCredentialRun();
+      const before = await hub.sessionEvidence(run.executionId);
+      const issued = await hub.credentialEvents();
+      assert.equal(issued.length, 1);
+      assert.equal(issued[0]?.["action"], "mint");
+      const after = await hub.restartHubWithRunningAgent(run.executionId, crash);
+      assert.deepEqual(after, before);
+      assert.deepEqual(await hub.credentialEvents(), issued);
+      await hub.allowRecoveredCompletion();
+      const completed = await hub.completedRun(run.executionId);
+      assert.equal(completed.status, "succeeded");
+      assert.equal(completed.agentId, run.agentId);
+      assert.deepEqual(await hub.credentialEvents(), [
+        ...issued,
+        { action: "revoke", token: issued[0]?.["token"] },
+      ]);
+    },
+    120_000,
+  );
+
   it("fails the same running agent when a real daemon restart interrupts it", async () => {
     const enrollment = await hub.connect();
     await hub.daemonIsConnected();

--- a/src/e2e/hub-foundation.e2e.test.ts
+++ b/src/e2e/hub-foundation.e2e.test.ts
@@ -247,6 +247,7 @@ describeHubE2E("Paseo Hub cross-repository contract", () => {
       const completed = await hub.completedRun(run.executionId);
       assert.equal(completed.status, "succeeded");
       assert.equal(completed.agentId, run.agentId);
+      await hub.credentialIsRevoked();
       assert.deepEqual(await hub.credentialEvents(), [
         ...issued,
         { action: "revoke", token: issued[0]?.["token"] },

--- a/src/execution-authority/index.test.ts
+++ b/src/execution-authority/index.test.ts
@@ -1,17 +1,17 @@
+import { createMemoryDatabase } from "../db/memory.js";
 import assert from "node:assert/strict";
 import { describe, it } from "vitest";
 import type { CompiledGitHubAuthority } from "../config/github-authority.js";
 import type { CreateExecutionAuthorityOptions, ExecutionAuthorityClock } from "./index.js";
 import { createExecutionAuthority as createProductionExecutionAuthority } from "./index.js";
-import { createLogger } from "../logger.js";
-import { assertOneFailure, FailureLogStream } from "../test-utils/failure-logs.js";
 
 function createExecutionAuthority(
-  options: Omit<CreateExecutionAuthorityOptions, "isExecutionActive"> &
-    Partial<Pick<CreateExecutionAuthorityOptions, "isExecutionActive">>,
+  options: Omit<CreateExecutionAuthorityOptions, "isExecutionActive" | "database"> &
+    Partial<Pick<CreateExecutionAuthorityOptions, "isExecutionActive" | "database">>,
 ) {
   return createProductionExecutionAuthority({
     ...options,
+    database: options.database ?? createMemoryDatabase(),
     isExecutionActive: options.isExecutionActive ?? (async () => true),
   });
 }
@@ -34,14 +34,14 @@ describe("Hub execution authority", () => {
         durationMs: 60_000,
       },
     };
-    assert.equal(authority.canResume(input), false);
+    assert.equal(await authority.canResume(input), false);
     await authority.materialize(input);
-    assert.equal(authority.canResume(input), true);
+    assert.equal(await authority.canResume(input), true);
     await authority.stop();
-    assert.equal(authority.canResume(input), false);
-    assert.equal(createExecutionAuthority(options).canResume(input), false);
+    assert.equal(await authority.canResume(input), false);
+    assert.equal(await createExecutionAuthority(options).canResume(input), false);
     assert.equal(
-      authority.canResume({ ...input, github: undefined, env: { STATIC: "value" } }),
+      await authority.canResume({ ...input, github: undefined, env: { STATIC: "value" } }),
       true,
     );
   });
@@ -52,12 +52,19 @@ describe("Hub execution authority", () => {
       const connectionRevocations: string[] = [];
       const authority = createExecutionAuthority({
         connectionsForProject: () => async (slug, value, context) => {
-          await context?.registerToken?.(`${slug}-${value}`, async () => {
-            connectionRevocations.push(`${slug}-${value}`);
+          await context?.registerToken?.({
+            provider: "github",
+            token: `${slug}-${value}`,
+            expiresAt: Date.now() + 3600_000,
           });
           return "resolved-secret";
         },
-        githubAuthority: githubAuthorityFake(),
+        githubAuthority: {
+          ...githubAuthorityFake(),
+          revoke: async (token) => {
+            connectionRevocations.push(token);
+          },
+        },
       });
       const authoredEnv = {
         SOME_TOKEN: "prefix-${{ paseo.connections.some-connection.token }}",
@@ -296,9 +303,17 @@ describe("Hub execution authority", () => {
     let active = true;
     const revocations: string[] = [];
     const authority = createExecutionAuthority({
+      githubAuthority: {
+        ...githubAuthorityFake(),
+        revoke: async (token) => {
+          revocations.push(token);
+        },
+      },
       connectionsForProject: () => async (_slug, _value, context) => {
-        await context?.registerToken?.("durable-token", () => {
-          revocations.push("durable-token");
+        await context?.registerToken?.({
+          provider: "github",
+          token: "durable-token",
+          expiresAt: Date.now() + 3600_000,
         });
         active = false;
         return "resolved-secret";
@@ -330,9 +345,17 @@ describe("Hub execution authority", () => {
     });
     const revocations: string[] = [];
     const authority = createExecutionAuthority({
+      githubAuthority: {
+        ...githubAuthorityFake(),
+        revoke: async (token) => {
+          revocations.push(token);
+        },
+      },
       connectionsForProject: () => async (_slug, _value, context) => {
-        await context?.registerToken?.("final-query-token", () => {
-          revocations.push("final-query-token");
+        await context?.registerToken?.({
+          provider: "github",
+          token: "final-query-token",
+          expiresAt: Date.now() + 3600_000,
         });
         return "resolved-secret";
       },
@@ -357,44 +380,6 @@ describe("Hub execution authority", () => {
     await assert.rejects(materialization, /terminal execution/iu);
     await terminal;
     assert.deepEqual(revocations, ["final-query-token"]);
-  });
-
-  it("registers materialization before the initial durable activity query", async () => {
-    let activityQueryStarted!: () => void;
-    const activityQueryObserved = new Promise<void>((resolve) => {
-      activityQueryStarted = resolve;
-    });
-    let resolveActivityQuery!: (active: boolean) => void;
-    const activityQuery = new Promise<boolean>((resolve) => {
-      resolveActivityQuery = resolve;
-    });
-    const authority = createExecutionAuthority({
-      connectionsForProject: () => async () => "unused",
-      isExecutionActive: async () => {
-        activityQueryStarted();
-        return activityQuery;
-      },
-    });
-
-    const materialization = authority.materialize({
-      executionId: "stop-during-initial-query",
-      projectId: "project-1",
-      triggerContext: { provider: "manual" },
-      env: { VALUE: "literal" },
-    });
-    await activityQueryObserved;
-    const stopping = authority.stop();
-    let stopReturned = false;
-    void stopping.then(() => {
-      stopReturned = true;
-      return undefined;
-    });
-    for (let index = 0; index < 10; index += 1) await Promise.resolve();
-    assert.equal(stopReturned, false);
-
-    resolveActivityQuery(true);
-    await assert.rejects(materialization, /stopped/iu);
-    await stopping;
   });
 
   it("does not return an explicit GitHub token after durable execution becomes terminal", async () => {
@@ -491,217 +476,6 @@ describe("Hub execution authority", () => {
     await assert.rejects(materialization, /terminal execution/iu);
     await terminal;
     assert.deepEqual(revoked, ["race-token"]);
-  });
-
-  it("revokes held connection credentials before waiting for an unrelated hung GitHub mint", async () => {
-    const revoked: string[] = [];
-    let releaseMint!: () => void;
-    const mintBlocked = new Promise<void>((resolve) => {
-      releaseMint = resolve;
-    });
-    const authority = createExecutionAuthority({
-      connectionsForProject: () => async (_slug, _value, context) => {
-        await context?.registerToken?.("held-connection-token", () => {
-          revoked.push("held-connection-token");
-        });
-        return "resolved-secret";
-      },
-      githubAuthority: {
-        mint: async () => {
-          await mintBlocked;
-          return {
-            token: "late-github-token",
-            expiresAt: Date.now() + 60 * 60 * 1000,
-            botUserId: 1,
-            botLogin: "paseo[bot]",
-          };
-        },
-        revoke: async (token) => {
-          revoked.push(token);
-        },
-      },
-      isExecutionActive: async () => true,
-    });
-    await authority.materialize({
-      executionId: "terminal-ordering",
-      projectId: "project-1",
-      triggerContext: { provider: "manual" },
-      env: { TOKEN: "${{ paseo.connections.some-connection.token }}" },
-    });
-    const hungMaterialization = authority.materialize({
-      executionId: "terminal-ordering",
-      projectId: "project-1",
-      triggerContext: { provider: "manual" },
-      github: {
-        connection: "getpaseo-github",
-        repositories: ["getpaseo/paseo"],
-        permissions: { contents: "read" },
-        durationMs: 60 * 60 * 1000,
-      },
-    });
-    await Promise.resolve();
-
-    const terminal = authority.onExecutionTerminal("terminal-ordering");
-    await Promise.resolve();
-    assert.deepEqual(revoked, ["held-connection-token"]);
-
-    releaseMint();
-    await assert.rejects(hungMaterialization, /terminal execution/iu);
-    await terminal;
-    assert.deepEqual(revoked, ["held-connection-token", "late-github-token"]);
-  });
-
-  it("revokes active leases when the authority owner stops", async () => {
-    const mint = githubAuthorityFake();
-    const authority = createExecutionAuthority({
-      connectionsForProject: () => async () => "unused",
-      githubAuthority: mint,
-    });
-    await authority.materialize({
-      executionId: "graceful-stop",
-      projectId: "project-1",
-      triggerContext: { provider: "manual" },
-      github: {
-        connection: "getpaseo-github",
-        repositories: ["getpaseo/paseo"],
-        permissions: { contents: "read" },
-        durationMs: 60 * 60 * 1000,
-      },
-    });
-
-    await authority.stop();
-
-    assert.deepEqual(mint.revoked, ["scoped-token-1"]);
-    await assert.rejects(
-      authority.materialize({
-        executionId: "new-after-stop",
-        projectId: "project-1",
-        triggerContext: { provider: "manual" },
-        env: { TOKEN: "literal" },
-      }),
-      /stopped/iu,
-    );
-  });
-
-  it("keeps graceful shutdown pending until a transient revocation succeeds", async () => {
-    const canary = "execution-authority-secret-75ad";
-    const stream = new FailureLogStream();
-    const clock = new TestClock();
-    let attempts = 0;
-    let firstAttempt!: () => void;
-    const firstAttemptObserved = new Promise<void>((resolve) => {
-      firstAttempt = resolve;
-    });
-    const authority = createExecutionAuthority({
-      connectionsForProject: () => async () => "unused",
-      githubAuthority: {
-        mint: async () => ({
-          token: "shutdown-retry-token",
-          expiresAt: clock.now() + 60 * 60 * 1000,
-          botUserId: 1,
-          botLogin: "paseo[bot]",
-        }),
-        revoke: async () => {
-          attempts += 1;
-          if (attempts === 1) {
-            firstAttempt();
-            throw new Error(canary);
-          }
-        },
-      },
-      clock,
-      logger: createLogger(stream),
-    });
-    await authority.materialize({
-      executionId: "shutdown-retry",
-      projectId: "project-1",
-      triggerContext: { provider: "manual" },
-      github: {
-        connection: "getpaseo-github",
-        repositories: ["getpaseo/paseo"],
-        permissions: { contents: "read" },
-        durationMs: 60 * 60 * 1000,
-      },
-    });
-
-    const stopping = authority.stop();
-    await firstAttemptObserved;
-    await clock.waitForScheduledDelay(1_000);
-    assert.equal(attempts, 1);
-    let stopped = false;
-    void stopping.then(() => {
-      stopped = true;
-      return undefined;
-    });
-    await Promise.resolve();
-    assert.equal(stopped, false);
-
-    await clock.advance(1_000);
-    await stopping;
-    assert.equal(attempts, 2);
-    assertOneFailure(stream, {
-      operation: "execution-authority.token.revoke",
-      component: "execution-authority",
-      failureKind: "upstreamUnavailable",
-      canary,
-    });
-  });
-
-  it("returns bounded token-free residual exposure when shutdown revocation keeps failing", async () => {
-    const clock = new TestClock();
-    let attempts = 0;
-    const authority = createExecutionAuthority({
-      connectionsForProject: () => async () => "unused",
-      githubAuthority: {
-        mint: async () => ({
-          token: "must-not-appear-in-stop-evidence",
-          expiresAt: clock.now() + 60 * 60 * 1000,
-          botUserId: 1,
-          botLogin: "paseo[bot]",
-        }),
-        revoke: async () => {
-          attempts += 1;
-          throw new Error("permanent upstream failure");
-        },
-      },
-      clock,
-      isExecutionActive: async () => true,
-    });
-    await authority.materialize({
-      executionId: "bounded-shutdown",
-      projectId: "project-1",
-      triggerContext: { provider: "manual" },
-      github: {
-        connection: "getpaseo-github",
-        repositories: ["getpaseo/paseo"],
-        permissions: { contents: "read" },
-        durationMs: 60 * 60 * 1000,
-      },
-    });
-
-    let stopResult: Awaited<ReturnType<typeof authority.stop>> | undefined;
-    void authority.stop().then((result) => {
-      stopResult = result;
-      return undefined;
-    });
-    await clock.waitForScheduledDelay(10_000);
-    await clock.advance(10_000);
-    for (let index = 0; index < 10; index += 1) await Promise.resolve();
-
-    assert.notEqual(stopResult, undefined);
-    assert.deepEqual(stopResult, {
-      residualExposures: [
-        {
-          executionId: "bounded-shutdown",
-          leaseCount: 1,
-          pendingMaterializations: 0,
-          earliestUpstreamExpiresAt: Date.parse("2026-08-01T01:00:00.000Z"),
-        },
-      ],
-    });
-    assert.equal(JSON.stringify(stopResult).includes("must-not-appear-in-stop-evidence"), false);
-    assert.equal(clock.referencedTimerCount(), 0);
-    assert.ok(attempts >= 1);
   });
 
   it("retains a failed deadline revocation and retries it through the clock seam", async () => {
@@ -822,9 +596,9 @@ describe("Hub execution authority", () => {
     await clock.advance(1_000);
     assert.equal(attempts, 2);
     await clock.advance(2_000);
-    assert.equal(attempts, 3);
+    assert.equal(attempts, 2);
     await clock.advance(10_000);
-    assert.equal(attempts, 3);
+    assert.equal(attempts, 2);
   });
 
   it("does not retain empty terminal execution states", async () => {
@@ -854,6 +628,226 @@ describe("Hub execution authority", () => {
       }),
       /terminal execution/iu,
     );
+  });
+  it.each(["shutdown", "crash"])(
+    "recovers the original credential and deadline after %s",
+    async (kind) => {
+      const database = createMemoryDatabase();
+      const clock = new TestClock();
+      const mint = githubAuthorityFake(() => clock.now());
+      const options = {
+        database,
+        clock,
+        githubAuthority: mint,
+        connectionsForProject: () => async () => "unused",
+      };
+      const first = createExecutionAuthority(options);
+      const input = restartInput();
+      const initial = await first.materialize(input);
+      if (kind === "shutdown") await first.stop();
+      // A fresh clock represents a replacement process: old timers cannot help recovery.
+      const replacementClock = new TestClock();
+      await replacementClock.advance(30_000);
+      const replacement = createExecutionAuthority({ ...options, clock: replacementClock });
+      await replacement.recover();
+      assert.equal(await replacement.canResume(input), true);
+      assert.deepEqual(await replacement.materialize(input), initial);
+      assert.equal(mint.inputs.length, 1);
+      assert.deepEqual(mint.revoked, []);
+      await replacementClock.advance(30_000);
+      assert.deepEqual(mint.revoked, [initial.env["GH_TOKEN"]]);
+      assert.equal(await replacement.canResume(input), false);
+      await first.stop();
+      await replacement.stop();
+    },
+  );
+
+  it("recovers connection tokens and resolved values that do not own a revocable token", async () => {
+    const database = createMemoryDatabase();
+    const mint = githubAuthorityFake();
+    const options = {
+      database,
+      githubAuthority: mint,
+      connectionsForProject:
+        () =>
+        async (
+          slug: string,
+          _value: string,
+          context?: import("../config/connections.js").ConnectionResolutionContext,
+        ) => {
+          if (slug === "leased")
+            await context?.registerToken?.({
+              provider: "github",
+              token: "connection-token",
+              expiresAt: Date.now() + 60_000,
+            });
+          return "resolved-value";
+        },
+    };
+    const first = createExecutionAuthority(options);
+    for (const slug of ["leased", "static"]) {
+      await first.materialize({
+        ...restartInput(),
+        executionId: slug,
+        github: undefined,
+        env: { TOKEN: "prefix-${{ paseo.connections." + slug + ".token }}" },
+      });
+    }
+    await first.stop();
+    const replacement = createExecutionAuthority(options);
+    await replacement.recover();
+    for (const slug of ["leased", "static"]) {
+      const input = {
+        ...restartInput(),
+        executionId: slug,
+        github: undefined,
+        env: { TOKEN: "prefix-${{ paseo.connections." + slug + ".token }}" },
+      };
+      assert.equal(await replacement.canResume(input), true);
+      assert.deepEqual(await replacement.materialize(input), {
+        env: { TOKEN: "prefix-resolved-value" },
+      });
+      await replacement.onExecutionTerminal(slug);
+      assert.equal(await database.executionAuthority.read(slug), undefined);
+    }
+    assert.deepEqual(mint.revoked, ["connection-token"]);
+    await replacement.stop();
+  });
+
+  it("finishes terminal cleanup after a crash and an upstream revocation failure", async () => {
+    const database = createMemoryDatabase();
+    const clock = new TestClock();
+    const mint = githubAuthorityFake(() => clock.now());
+    let active = true;
+    let attempts = 0;
+    const options = {
+      database,
+      clock,
+      connectionsForProject: () => async () => "unused",
+      isExecutionActive: async () => active,
+      githubAuthority: {
+        ...mint,
+        revoke: async (token: string) => {
+          if (++attempts === 1) throw new Error("temporary upstream failure");
+          await mint.revoke(token);
+        },
+      },
+    };
+    const first = createExecutionAuthority(options);
+    const input = restartInput();
+    await first.materialize(input);
+    active = false;
+    await first.onExecutionTerminal(input.executionId);
+    await first.stop();
+    const replacement = createExecutionAuthority(options);
+    await replacement.recover();
+    assert.equal(attempts, 1);
+    await clock.advance(1_000);
+    assert.deepEqual(mint.revoked, ["scoped-token-1"]);
+    assert.deepEqual(await database.executionAuthority.leases(), []);
+    assert.equal(await database.executionAuthority.read(input.executionId), undefined);
+    await replacement.stop();
+  });
+
+  it("does not let an old process revoke a replacement process's active credentials on shutdown", async () => {
+    const database = createMemoryDatabase();
+    const clock = new TestClock();
+    const mint = githubAuthorityFake(() => clock.now());
+    const options = {
+      database,
+      clock,
+      githubAuthority: mint,
+      connectionsForProject: () => async () => "unused",
+    };
+    const first = createExecutionAuthority(options);
+    const input = restartInput();
+    await first.materialize(input);
+    const replacement = createExecutionAuthority(options);
+    await replacement.recover();
+    await first.stop();
+    assert.deepEqual(mint.revoked, []);
+    assert.equal(await replacement.canResume(input), true);
+    await replacement.onExecutionTerminal(input.executionId);
+    assert.deepEqual(mint.revoked, ["scoped-token-1"]);
+    await replacement.stop();
+  });
+
+  it("serializes revocation across two recovering processes", async () => {
+    const database = createMemoryDatabase();
+    const clock = new TestClock();
+    const mint = githubAuthorityFake(() => clock.now());
+    const options = {
+      database,
+      clock,
+      githubAuthority: mint,
+      connectionsForProject: () => async () => "unused",
+    };
+    const first = createExecutionAuthority(options);
+    const input = restartInput();
+    await first.materialize(input);
+    const replacement = createExecutionAuthority(options);
+    await replacement.recover();
+    await Promise.all([
+      first.onExecutionTerminal(input.executionId),
+      replacement.onExecutionTerminal(input.executionId),
+    ]);
+    assert.deepEqual(mint.revoked, ["scoped-token-1"]);
+    await first.stop();
+    await replacement.stop();
+  });
+
+  it("commits one environment when two processes materialize the same execution", async () => {
+    const database = createMemoryDatabase();
+    const mint = githubAuthorityFake();
+    const options = {
+      database,
+      githubAuthority: mint,
+      connectionsForProject: () => async () => "unused",
+    };
+    const first = createExecutionAuthority(options);
+    const second = createExecutionAuthority(options);
+    const input = restartInput();
+    const [a, b] = await Promise.all([first.materialize(input), second.materialize(input)]);
+    assert.deepEqual(a, b);
+    assert.equal(mint.revoked.includes(a.env["GH_TOKEN"]!), false);
+    assert.equal((await database.executionAuthority.leases()).length, 1);
+    await first.onExecutionTerminal(input.executionId);
+    assert.equal(new Set(mint.revoked).size, mint.inputs.length);
+    await first.stop();
+    await second.stop();
+  });
+
+  it("returns promptly from shutdown with a hung mint and revokes its late result", async () => {
+    const database = createMemoryDatabase();
+    const mint = githubAuthorityFake();
+    let begun!: () => void;
+    const started = new Promise<void>((resolve) => {
+      begun = resolve;
+    });
+    let finish!: () => void;
+    const blocked = new Promise<void>((resolve) => {
+      finish = resolve;
+    });
+    const authority = createExecutionAuthority({
+      database,
+      connectionsForProject: () => async () => "unused",
+      githubAuthority: {
+        ...mint,
+        mint: async (input) => {
+          begun();
+          await blocked;
+          return mint.mint(input);
+        },
+      },
+    });
+    const materialization = authority.materialize(restartInput());
+    await started;
+    await authority.stop();
+    assert.deepEqual(mint.revoked, []);
+    finish();
+    await assert.rejects(materialization, /stopped/);
+    assert.deepEqual(mint.revoked, ["scoped-token-1"]);
+    assert.deepEqual(await database.executionAuthority.leases(), []);
   });
 });
 
@@ -926,4 +920,18 @@ class TestClock implements ExecutionAuthorityClock {
       await timer.callback();
     }
   }
+}
+
+function restartInput() {
+  return {
+    executionId: "restart",
+    projectId: "project-1",
+    triggerContext: {},
+    github: {
+      connection: "github",
+      repositories: ["getpaseo/paseo"],
+      permissions: { contents: "write" as const },
+      durationMs: 60_000,
+    },
+  };
 }

--- a/src/execution-authority/index.ts
+++ b/src/execution-authority/index.ts
@@ -1,32 +1,41 @@
+import { randomUUID } from "node:crypto";
+import type { Logger } from "pino";
 import type { CompiledGitHubAuthority } from "../config/github-authority.js";
 import {
   parseConnectionTemplate,
   resolveConnectionTemplate,
 } from "../config/connection-template.js";
-import type { ConnectionResolver } from "../config/connections.js";
+import type {
+  ConnectionResolver,
+  ConnectionResolutionContext,
+  ConnectionTokenLease,
+} from "../config/connections.js";
+import type { Database } from "../db/types.js";
 import type { GitHubAuthorityRegistration } from "../providers/registration.js";
-import { reportFailure, type FailureContext, type ReportOptions } from "../failures/index.js";
-import type { Logger } from "pino";
+import { reportFailure } from "../failures/index.js";
+import type { ExecutionCredentialLease } from "./internal/store.js";
+export { ExecutionAuthorityRepository } from "./internal/store.js";
+export type {
+  ExecutionAuthorityStore,
+  ExecutionAuthorityRecord,
+  ExecutionCredentialLease,
+} from "./internal/store.js";
 
 const TOKEN_REVOCATION_TIMEOUT_MS = 10_000;
 const REVOCATION_RETRY_BASE_DELAY_MS = 1_000;
-const REVOCATION_RETRY_WINDOW_MS = 60 * 60 * 1_000;
-const SHUTDOWN_GRACE_MS = 10_000;
 
 export interface ExecutionAuthorityClock {
   now(): number;
   schedule(callback: () => Promise<void>, delayMs: number, options?: { ref?: boolean }): () => void;
 }
-
 const systemClock: ExecutionAuthorityClock = {
   now: Date.now,
-  schedule(callback, delayMs, options) {
+  schedule(callback, delayMs) {
     const timer = setTimeout(() => void callback(), delayMs);
-    if (options?.ref !== true) timer.unref();
+    timer.unref();
     return () => clearTimeout(timer);
   },
 };
-
 export interface ExecutionAuthorityMaterialization {
   executionId: string;
   projectId: string;
@@ -34,37 +43,24 @@ export interface ExecutionAuthorityMaterialization {
   env?: Readonly<Record<string, string>> | undefined;
   github?: CompiledGitHubAuthority | undefined;
 }
-
 export interface MaterializedExecutionAuthority {
   env: Record<string, string>;
 }
-
 export interface ExecutionAuthority {
   materialize(input: ExecutionAuthorityMaterialization): Promise<MaterializedExecutionAuthority>;
-  canResume(input: ExecutionAuthorityMaterialization): boolean;
+  canResume(input: ExecutionAuthorityMaterialization): Promise<boolean>;
+  recover(): Promise<void>;
   onExecutionTerminal(executionId: string): Promise<void>;
   resourceCounts(): ExecutionAuthorityResourceCounts;
-  stop(): Promise<ExecutionAuthorityStopResult>;
+  stop(): Promise<void>;
 }
-
 export interface ExecutionAuthorityResourceCounts {
   executionStates: number;
   leases: number;
   pendingMaterializations: number;
 }
-
-export interface ExecutionAuthorityResidualExposure {
-  executionId: string;
-  leaseCount: number;
-  pendingMaterializations: number;
-  earliestUpstreamExpiresAt?: number;
-}
-
-export interface ExecutionAuthorityStopResult {
-  residualExposures: ExecutionAuthorityResidualExposure[];
-}
-
 export interface CreateExecutionAuthorityOptions {
+  database: Pick<Database, "executionAuthority" | "withAdvisoryLock">;
   connectionsForProject: (projectId: string) => ConnectionResolver;
   githubAuthority?: GitHubAuthorityRegistration | undefined;
   clock?: ExecutionAuthorityClock | undefined;
@@ -72,511 +68,333 @@ export interface CreateExecutionAuthorityOptions {
   logger?: Pick<Logger, "warn" | "error">;
 }
 
-interface TokenLease {
-  token: string;
-  revoke: () => Promise<void>;
-  cancelLeaseDeadline: () => void;
-  cancelUpstreamExpiry: () => void;
-  cancelRetry: () => void;
-  upstreamExpiresAt?: number;
-  retryUntil?: number;
-  revocationAttempts: number;
-  revocationPromise?: Promise<void>;
-  retryScheduled: boolean;
-}
-
-interface ExecutionState {
-  pendingMaterializations: number;
-  terminal: boolean;
-  leases: Map<string, TokenLease>;
-  pendingWaiters: Set<() => void>;
-  leaseWaiters: Set<() => void>;
-}
-
-interface TerminalCleanup {
-  cancel(): void;
-  promise: Promise<void>;
-}
-
+/** Owns issuance, durable lease recovery, and revocation independently of Hub process lifetime. */
 export function createExecutionAuthority(
   options: CreateExecutionAuthorityOptions,
 ): ExecutionAuthority {
   const clock = options.clock ?? systemClock;
-  const states = new Map<string, ExecutionState>();
-  const terminalCleanups = new Map<string, TerminalCleanup>();
+  const store = options.database.executionAuthority;
+  const timers = new Map<string, { executionId: string; cancel: () => void }>();
+  const pending = new Map<string, { count: number; terminal: boolean }>();
   let stopped = false;
-  let stopPromise: Promise<ExecutionAuthorityStopResult> | undefined;
-
-  const report = (error: unknown, context: FailureContext, reportOptions: ReportOptions = {}) => {
-    reportFailure(error, context, {
-      ...reportOptions,
-      ...(options.logger === undefined ? {} : { logger: options.logger }),
-    });
-  };
 
   async function materialize(
     input: ExecutionAuthorityMaterialization,
   ): Promise<MaterializedExecutionAuthority> {
     if (stopped) throw authorityStoppedError();
-    const state = getOrCreateState(input.executionId);
-    state.pendingMaterializations += 1;
-    const ownedTokens = new Set<string>();
+    const state = pending.get(input.executionId) ?? { count: 0, terminal: false };
+    state.count++;
+    pending.set(input.executionId, state);
+    const ownedLeases: string[] = [];
+    const assertActive = async () => {
+      if (stopped) throw authorityStoppedError();
+      if (
+        state.terminal ||
+        !(await options.isExecutionActive(input.executionId)) ||
+        state.terminal
+      ) {
+        throw terminalExecutionError(input.executionId);
+      }
+      if (stopped) throw authorityStoppedError();
+    };
     try {
-      await assertExecutionActive(state, input.executionId);
-      const tokenRevocations = new Map<string, Promise<string> | undefined>();
-      const context = {
-        executionId: input.executionId,
-        registerToken: async (token: string, revoke?: () => Promise<void> | void) => {
-          if (revoke === undefined) return;
-          await registerLease(state, input.executionId, token, revoke);
-          ownedTokens.add(token);
-        },
+      await assertActive();
+      const existing = await store.read(input.executionId);
+      if (existing) {
+        if (!(await canResume(input)))
+          throw authorityError(
+            "execution_credentials_unavailable",
+            "Execution credentials are no longer available",
+          );
+        await assertActive();
+        return { env: existing.env };
+      }
+      const register = async (credential: ConnectionTokenLease, durationMs?: number) => {
+        const lease: ExecutionCredentialLease = {
+          id: randomUUID(),
+          executionId: input.executionId,
+          ...credential,
+          deadlineAt: Math.min(
+            credential.expiresAt,
+            durationMs === undefined ? credential.expiresAt : clock.now() + durationMs,
+          ),
+          revoking: false,
+          attempts: 0,
+          nextAttemptAt: 0,
+        };
+        // Registration completes durably before a token can enter an agent environment.
+        try {
+          await store.saveLease(lease);
+        } catch (error) {
+          await revokeToken(lease);
+          throw error;
+        }
+        ownedLeases.push(lease.id);
+        schedule(lease);
+        if (state.terminal || stopped) {
+          await release(lease, true);
+          throw stopped ? authorityStoppedError() : terminalExecutionError(input.executionId);
+        }
       };
-      const env = await materializeEnvironment(input, context, tokenRevocations);
-      if (input.github !== undefined) {
-        if (options.githubAuthority === undefined) {
+      const context: ConnectionResolutionContext = {
+        executionId: input.executionId,
+        registerToken: register,
+      };
+      const resolver = options.connectionsForProject(input.projectId);
+      const resolved = new Map<string, Promise<string>>();
+      const env = Object.fromEntries(
+        await Promise.all(
+          Object.entries(input.env ?? {}).map(
+            async ([key, value]): Promise<[string, string]> => [
+              key,
+              await resolveConnectionTemplate(
+                value,
+                (slug, name, resolutionContext) => {
+                  const reference = `${slug}:${name}`;
+                  let result = resolved.get(reference);
+                  if (!result) {
+                    result = Promise.resolve(resolver(slug, name, resolutionContext));
+                    resolved.set(reference, result);
+                  }
+                  return result;
+                },
+                context,
+                `step env.${key}`,
+              ),
+            ],
+          ),
+        ),
+      );
+      if (input.github) {
+        if (!options.githubAuthority)
           throw authorityError(
             "github_authority_unavailable",
             "GitHub step authority is unavailable",
           );
-        }
-        const repositories = repositoriesForAuthority(input.github, input.triggerContext);
-        const authority = await options.githubAuthority.mint({
+        const github = await options.githubAuthority.mint({
           projectId: input.projectId,
           connectionSlug: input.github.connection,
-          repositories,
+          repositories: repositoriesForAuthority(input.github, input.triggerContext),
           permissions: input.github.permissions,
         });
-        await registerLease(
-          state,
-          input.executionId,
-          authority.token,
-          () => options.githubAuthority!.revoke(authority.token),
+        await register(
+          { provider: "github", token: github.token, expiresAt: github.expiresAt },
           input.github.durationMs,
-          authority.expiresAt,
         );
-        ownedTokens.add(authority.token);
-        await assertExecutionActive(state, input.executionId);
-        return {
-          env: {
-            ...env,
-            ...githubEnvironment(authority.botUserId, authority.botLogin, authority.token),
-          },
-        };
+        Object.assign(env, githubEnvironment(github.botUserId, github.botLogin, github.token));
       }
-      await assertExecutionActive(state, input.executionId);
-      return { env };
+      await assertActive();
+      // A concurrent launch may have won. Keep its environment and revoke only our unused tokens.
+      const committed = await store.commit({
+        executionId: input.executionId,
+        env,
+        leaseIds: ownedLeases,
+      });
+      const unused = ownedLeases.filter((id) => !committed.leaseIds.includes(id));
+      await releaseOwned(input.executionId, unused);
+      await assertActive();
+      return { env: committed.env };
     } catch (error) {
-      await Promise.all(
-        [...ownedTokens].map((token) => releaseLease(input.executionId, token, "materialization")),
-      );
+      const committed = await store.read(input.executionId);
+      if (state.terminal || !(await options.isExecutionActive(input.executionId))) {
+        await onExecutionTerminal(input.executionId);
+      } else {
+        // A stopped worker must preserve credentials already committed for delivery.
+        await releaseOwned(
+          input.executionId,
+          ownedLeases.filter((id) => !committed?.leaseIds.includes(id)),
+        );
+      }
       throw error;
     } finally {
-      state.pendingMaterializations -= 1;
-      if (state.pendingMaterializations === 0) {
-        for (const resolve of state.pendingWaiters) resolve();
-        state.pendingWaiters.clear();
-      }
-      deleteEmptyState(states, input.executionId, state);
+      state.count--;
+      if (state.count === 0) pending.delete(input.executionId);
     }
   }
 
-  async function materializeEnvironment(
-    input: ExecutionAuthorityMaterialization,
-    context: {
-      executionId: string;
-      registerToken: (token: string, revoke?: () => Promise<void> | void) => Promise<void>;
-    },
-    tokenRevocations: Map<string, Promise<string> | undefined>,
-  ): Promise<Record<string, string>> {
-    if (input.env === undefined) return {};
-    const resolver = options.connectionsForProject(input.projectId);
-    return Object.fromEntries(
-      await Promise.all(
-        Object.entries(input.env).map(async ([key, value]) => {
-          const references = parseConnectionTemplate(value, `step env.${key}`);
-          const resolved = await resolveConnectionTemplate(
-            value,
-            (slug, namedValue, resolutionContext) => {
-              const cacheKey = `${slug}:${namedValue}`;
-              const cached = tokenRevocations.get(cacheKey);
-              if (cached !== undefined) return cached;
-              const pending = Promise.resolve(resolver(slug, namedValue, resolutionContext));
-              tokenRevocations.set(cacheKey, pending);
-              return pending;
-            },
-            context,
-            `step env.${key}`,
-          );
-          if (references.length === 0) return [key, resolved] as const;
-          return [key, resolved] as const;
-        }),
-      ),
+  async function releaseOwned(executionId: string, ids: string[]) {
+    const leases = await store.leases(executionId);
+    await Promise.all(
+      leases.filter((lease) => ids.includes(lease.id)).map((lease) => release(lease, true)),
     );
   }
 
-  async function registerLease(
-    state: ExecutionState,
-    executionId: string,
-    token: string,
-    revoke: () => Promise<void> | void,
-    leaseDurationMs?: number,
-    upstreamExpiresAt?: number,
-  ): Promise<void> {
-    const now = clock.now();
-    const leaseDeadline =
-      leaseDurationMs === undefined
-        ? undefined
-        : Math.min(
-            now + leaseDurationMs,
-            upstreamExpiresAt === undefined ? Number.POSITIVE_INFINITY : upstreamExpiresAt,
-          );
-    const cancelLeaseDeadline =
-      leaseDeadline === undefined
-        ? () => undefined
-        : clock.schedule(
-            () => releaseLease(executionId, token, "lease-deadline"),
-            Math.max(0, leaseDeadline - now),
-          );
-    const cancelUpstreamExpiry =
-      upstreamExpiresAt === undefined
-        ? () => undefined
-        : clock.schedule(
-            () => releaseLease(executionId, token, "upstream-expiry"),
-            Math.max(0, upstreamExpiresAt - now),
-          );
-    const lease: TokenLease = {
-      token,
-      revoke: async () => revoke(),
-      cancelLeaseDeadline,
-      cancelUpstreamExpiry,
-      cancelRetry: () => undefined,
-      ...(upstreamExpiresAt === undefined ? {} : { upstreamExpiresAt }),
-      revocationAttempts: 0,
-      retryScheduled: false,
-    };
-    state.leases.set(token, lease);
-    if (state.terminal || stopped) {
-      await requestLeaseRevocation(executionId, token, "terminal");
-      throw terminalExecutionError(executionId);
-    }
+  async function canResume(input: ExecutionAuthorityMaterialization): Promise<boolean> {
+    if (
+      input.github === undefined &&
+      !Object.values(input.env ?? {}).some((value) => parseConnectionTemplate(value).length > 0)
+    )
+      return true;
+    if (stopped) return false;
+    const record = await store.read(input.executionId);
+    if (!record) return false;
+    const leases = await store.leases(input.executionId);
+    const valid = record.leaseIds.every((id) =>
+      leases.some((lease) => lease.id === id && !lease.revoking && lease.deadlineAt > clock.now()),
+    );
+    if (valid) for (const lease of leases) schedule(lease);
+    return valid;
   }
 
-  async function releaseLease(
-    executionId: string,
-    token: string,
-    reason: "lease-deadline" | "upstream-expiry" | "terminal" | "materialization" | "stop",
-  ): Promise<void> {
-    const state = states.get(executionId);
-    const lease = state?.leases.get(token);
-    if (state === undefined || lease === undefined) return;
-    await requestLeaseRevocation(executionId, token, reason);
+  async function recover(): Promise<void> {
+    for (const executionId of await store.executions()) {
+      if (stopped) return;
+      if (!(await options.isExecutionActive(executionId))) await onExecutionTerminal(executionId);
+    }
+    for (const lease of await store.leases()) {
+      if (stopped) return;
+      if (!(await options.isExecutionActive(lease.executionId))) {
+        await store.remove(lease.executionId);
+        await release(lease, true);
+      } else if (lease.revoking || lease.deadlineAt <= clock.now()) {
+        await release(lease);
+      } else {
+        schedule(lease);
+      }
+    }
   }
 
   async function onExecutionTerminal(executionId: string): Promise<void> {
-    const state = getOrCreateState(executionId);
-    state.terminal = true;
-    await revokeLeases(executionId, state, "terminal");
-    startTerminalCleanup(executionId, state);
+    const state = pending.get(executionId);
+    if (state) state.terminal = true;
+    await store.remove(executionId);
+    await Promise.all((await store.leases(executionId)).map((lease) => release(lease, true)));
   }
 
-  function startTerminalCleanup(executionId: string, state: ExecutionState): void {
-    if (state.pendingMaterializations === 0) {
-      deleteEmptyState(states, executionId, state);
-      return;
-    }
-    if (terminalCleanups.has(executionId)) return;
-    const pending = waitForPendingMaterializationsUntilCanceled(state);
-    const cleanup: TerminalCleanup = {
-      cancel: () => pending.cancel(),
-      promise: Promise.resolve(),
-    };
-    cleanup.promise = (async () => {
-      if ((await pending.outcome) === "canceled") return;
-      await revokeLeases(executionId, state, "terminal");
-      deleteEmptyState(states, executionId, state);
-    })()
-      .catch((error: unknown) => {
-        report(error, {
-          operation: "execution-authority.terminal.cleanup",
-          component: "execution-authority",
-          executionId,
-        });
-      })
-      .finally(() => {
-        if (terminalCleanups.get(executionId) === cleanup) {
-          terminalCleanups.delete(executionId);
-        }
-      });
-    terminalCleanups.set(executionId, cleanup);
+  function cancelTimer(id: string) {
+    timers.get(id)?.cancel();
+    timers.delete(id);
   }
 
-  function getOrCreateState(executionId: string): ExecutionState {
-    const existing = states.get(executionId);
-    if (existing !== undefined) return existing;
-    const state: ExecutionState = {
-      pendingMaterializations: 0,
-      terminal: false,
-      leases: new Map(),
-      pendingWaiters: new Set(),
-      leaseWaiters: new Set(),
-    };
-    states.set(executionId, state);
-    return state;
-  }
-
-  function resourceCounts(): ExecutionAuthorityResourceCounts {
-    let leases = 0;
-    let pendingMaterializations = 0;
-    for (const state of states.values()) {
-      leases += state.leases.size;
-      pendingMaterializations += state.pendingMaterializations;
-    }
-    return { executionStates: states.size, leases, pendingMaterializations };
-  }
-
-  async function stop(): Promise<ExecutionAuthorityStopResult> {
-    if (stopPromise !== undefined) return stopPromise;
-    stopped = true;
-    for (const cleanup of terminalCleanups.values()) cleanup.cancel();
-    stopPromise = (async () => {
-      const activeStates = [...states.entries()];
-      for (const [, state] of activeStates) state.terminal = true;
-      let graceElapsed!: () => void;
-      const grace = new Promise<"grace-elapsed">((resolve) => {
-        graceElapsed = () => resolve("grace-elapsed");
-      });
-      const cancelGrace = clock.schedule(async () => graceElapsed(), SHUTDOWN_GRACE_MS, {
-        ref: true,
-      });
-      const cleanup = Promise.all(
-        activeStates.map(async ([executionId, state]) => {
-          await revokeLeases(executionId, state, "stop");
-          await waitForPendingMaterializations(state);
-          await revokeLeases(executionId, state, "stop");
-          await waitForLeasesClosed(state);
-          deleteEmptyState(states, executionId, state);
-        }),
-      ).then(() => "clean" as const);
-      const outcome = await Promise.race([cleanup, grace]);
-      cancelGrace();
-      const residualExposures = outcome === "clean" ? [] : collectResidualExposures(activeStates);
-      if (residualExposures.length > 0) {
-        report(
-          Object.assign(new Error("Execution authority shutdown grace elapsed"), {
-            code: "shutdown_timeout",
-          }),
-          { operation: "execution-authority.shutdown", component: "execution-authority" },
-          {
-            kind: "timeout",
-            diagnostic: {
-              shutdownGraceMs: SHUTDOWN_GRACE_MS,
-              residualExposureCount: residualExposures.length,
+  function schedule(lease: ExecutionCredentialLease, databaseRetry = false) {
+    cancelTimer(lease.id);
+    if (stopped) return;
+    let at = lease.revoking ? Math.min(lease.nextAttemptAt, lease.expiresAt) : lease.deadlineAt;
+    if (databaseRetry) at = clock.now() + REVOCATION_RETRY_BASE_DELAY_MS;
+    const cancel = clock.schedule(
+      async () => {
+        timers.delete(lease.id);
+        try {
+          await release(lease);
+        } catch (error) {
+          reportFailure(
+            error,
+            {
+              operation: "execution-authority.token.revoke",
+              component: "execution-authority",
+              executionId: lease.executionId,
             },
-          },
-        );
-      }
-      return { residualExposures };
-    })();
-    return stopPromise;
-  }
-
-  function canResume(input: ExecutionAuthorityMaterialization): boolean {
-    const needsCredentials =
-      input.github !== undefined ||
-      Object.values(input.env ?? {}).some((value) => parseConnectionTemplate(value).length > 0);
-    if (!needsCredentials) return true;
-    const state = states.get(input.executionId);
-    return state !== undefined && !state.terminal && state.leases.size > 0;
-  }
-
-  return { materialize, canResume, onExecutionTerminal, resourceCounts, stop };
-
-  function collectResidualExposures(
-    activeStates: Array<[string, ExecutionState]>,
-  ): ExecutionAuthorityResidualExposure[] {
-    return activeStates.flatMap(([executionId, state]) => {
-      if (state.leases.size === 0 && state.pendingMaterializations === 0) return [];
-      const upstreamExpiries = [...state.leases.values()].flatMap((lease) =>
-        lease.upstreamExpiresAt === undefined ? [] : [lease.upstreamExpiresAt],
-      );
-      return [
-        {
-          executionId,
-          leaseCount: state.leases.size,
-          pendingMaterializations: state.pendingMaterializations,
-          ...(upstreamExpiries.length === 0
-            ? {}
-            : { earliestUpstreamExpiresAt: Math.min(...upstreamExpiries) }),
-        },
-      ];
-    });
-  }
-
-  async function requestLeaseRevocation(
-    executionId: string,
-    token: string,
-    reason: "lease-deadline" | "upstream-expiry" | "terminal" | "materialization" | "stop",
-  ): Promise<void> {
-    const state = states.get(executionId);
-    const lease = state?.leases.get(token);
-    if (state === undefined || lease === undefined) return;
-    lease.cancelLeaseDeadline();
-    lease.cancelUpstreamExpiry();
-    if (lease.revocationPromise !== undefined) return lease.revocationPromise;
-    if (lease.retryScheduled) return;
-
-    let retryDelayMs: number | undefined;
-    const attempt = async (): Promise<void> => {
-      lease.revocationAttempts += 1;
-      const succeeded = await revokeWithTimeout(lease.revoke, executionId, {
-        reason,
-        attempt: lease.revocationAttempts,
-      });
-      if (succeeded) {
-        removeLease(states, executionId, state, lease);
-        return;
-      }
-
-      const now = clock.now();
-      const retryUntil =
-        lease.retryUntil ??
-        (lease.retryUntil = Math.min(
-          lease.upstreamExpiresAt ?? Number.POSITIVE_INFINITY,
-          now + REVOCATION_RETRY_WINDOW_MS,
-        ));
-      if (now >= retryUntil) {
-        removeLease(states, executionId, state, lease);
-        report(
-          Object.assign(new Error("Execution authority revocation retry window elapsed"), {
-            code: "revocation_retry_exhausted",
-          }),
-          {
-            operation: "execution-authority.token.revoke",
-            component: "execution-authority",
-            executionId,
-          },
-          {
-            kind: "upstreamUnavailable",
-            diagnostic: { reason, attempts: lease.revocationAttempts },
-          },
-        );
-        return;
-      }
-
-      retryDelayMs = Math.max(
-        0,
-        Math.min(
-          REVOCATION_RETRY_BASE_DELAY_MS * 2 ** Math.min(lease.revocationAttempts - 1, 10),
-          retryUntil - now,
-        ),
-      );
-    };
-
-    const pending = attempt();
-    let revocationPromise!: Promise<void>;
-    revocationPromise = pending.finally(() => {
-      if (lease.revocationPromise === revocationPromise) delete lease.revocationPromise;
-      if (retryDelayMs === undefined || state.leases.get(token) !== lease) return;
-      lease.cancelRetry();
-      lease.retryScheduled = true;
-      lease.cancelRetry = clock.schedule(() => {
-        lease.retryScheduled = false;
-        return requestLeaseRevocation(executionId, token, reason);
-      }, retryDelayMs);
-    });
-    lease.revocationPromise = revocationPromise;
-    return revocationPromise;
-  }
-
-  async function revokeLeases(
-    executionId: string,
-    state: ExecutionState,
-    reason: "terminal" | "stop",
-  ): Promise<void> {
-    await Promise.all(
-      [...state.leases.keys()].map((token) => requestLeaseRevocation(executionId, token, reason)),
+            options.logger ? { logger: options.logger } : {},
+          );
+          // A database outage must not discard the wakeup; durable state remains authoritative.
+          schedule(lease, true);
+        }
+      },
+      Math.max(0, at - clock.now()),
     );
+    timers.set(lease.id, { executionId: lease.executionId, cancel });
   }
 
-  async function waitForPendingMaterializations(state: ExecutionState): Promise<void> {
-    if (state.pendingMaterializations === 0) return;
-    await new Promise<void>((resolve) => state.pendingWaiters.add(resolve));
-  }
-
-  function waitForPendingMaterializationsUntilCanceled(state: ExecutionState): {
-    outcome: Promise<"settled" | "canceled">;
-    cancel(): void;
-  } {
-    if (state.pendingMaterializations === 0) {
-      return { outcome: Promise.resolve("settled"), cancel: () => undefined };
-    }
-    let resolveOutcome!: (outcome: "settled" | "canceled") => void;
-    let finished = false;
-    const outcome = new Promise<"settled" | "canceled">((resolve) => {
-      resolveOutcome = resolve;
-    });
-    const settle = (result: "settled" | "canceled"): void => {
-      if (finished) return;
-      finished = true;
-      state.pendingWaiters.delete(onSettled);
-      resolveOutcome(result);
-    };
-    const onSettled = (): void => settle("settled");
-    state.pendingWaiters.add(onSettled);
-    return { outcome, cancel: () => settle("canceled") };
-  }
-
-  async function waitForLeasesClosed(state: ExecutionState): Promise<void> {
-    if (state.leases.size === 0) return;
-    await new Promise<void>((resolve) => state.leaseWaiters.add(resolve));
-  }
-
-  async function assertExecutionActive(state: ExecutionState, executionId: string): Promise<void> {
-    if (stopped) throw authorityStoppedError();
-    if (state.terminal) throw terminalExecutionError(executionId);
-    const active = await options.isExecutionActive(executionId);
-    if (stopped) throw authorityStoppedError();
-    if (state.terminal) throw terminalExecutionError(executionId);
-    if (active) return;
-    state.terminal = true;
-    await revokeLeases(executionId, state, "terminal");
-    throw terminalExecutionError(executionId);
-  }
-
-  async function revokeWithTimeout(
-    revoke: () => Promise<void>,
-    executionId: string,
-    details: { reason: string; attempt: number },
-  ): Promise<boolean> {
-    let timer: NodeJS.Timeout | undefined;
-    const timeout = new Promise<never>((_, reject) => {
-      timer = setTimeout(
-        () =>
-          reject(new Error(`token revocation timed out after ${TOKEN_REVOCATION_TIMEOUT_MS}ms`)),
-        TOKEN_REVOCATION_TIMEOUT_MS,
+  async function release(observed: ExecutionCredentialLease, requested = false): Promise<void> {
+    await options.database.withAdvisoryLock(`execution-credential:${observed.id}`, async () => {
+      const lease = (await store.leases(observed.executionId)).find(
+        (item) => item.id === observed.id,
       );
+      if (!lease) {
+        cancelTimer(observed.id);
+        return;
+      }
+      if (!requested && !lease.revoking && lease.deadlineAt > clock.now()) {
+        schedule(lease);
+        return;
+      }
+      lease.revoking = true;
+      // Persist intent before the external call; a replacement worker can finish it.
+      await store.saveLease(lease);
+      if (lease.expiresAt <= clock.now()) {
+        await store.removeLease(lease.id);
+        cancelTimer(lease.id);
+        return;
+      }
+      if (lease.nextAttemptAt > clock.now()) {
+        schedule(lease);
+        return;
+      }
+      lease.attempts++;
+      if (await revokeToken(lease)) {
+        await store.removeLease(lease.id);
+        cancelTimer(lease.id);
+      } else {
+        lease.nextAttemptAt = Math.min(
+          lease.expiresAt,
+          clock.now() + REVOCATION_RETRY_BASE_DELAY_MS * 2 ** Math.min(lease.attempts - 1, 10),
+        );
+        await store.saveLease(lease);
+        schedule(lease);
+      }
     });
+  }
+
+  async function revokeToken(lease: ExecutionCredentialLease): Promise<boolean> {
+    let timer: NodeJS.Timeout | undefined;
     try {
-      await Promise.race([Promise.resolve().then(revoke), timeout]);
+      await Promise.race([
+        Promise.resolve().then(() => {
+          if (!options.githubAuthority)
+            throw new Error("GitHub credential revocation is unavailable");
+          return options.githubAuthority.revoke(lease.token);
+        }),
+        new Promise<never>((_, reject) => {
+          timer = setTimeout(
+            () => reject(new Error("token revocation timed out")),
+            TOKEN_REVOCATION_TIMEOUT_MS,
+          );
+        }),
+      ]);
       return true;
     } catch (error) {
-      report(
+      reportFailure(
         error,
         {
           operation: "execution-authority.token.revoke",
           component: "execution-authority",
-          executionId,
+          executionId: lease.executionId,
         },
-        { kind: "upstreamUnavailable", diagnostic: details },
+        {
+          kind: "upstreamUnavailable",
+          diagnostic: { attempt: lease.attempts },
+          ...(options.logger ? { logger: options.logger } : {}),
+        },
       );
       return false;
     } finally {
       clearTimeout(timer);
     }
   }
-}
 
+  return {
+    materialize,
+    canResume,
+    recover,
+    onExecutionTerminal,
+    resourceCounts: () => ({
+      executionStates: new Set([
+        ...pending.keys(),
+        ...[...timers.values()].map((timer) => timer.executionId),
+      ]).size,
+      leases: timers.size,
+      pendingMaterializations: [...pending.values()].reduce(
+        (count, state) => count + state.count,
+        0,
+      ),
+    }),
+    async stop() {
+      stopped = true;
+      for (const timer of timers.values()) timer.cancel();
+      timers.clear();
+    },
+  };
+}
 function repositoriesForAuthority(
   github: CompiledGitHubAuthority,
   triggerContext: unknown,
@@ -638,36 +456,4 @@ function authorityStoppedError(): Error {
 
 function authorityError(code: string, message: string): Error & { code: string } {
   return Object.assign(new Error(message), { code });
-}
-
-function removeLease(
-  states: Map<string, ExecutionState>,
-  executionId: string,
-  state: ExecutionState,
-  lease: TokenLease,
-): void {
-  if (state.leases.get(lease.token) !== lease) return;
-  state.leases.delete(lease.token);
-  lease.cancelLeaseDeadline();
-  lease.cancelUpstreamExpiry();
-  lease.cancelRetry();
-  if (state.leases.size === 0) {
-    for (const resolve of state.leaseWaiters) resolve();
-    state.leaseWaiters.clear();
-  }
-  deleteEmptyState(states, executionId, state);
-}
-
-function deleteEmptyState(
-  states: Map<string, ExecutionState>,
-  executionId: string,
-  state: ExecutionState,
-): void {
-  if (
-    states.get(executionId) === state &&
-    state.pendingMaterializations === 0 &&
-    state.leases.size === 0
-  ) {
-    states.delete(executionId);
-  }
 }

--- a/src/execution-authority/internal/store.ts
+++ b/src/execution-authority/internal/store.ts
@@ -1,0 +1,87 @@
+import type { QueryHandle } from "../../db/runtime/index.js";
+
+export interface ExecutionCredentialLease {
+  id: string;
+  executionId: string;
+  token: string;
+  provider: "github";
+  expiresAt: number;
+  deadlineAt: number;
+  revoking: boolean;
+  attempts: number;
+  nextAttemptAt: number;
+}
+
+export interface ExecutionAuthorityRecord {
+  executionId: string;
+  env: Record<string, string>;
+  leaseIds: string[];
+}
+
+export interface ExecutionAuthorityStore {
+  executions(): Promise<string[]>;
+  read(executionId: string): Promise<ExecutionAuthorityRecord | undefined>;
+  commit(record: ExecutionAuthorityRecord): Promise<ExecutionAuthorityRecord>;
+  remove(executionId: string): Promise<void>;
+  leases(executionId?: string): Promise<ExecutionCredentialLease[]>;
+  saveLease(lease: ExecutionCredentialLease): Promise<void>;
+  removeLease(id: string): Promise<void>;
+}
+
+export class ExecutionAuthorityRepository implements ExecutionAuthorityStore {
+  constructor(private readonly database: QueryHandle) {}
+
+  async executions() {
+    const result = await this.database.query<{ execution_id: string }>(
+      "select execution_id from execution_authorities",
+    );
+    return result.rows.map((row) => row.execution_id);
+  }
+
+  async read(executionId: string) {
+    const result = await this.database.query<{ data: ExecutionAuthorityRecord }>(
+      "select data from execution_authorities where execution_id = $1",
+      [executionId],
+    );
+    return result.rows[0]?.data;
+  }
+
+  async commit(record: ExecutionAuthorityRecord) {
+    await this.database.query(
+      `insert into execution_authorities (execution_id, data) values ($1, $2)
+       on conflict (execution_id) do nothing`,
+      [record.executionId, record],
+    );
+    const stored = await this.read(record.executionId);
+    if (!stored) throw new Error("Execution authority disappeared during materialization");
+    return stored;
+  }
+
+  async remove(executionId: string) {
+    await this.database.query("delete from execution_authorities where execution_id = $1", [
+      executionId,
+    ]);
+  }
+
+  async leases(executionId?: string) {
+    const result = await this.database.query<{ data: ExecutionCredentialLease }>(
+      executionId === undefined
+        ? "select data from execution_credential_leases"
+        : "select data from execution_credential_leases where execution_id = $1",
+      executionId === undefined ? [] : [executionId],
+    );
+    return result.rows.map((row) => row.data);
+  }
+
+  async saveLease(lease: ExecutionCredentialLease) {
+    await this.database.query(
+      `insert into execution_credential_leases (id, execution_id, data) values ($1, $2, $3)
+       on conflict (id) do update set data = excluded.data`,
+      [lease.id, lease.executionId, lease],
+    );
+  }
+
+  async removeLease(id: string) {
+    await this.database.query("delete from execution_credential_leases where id = $1", [id]);
+  }
+}

--- a/src/providers/github/client.test.ts
+++ b/src/providers/github/client.test.ts
@@ -81,7 +81,7 @@ class GitHubProviderPort implements GitHubAuth {
     return Promise.reject(new Error("unused"));
   }
 
-  mintInstallationToken(): Promise<string> {
+  mintInstallationToken(): Promise<never> {
     return Promise.reject(new Error("unused"));
   }
 

--- a/src/providers/github/index.ts
+++ b/src/providers/github/index.ts
@@ -181,8 +181,12 @@ export function createGitHubRegistration(
           throw new Error(`github connection is unavailable: ${connectionSlug}`);
         }
         const token = await appAuth.mintInstallationToken(selectedConnection.installationId);
-        await context?.registerToken?.(token, () => appAuth.revokeInstallationToken(token));
-        return token;
+        await context?.registerToken?.({
+          provider: "github",
+          token: token.token,
+          expiresAt: token.expiresAt,
+        });
+        return token.token;
       },
       githubAuthority: {
         async mint(input) {

--- a/src/providers/github/registration.test.ts
+++ b/src/providers/github/registration.test.ts
@@ -161,7 +161,8 @@ describe("GitHub registration", () => {
       appAuth: {
         getInstallation: () => Promise.resolve(undefined),
         getInstallationToken: () => Promise.resolve("token"),
-        mintInstallationToken: () => Promise.resolve("token"),
+        mintInstallationToken: () =>
+          Promise.resolve({ token: "token", expiresAt: Date.now() + 3600_000 }),
         mintInstallationAccessToken: () =>
           Promise.resolve({ token: "scoped-token", expiresAt: Date.now() + 3_600_000 }),
         getAppBotIdentity: () => Promise.resolve({ id: 123, login: "paseo[bot]" }),
@@ -251,7 +252,10 @@ describe("GitHub registration", () => {
         getInstallationToken: () => Promise.reject(new Error("unused")),
         mintInstallationToken: (installationId) => {
           installations.push(installationId);
-          return Promise.resolve("test-installation-token");
+          return Promise.resolve({
+            token: "test-installation-token",
+            expiresAt: Date.now() + 3600_000,
+          });
         },
         mintInstallationAccessToken: () =>
           Promise.resolve({ token: "scoped-token", expiresAt: Date.now() + 3_600_000 }),
@@ -313,7 +317,8 @@ describe("GitHub registration", () => {
       appAuth: {
         getInstallation: () => Promise.resolve(undefined),
         getInstallationToken: () => Promise.resolve("token"),
-        mintInstallationToken: () => Promise.resolve("token"),
+        mintInstallationToken: () =>
+          Promise.resolve({ token: "token", expiresAt: Date.now() + 3600_000 }),
         mintInstallationAccessToken: (input) => {
           requests.push(input);
           return Promise.resolve({ token: "scoped-token", expiresAt: Date.now() + 3_600_000 });
@@ -530,7 +535,8 @@ describe("GitHub registration", () => {
       appAuth: {
         getInstallation: () => Promise.resolve(undefined),
         getInstallationToken: () => Promise.resolve("token"),
-        mintInstallationToken: () => Promise.resolve("token"),
+        mintInstallationToken: () =>
+          Promise.resolve({ token: "token", expiresAt: Date.now() + 3600_000 }),
         mintInstallationAccessToken: () =>
           Promise.resolve({ token: "scoped-token", expiresAt: Date.now() + 3_600_000 }),
         getAppBotIdentity: () => Promise.resolve({ id: 123, login: "paseo[bot]" }),
@@ -714,7 +720,8 @@ function githubAuth() {
   return {
     getInstallation: () => Promise.resolve(undefined),
     getInstallationToken: () => Promise.resolve("token"),
-    mintInstallationToken: () => Promise.resolve("token"),
+    mintInstallationToken: () =>
+      Promise.resolve({ token: "token", expiresAt: Date.now() + 3600_000 }),
     mintInstallationAccessToken: () =>
       Promise.resolve({ token: "scoped-token", expiresAt: Date.now() + 3_600_000 }),
     getAppBotIdentity: () => Promise.resolve({ id: 123, login: "paseo[bot]" }),


### PR DESCRIPTION
Active agents now retain their execution credentials across Hub restarts and reconnect to the same daemon agent. Previously, stopping Hub revoked process-owned credentials, and recovery failed with `execution_credentials_unavailable` even when the agent had already performed external actions.

## Goals

- Preserve materialized execution credentials and token leases in Hub's existing database.
- Recover the same running agent after graceful shutdown or process death, without minting replacement credentials or extending the original deadline.
- Retain terminal, expiry, and failed-revocation cleanup across restarts.

## Non-goals

- Restarting daemon processes, replaying completed external actions, or changing daemon protocols and workflow configuration.
- Rescuing executions that already failed, or adding a separate credential service.

## Design and rollout

Execution authority owns durable credential state and uses the existing database locking mechanism for revocation. Hub shutdown cancels local timers; startup reconciles persisted state before execution recovery. Migration 0048 adds two private runtime tables. These contain sensitive materialized credentials and require the same database access controls as other private runtime state.

The first upgrade must drain credentialed executions started by the old version: their in-memory authority cannot be recovered retroactively. Subsequent restarts preserve credentials until the existing execution deadline or termination.

## Verification

- Demonstrated the restart regression failing before the fix.
- Source-built daemon E2E: 10 passed, including graceful shutdown and SIGKILL while the agent is actively running; verifies the same agent/session, one mint, completion, and original-token revocation.
- Browser suite: 80 passed.
- Affected unit/integration suites: 70 passed, including durable authority and migration tests.
- Full local suite: 1,325 passed; its sole failure was the migration-count expectation, corrected and verified by the affected-suite rerun.
- Typecheck, lint, formatting, migration drift check, production build, and Docker smoke passed.




## Continuation integration

Includes #131 for combined verification; merge #131 first. Recovery now retains credentials owned by a completed request while another request in the same agent session is active. A failing-first PostgreSQL/HTTP/WebSocket regression completes the first request, restarts Hub during the follow-up, and verifies retained credentials, the same agent, and final revocation. The regression, typecheck, and lint pass.

Maintainer instructions now limit new public docs to API, interface, or user-facing workflow changes; existing inaccurate text gets the smallest correction.
